### PR TITLE
chore: add ci-operator build root for OpenShift CI

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,2 @@
+build_root_image:
+  dockerfile_path: .ci-operator/build-root/Dockerfile

--- a/.ci-operator/build-root/Dockerfile
+++ b/.ci-operator/build-root/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:22-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git ca-certificates && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- Adds `.ci-operator.yaml` pointing to a custom build root Dockerfile
- Adds `.ci-operator/build-root/Dockerfile` with a minimal Node.js 22 image

## Why
The [openshift/release PR #77766](https://github.com/openshift/release/pull/77766) onboards mirror-gui to Prow CI with `build_root: from_repository: true`. This requires a `.ci-operator.yaml` file in the mirror-gui repo so ci-operator knows what build environment to use for running lint, unit tests, and image builds.

Without this file, all CI jobs fail with: `failed to read .ci-operator.yaml file: no such file or directory`

## Test plan
- [ ] Merge this PR to main
- [ ] Re-trigger rehearsals on openshift/release#77766 (`/pj-rehearse`)
- [ ] Verify rehearsal jobs can resolve the build root and proceed