### PR TITLE
chore: refresh catalog metadata

### DIFF
--- a/catalog-data/catalog-index.json
+++ b/catalog-data/catalog-index.json
@@ -107,19 +107,19 @@
       "catalog_type": "redhat-operator-index",
       "ocp_version": "v4.21",
       "catalog_url": "registry.redhat.io/redhat/redhat-operator-index:v4.21",
-      "operator_count": 141
+      "operator_count": 143
     },
     {
       "catalog_type": "certified-operator-index",
       "ocp_version": "v4.21",
       "catalog_url": "registry.redhat.io/redhat/certified-operator-index:v4.21",
-      "operator_count": 137
+      "operator_count": 139
     },
     {
       "catalog_type": "community-operator-index",
       "ocp_version": "v4.21",
       "catalog_url": "registry.redhat.io/redhat/community-operator-index:v4.21",
-      "operator_count": 269
+      "operator_count": 270
     }
   ]
 }

--- a/catalog-data/certified-operator-index/v4.16/dependencies.json
+++ b/catalog-data/certified-operator-index/v4.16/dependencies.json
@@ -52,7 +52,7 @@
     },
     {
       "packageName": "mto-dependencies-operator",
-      "versionRange": ">=0.0.5"
+      "versionRange": ">=0.0.7"
     },
     {
       "packageName": "template-operator",

--- a/catalog-data/certified-operator-index/v4.16/operators.json
+++ b/catalog-data/certified-operator-index/v4.16/operators.json
@@ -2096,17 +2096,21 @@
   },
   {
     "name": "cp-fko",
-    "defaultChannel": "alpha",
+    "defaultChannel": "stable-v1.14",
     "channels": [
       "alpha",
-      "stable"
+      "stable",
+      "stable-v1.14"
     ],
     "channelVersions": {
       "alpha": [
         "0.0.1"
       ],
       "stable": [
-        "1.13.0-cp2"
+        "1.14.0-cp1"
+      ],
+      "stable-v1.14": [
+        "1.14.0-cp1"
       ]
     },
     "channelVersionRanges": {
@@ -2115,16 +2119,20 @@
         "maxVersion": "0.0.1"
       },
       "stable": {
-        "minVersion": "1.13.0-cp2",
-        "maxVersion": "1.13.0-cp2"
+        "minVersion": "1.14.0-cp1",
+        "maxVersion": "1.14.0-cp1"
+      },
+      "stable-v1.14": {
+        "minVersion": "1.14.0-cp1",
+        "maxVersion": "1.14.0-cp1"
       }
     },
     "availableVersions": [
       "0.0.1",
-      "1.13.0-cp2"
+      "1.14.0-cp1"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.13.0-cp2",
+    "maxVersion": "1.14.0-cp1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"
@@ -2592,7 +2600,8 @@
         "25.1.5",
         "25.1.6",
         "25.1.8",
-        "25.1.9"
+        "25.1.9",
+        "25.1.10-1"
       ]
     },
     "channelVersionRanges": {
@@ -2614,7 +2623,7 @@
       },
       "stable-v25.1": {
         "minVersion": "25.1.0",
-        "maxVersion": "25.1.9"
+        "maxVersion": "25.1.10-1"
       }
     },
     "availableVersions": [
@@ -2644,6 +2653,7 @@
       "25.1.6",
       "25.1.8",
       "25.1.9",
+      "25.1.10-1",
       "26.1.0"
     ],
     "minVersion": "24.1.10",
@@ -2729,13 +2739,14 @@
         "1.7.2",
         "1.7.3",
         "1.8.0",
-        "1.8.1"
+        "1.8.1",
+        "1.9.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.4.0",
-        "maxVersion": "1.8.1"
+        "maxVersion": "1.9.0"
       }
     },
     "availableVersions": [
@@ -2752,10 +2763,11 @@
       "1.7.2",
       "1.7.3",
       "1.8.0",
-      "1.8.1"
+      "1.8.1",
+      "1.9.0"
     ],
     "minVersion": "1.4.0",
-    "maxVersion": "1.8.1",
+    "maxVersion": "1.9.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"
@@ -3228,33 +3240,33 @@
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.11.0"
       ],
       "unstable": [
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.11.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.9.2",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       },
       "unstable": {
         "minVersion": "2.9.2",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       }
     },
     "availableVersions": [
       "2.9.2",
       "2.10.0",
       "2.10.1",
-      "2.10.2"
+      "2.11.0"
     ],
     "minVersion": "2.9.2",
-    "maxVersion": "2.10.2",
+    "maxVersion": "2.11.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"
@@ -3275,13 +3287,14 @@
         "1.45.0",
         "1.46.0",
         "1.47.0",
-        "1.47.1"
+        "1.47.1",
+        "1.48.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.42.0",
-        "maxVersion": "1.47.1"
+        "maxVersion": "1.48.0"
       }
     },
     "availableVersions": [
@@ -3293,10 +3306,11 @@
       "1.45.0",
       "1.46.0",
       "1.47.0",
-      "1.47.1"
+      "1.47.1",
+      "1.48.0"
     ],
     "minVersion": "1.42.0",
-    "maxVersion": "1.47.1",
+    "maxVersion": "1.48.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"
@@ -5209,13 +5223,15 @@
         "2.2.5",
         "2.2.6",
         "2.2.7",
-        "2.2.8"
+        "2.2.8",
+        "2.2.9",
+        "2.2.10"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.0.4",
-        "maxVersion": "2.2.8"
+        "maxVersion": "2.2.10"
       }
     },
     "availableVersions": [
@@ -5278,10 +5294,12 @@
       "2.2.5",
       "2.2.6",
       "2.2.7",
-      "2.2.8"
+      "2.2.8",
+      "2.2.9",
+      "2.2.10"
     ],
     "minVersion": "2.0.4",
-    "maxVersion": "2.2.8",
+    "maxVersion": "2.2.10",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"
@@ -6475,7 +6493,7 @@
         "8.19.40-beta.1"
       ],
       "stable": [
-        "8.19.30"
+        "8.19.40"
       ]
     },
     "channelVersionRanges": {
@@ -6484,15 +6502,15 @@
         "maxVersion": "8.19.40-beta.1"
       },
       "stable": {
-        "minVersion": "8.19.30",
-        "maxVersion": "8.19.30"
+        "minVersion": "8.19.40",
+        "maxVersion": "8.19.40"
       }
     },
     "availableVersions": [
-      "8.19.30",
+      "8.19.40",
       "8.19.40-beta.1"
     ],
-    "minVersion": "8.19.30",
+    "minVersion": "8.19.40",
     "maxVersion": "8.19.40-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
@@ -6675,35 +6693,35 @@
   },
   {
     "name": "mediation-openstack-operator",
-    "defaultChannel": "beta",
+    "defaultChannel": "stable",
     "channels": [
       "alpha",
-      "beta"
+      "stable"
     ],
     "channelVersions": {
       "alpha": [
-        "8.19.2"
+        "8.19.40-beta.1"
       ],
-      "beta": [
-        "8.19.4"
+      "stable": [
+        "8.19.40"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
-        "minVersion": "8.19.2",
-        "maxVersion": "8.19.2"
+        "minVersion": "8.19.40-beta.1",
+        "maxVersion": "8.19.40-beta.1"
       },
-      "beta": {
-        "minVersion": "8.19.4",
-        "maxVersion": "8.19.4"
+      "stable": {
+        "minVersion": "8.19.40",
+        "maxVersion": "8.19.40"
       }
     },
     "availableVersions": [
-      "8.19.2",
-      "8.19.4"
+      "8.19.40",
+      "8.19.40-beta.1"
     ],
-    "minVersion": "8.19.2",
-    "maxVersion": "8.19.4",
+    "minVersion": "8.19.40",
+    "maxVersion": "8.19.40-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"
@@ -8411,7 +8429,7 @@
         "8.19.40-beta.1"
       ],
       "stable": [
-        "8.19.30"
+        "8.19.40"
       ]
     },
     "channelVersionRanges": {
@@ -8420,15 +8438,15 @@
         "maxVersion": "8.19.40-beta.1"
       },
       "stable": {
-        "minVersion": "8.19.30",
-        "maxVersion": "8.19.30"
+        "minVersion": "8.19.40",
+        "maxVersion": "8.19.40"
       }
     },
     "availableVersions": [
-      "8.19.30",
+      "8.19.40",
       "8.19.40-beta.1"
     ],
-    "minVersion": "8.19.30",
+    "minVersion": "8.19.40",
     "maxVersion": "8.19.40-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
@@ -8550,6 +8568,7 @@
       "7.22.2-32.1",
       "7.22.2-37.1",
       "7.22.2-38.0",
+      "7.22.2-39.0",
       "7.4.6",
       "7.8.2",
       "7.8.4",
@@ -8628,6 +8647,7 @@
         "7.8.6-1.2",
         "7.8.6-11.0",
         "7.8.6-13.0",
+        "7.8.6-14.0",
         "7.8.6-2.2",
         "7.8.6-3.2",
         "7.8.6-5.1",
@@ -8643,7 +8663,8 @@
         "7.22.2-31.1",
         "7.22.2-32.1",
         "7.22.2-37.1",
-        "7.22.2-38.0"
+        "7.22.2-38.0",
+        "7.22.2-39.0"
       ],
       "7.22.2-21.1": [
         "7.4.6-2.0",
@@ -8836,6 +8857,45 @@
         "7.22.2-37.1",
         "7.22.2-38.0"
       ],
+      "7.22.2-39.0": [
+        "7.4.6-2.0",
+        "7.4.6-2.3",
+        "7.4.6-2.4",
+        "7.4.6-2.8",
+        "7.4.6-6.1",
+        "7.4.6-6.3",
+        "7.4.6-6.4",
+        "7.4.6-7.2",
+        "7.4.6-7.5",
+        "7.4.6-9.0",
+        "7.8.2-6.3",
+        "7.8.2-6.8",
+        "7.8.4-8.0",
+        "7.8.4-9.0",
+        "7.8.6-1.0",
+        "7.8.6-1.1",
+        "7.8.6-1.2",
+        "7.8.6-11.0",
+        "7.8.6-13.0",
+        "7.8.6-14.0",
+        "7.8.6-2.2",
+        "7.8.6-3.2",
+        "7.8.6-5.1",
+        "7.8.6-8.1",
+        "7.22.0-11.2",
+        "7.22.0-11.3",
+        "7.22.0-15.0",
+        "7.22.0-16.0",
+        "7.22.0-17.0",
+        "7.22.0-7.0",
+        "7.22.2-21.1",
+        "7.22.2-22.0",
+        "7.22.2-31.1",
+        "7.22.2-32.1",
+        "7.22.2-37.1",
+        "7.22.2-38.0",
+        "7.22.2-39.0"
+      ],
       "7.4.6": [
         "6.2.10-45",
         "7.4.6-2.0",
@@ -8890,6 +8950,7 @@
         "7.8.6-1.2",
         "7.8.6-11.0",
         "7.8.6-13.0",
+        "7.8.6-14.0",
         "7.8.6-2.2",
         "7.8.6-3.2",
         "7.8.6-5.1",
@@ -9038,7 +9099,7 @@
       },
       "7.22.2": {
         "minVersion": "7.4.6-2.0",
-        "maxVersion": "7.22.2-38.0"
+        "maxVersion": "7.22.2-39.0"
       },
       "7.22.2-21.1": {
         "minVersion": "7.4.6-2.0",
@@ -9063,6 +9124,10 @@
       "7.22.2-38.0": {
         "minVersion": "7.4.6-2.0",
         "maxVersion": "7.22.2-38.0"
+      },
+      "7.22.2-39.0": {
+        "minVersion": "7.4.6-2.0",
+        "maxVersion": "7.22.2-39.0"
       },
       "7.4.6": {
         "minVersion": "6.2.10-45",
@@ -9124,6 +9189,7 @@
       "7.8.6-1.2",
       "7.8.6-11.0",
       "7.8.6-13.0",
+      "7.8.6-14.0",
       "7.8.6-2.2",
       "7.8.6-3.2",
       "7.8.6-5.1",
@@ -9140,6 +9206,7 @@
       "7.22.2-32.1",
       "7.22.2-37.1",
       "7.22.2-38.0",
+      "7.22.2-39.0",
       "8.0.2-2.9",
       "8.0.2-6.1"
     ],
@@ -9363,7 +9430,10 @@
         "1.29.3",
         "1.29.4",
         "1.29.6",
-        "1.29.7"
+        "1.29.7",
+        "1.29.8",
+        "1.29.10",
+        "1.29.11"
       ],
       "stable-v1.26": [
         "1.26.8",
@@ -9418,13 +9488,16 @@
         "1.29.3",
         "1.29.4",
         "1.29.6",
-        "1.29.7"
+        "1.29.7",
+        "1.29.8",
+        "1.29.10",
+        "1.29.11"
       ]
     },
     "channelVersionRanges": {
       "stable-v1": {
         "minVersion": "1.26.8",
-        "maxVersion": "1.29.7"
+        "maxVersion": "1.29.11"
       },
       "stable-v1.26": {
         "minVersion": "1.26.8",
@@ -9440,7 +9513,7 @@
       },
       "stable-v1.29": {
         "minVersion": "1.29.3",
-        "maxVersion": "1.29.7"
+        "maxVersion": "1.29.11"
       }
     },
     "availableVersions": [
@@ -9490,10 +9563,13 @@
       "1.29.3",
       "1.29.4",
       "1.29.6",
-      "1.29.7"
+      "1.29.7",
+      "1.29.8",
+      "1.29.10",
+      "1.29.11"
     ],
     "minVersion": "1.26.8",
-    "maxVersion": "1.29.7",
+    "maxVersion": "1.29.11",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"
@@ -10742,28 +10818,28 @@
     ],
     "channelVersions": {
       "beta": [
-        "42.102.0-beta.1"
+        "42.102.0-beta.2"
       ],
       "stable": [
-        "42.101.0"
+        "42.102.0"
       ]
     },
     "channelVersionRanges": {
       "beta": {
-        "minVersion": "42.102.0-beta.1",
-        "maxVersion": "42.102.0-beta.1"
+        "minVersion": "42.102.0-beta.2",
+        "maxVersion": "42.102.0-beta.2"
       },
       "stable": {
-        "minVersion": "42.101.0",
-        "maxVersion": "42.101.0"
+        "minVersion": "42.102.0",
+        "maxVersion": "42.102.0"
       }
     },
     "availableVersions": [
-      "42.101.0",
-      "42.102.0-beta.1"
+      "42.102.0",
+      "42.102.0-beta.2"
     ],
-    "minVersion": "42.101.0",
-    "maxVersion": "42.102.0-beta.1",
+    "minVersion": "42.102.0",
+    "maxVersion": "42.102.0-beta.2",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"
@@ -10908,7 +10984,7 @@
   },
   {
     "name": "tenant-operator",
-    "defaultChannel": "release-1.6",
+    "defaultChannel": "release-1.7",
     "channels": [
       "release-0.12",
       "release-1.0",
@@ -10917,7 +10993,8 @@
       "release-1.3",
       "release-1.4",
       "release-1.5",
-      "release-1.6"
+      "release-1.6",
+      "release-1.7"
     ],
     "channelVersions": {
       "release-0.12": [
@@ -10943,6 +11020,9 @@
       ],
       "release-1.6": [
         "1.6.2"
+      ],
+      "release-1.7": [
+        "1.7.0"
       ]
     },
     "channelVersionRanges": {
@@ -10977,6 +11057,10 @@
       "release-1.6": {
         "minVersion": "1.6.2",
         "maxVersion": "1.6.2"
+      },
+      "release-1.7": {
+        "minVersion": "1.7.0",
+        "maxVersion": "1.7.0"
       }
     },
     "availableVersions": [
@@ -10987,10 +11071,11 @@
       "1.3.0",
       "1.4.2",
       "1.5.2",
-      "1.6.2"
+      "1.6.2",
+      "1.7.0"
     ],
     "minVersion": "0.12.66",
-    "maxVersion": "1.6.2",
+    "maxVersion": "1.7.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"
@@ -11518,7 +11603,7 @@
   },
   {
     "name": "uma-team-operator",
-    "defaultChannel": "stable",
+    "defaultChannel": "alpha",
     "channels": [
       "2024.10",
       "2025.1",
@@ -11574,7 +11659,7 @@
         "2026.3.1-2"
       ],
       "alpha": [
-        "2025.11.4-3"
+        "2026.4.0-15"
       ],
       "beta": [
         "2026.2.0-10"
@@ -11633,8 +11718,8 @@
         "maxVersion": "2026.3.1-2"
       },
       "alpha": {
-        "minVersion": "2025.11.4-3",
-        "maxVersion": "2025.11.4-3"
+        "minVersion": "2026.4.0-15",
+        "maxVersion": "2026.4.0-15"
       },
       "beta": {
         "minVersion": "2026.2.0-10",
@@ -11656,13 +11741,13 @@
       "2025.9.1-12",
       "2025.10.1-12",
       "2025.11.1-38",
-      "2025.11.4-3",
       "2026.1.1-35",
       "2026.2.0-10",
-      "2026.3.1-2"
+      "2026.3.1-2",
+      "2026.4.0-15"
     ],
     "minVersion": "2024.10.2-12",
-    "maxVersion": "2026.3.1-2",
+    "maxVersion": "2026.4.0-15",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"
@@ -11817,21 +11902,23 @@
     "channelVersions": {
       "stable": [
         "4.5.1961",
-        "4.6.1984"
+        "4.6.1984",
+        "4.6.2014"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.5.1961",
-        "maxVersion": "4.6.1984"
+        "maxVersion": "4.6.2014"
       }
     },
     "availableVersions": [
       "4.5.1961",
-      "4.6.1984"
+      "4.6.1984",
+      "4.6.2014"
     ],
     "minVersion": "4.5.1961",
-    "maxVersion": "4.6.1984",
+    "maxVersion": "4.6.2014",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"

--- a/catalog-data/certified-operator-index/v4.17/dependencies.json
+++ b/catalog-data/certified-operator-index/v4.17/dependencies.json
@@ -52,7 +52,7 @@
     },
     {
       "packageName": "mto-dependencies-operator",
-      "versionRange": ">=0.0.5"
+      "versionRange": ">=0.0.7"
     },
     {
       "packageName": "template-operator",

--- a/catalog-data/certified-operator-index/v4.17/operators.json
+++ b/catalog-data/certified-operator-index/v4.17/operators.json
@@ -2083,17 +2083,21 @@
   },
   {
     "name": "cp-fko",
-    "defaultChannel": "alpha",
+    "defaultChannel": "stable-v1.14",
     "channels": [
       "alpha",
-      "stable"
+      "stable",
+      "stable-v1.14"
     ],
     "channelVersions": {
       "alpha": [
         "0.0.1"
       ],
       "stable": [
-        "1.13.0-cp2"
+        "1.14.0-cp1"
+      ],
+      "stable-v1.14": [
+        "1.14.0-cp1"
       ]
     },
     "channelVersionRanges": {
@@ -2102,16 +2106,20 @@
         "maxVersion": "0.0.1"
       },
       "stable": {
-        "minVersion": "1.13.0-cp2",
-        "maxVersion": "1.13.0-cp2"
+        "minVersion": "1.14.0-cp1",
+        "maxVersion": "1.14.0-cp1"
+      },
+      "stable-v1.14": {
+        "minVersion": "1.14.0-cp1",
+        "maxVersion": "1.14.0-cp1"
       }
     },
     "availableVersions": [
       "0.0.1",
-      "1.13.0-cp2"
+      "1.14.0-cp1"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.13.0-cp2",
+    "maxVersion": "1.14.0-cp1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -2587,7 +2595,8 @@
         "25.1.5",
         "25.1.6",
         "25.1.8",
-        "25.1.9"
+        "25.1.9",
+        "25.1.10-1"
       ]
     },
     "channelVersionRanges": {
@@ -2609,7 +2618,7 @@
       },
       "stable-v25.1": {
         "minVersion": "25.1.0",
-        "maxVersion": "25.1.9"
+        "maxVersion": "25.1.10-1"
       }
     },
     "availableVersions": [
@@ -2639,6 +2648,7 @@
       "25.1.6",
       "25.1.8",
       "25.1.9",
+      "25.1.10-1",
       "26.1.0"
     ],
     "minVersion": "24.1.10",
@@ -2724,13 +2734,14 @@
         "1.7.2",
         "1.7.3",
         "1.8.0",
-        "1.8.1"
+        "1.8.1",
+        "1.9.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.4.0",
-        "maxVersion": "1.8.1"
+        "maxVersion": "1.9.0"
       }
     },
     "availableVersions": [
@@ -2747,10 +2758,11 @@
       "1.7.2",
       "1.7.3",
       "1.8.0",
-      "1.8.1"
+      "1.8.1",
+      "1.9.0"
     ],
     "minVersion": "1.4.0",
-    "maxVersion": "1.8.1",
+    "maxVersion": "1.9.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -2802,7 +2814,8 @@
         "1.3.3",
         "1.3.4",
         "1.3.5",
-        "1.3.6"
+        "1.3.6",
+        "1.3.7"
       ],
       "innovation": [
         "2025.11.0",
@@ -2816,7 +2829,8 @@
         "1.3.3",
         "1.3.4",
         "1.3.5",
-        "1.3.6"
+        "1.3.6",
+        "1.3.7"
       ],
       "stable": [
         "1.2.0",
@@ -2829,13 +2843,14 @@
         "1.3.3",
         "1.3.4",
         "1.3.5",
-        "1.3.6"
+        "1.3.6",
+        "1.3.7"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.2.0",
-        "maxVersion": "1.3.6"
+        "maxVersion": "1.3.7"
       },
       "innovation": {
         "minVersion": "2025.11.0",
@@ -2843,11 +2858,11 @@
       },
       "lts-v1.3": {
         "minVersion": "1.3.2",
-        "maxVersion": "1.3.6"
+        "maxVersion": "1.3.7"
       },
       "stable": {
         "minVersion": "1.2.0",
-        "maxVersion": "1.3.6"
+        "maxVersion": "1.3.7"
       }
     },
     "availableVersions": [
@@ -2862,6 +2877,7 @@
       "1.3.4",
       "1.3.5",
       "1.3.6",
+      "1.3.7",
       "2025.11.0",
       "2025.12.0",
       "2026.1.0",
@@ -3016,7 +3032,7 @@
         "0.4.3"
       ],
       "stable": [
-        "0.7.0"
+        "0.7.1"
       ]
     },
     "channelVersionRanges": {
@@ -3025,16 +3041,16 @@
         "maxVersion": "0.4.3"
       },
       "stable": {
-        "minVersion": "0.7.0",
-        "maxVersion": "0.7.0"
+        "minVersion": "0.7.1",
+        "maxVersion": "0.7.1"
       }
     },
     "availableVersions": [
       "0.4.3",
-      "0.7.0"
+      "0.7.1"
     ],
     "minVersion": "0.4.3",
-    "maxVersion": "0.7.0",
+    "maxVersion": "0.7.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -3291,33 +3307,33 @@
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.11.0"
       ],
       "unstable": [
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.11.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.9.2",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       },
       "unstable": {
         "minVersion": "2.9.2",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       }
     },
     "availableVersions": [
       "2.9.2",
       "2.10.0",
       "2.10.1",
-      "2.10.2"
+      "2.11.0"
     ],
     "minVersion": "2.9.2",
-    "maxVersion": "2.10.2",
+    "maxVersion": "2.11.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -3338,13 +3354,14 @@
         "1.45.0",
         "1.46.0",
         "1.47.0",
-        "1.47.1"
+        "1.47.1",
+        "1.48.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.42.0",
-        "maxVersion": "1.47.1"
+        "maxVersion": "1.48.0"
       }
     },
     "availableVersions": [
@@ -3356,10 +3373,11 @@
       "1.45.0",
       "1.46.0",
       "1.47.0",
-      "1.47.1"
+      "1.47.1",
+      "1.48.0"
     ],
     "minVersion": "1.42.0",
-    "maxVersion": "1.47.1",
+    "maxVersion": "1.48.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -5266,13 +5284,15 @@
         "2.2.5",
         "2.2.6",
         "2.2.7",
-        "2.2.8"
+        "2.2.8",
+        "2.2.9",
+        "2.2.10"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.0.4",
-        "maxVersion": "2.2.8"
+        "maxVersion": "2.2.10"
       }
     },
     "availableVersions": [
@@ -5335,10 +5355,12 @@
       "2.2.5",
       "2.2.6",
       "2.2.7",
-      "2.2.8"
+      "2.2.8",
+      "2.2.9",
+      "2.2.10"
     ],
     "minVersion": "2.0.4",
-    "maxVersion": "2.2.8",
+    "maxVersion": "2.2.10",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -6558,7 +6580,7 @@
         "8.19.40-beta.1"
       ],
       "stable": [
-        "8.19.30"
+        "8.19.40"
       ]
     },
     "channelVersionRanges": {
@@ -6567,15 +6589,15 @@
         "maxVersion": "8.19.40-beta.1"
       },
       "stable": {
-        "minVersion": "8.19.30",
-        "maxVersion": "8.19.30"
+        "minVersion": "8.19.40",
+        "maxVersion": "8.19.40"
       }
     },
     "availableVersions": [
-      "8.19.30",
+      "8.19.40",
       "8.19.40-beta.1"
     ],
-    "minVersion": "8.19.30",
+    "minVersion": "8.19.40",
     "maxVersion": "8.19.40-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
@@ -6784,26 +6806,35 @@
   },
   {
     "name": "mediation-openstack-operator",
-    "defaultChannel": "alpha",
+    "defaultChannel": "stable",
     "channels": [
-      "alpha"
+      "alpha",
+      "stable"
     ],
     "channelVersions": {
       "alpha": [
-        "8.19.2"
+        "8.19.40-beta.1"
+      ],
+      "stable": [
+        "8.19.40"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
-        "minVersion": "8.19.2",
-        "maxVersion": "8.19.2"
+        "minVersion": "8.19.40-beta.1",
+        "maxVersion": "8.19.40-beta.1"
+      },
+      "stable": {
+        "minVersion": "8.19.40",
+        "maxVersion": "8.19.40"
       }
     },
     "availableVersions": [
-      "8.19.2"
+      "8.19.40",
+      "8.19.40-beta.1"
     ],
-    "minVersion": "8.19.2",
-    "maxVersion": "8.19.2",
+    "minVersion": "8.19.40",
+    "maxVersion": "8.19.40-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -8459,7 +8490,7 @@
         "8.19.40-beta.1"
       ],
       "stable": [
-        "8.19.30"
+        "8.19.40"
       ]
     },
     "channelVersionRanges": {
@@ -8468,15 +8499,15 @@
         "maxVersion": "8.19.40-beta.1"
       },
       "stable": {
-        "minVersion": "8.19.30",
-        "maxVersion": "8.19.30"
+        "minVersion": "8.19.40",
+        "maxVersion": "8.19.40"
       }
     },
     "availableVersions": [
-      "8.19.30",
+      "8.19.40",
       "8.19.40-beta.1"
     ],
-    "minVersion": "8.19.30",
+    "minVersion": "8.19.40",
     "maxVersion": "8.19.40-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
@@ -8598,6 +8629,7 @@
       "7.22.2-32.1",
       "7.22.2-37.1",
       "7.22.2-38.0",
+      "7.22.2-39.0",
       "7.8.4",
       "7.8.6",
       "8.0.10",
@@ -8651,6 +8683,7 @@
         "7.8.6-1.2",
         "7.8.6-11.0",
         "7.8.6-13.0",
+        "7.8.6-14.0",
         "7.8.6-2.2",
         "7.8.6-3.2",
         "7.8.6-5.1",
@@ -8666,7 +8699,8 @@
         "7.22.2-31.1",
         "7.22.2-32.1",
         "7.22.2-37.1",
-        "7.22.2-38.0"
+        "7.22.2-38.0",
+        "7.22.2-39.0"
       ],
       "7.22.2-21.1": [
         "7.8.4-9.0",
@@ -8788,6 +8822,32 @@
         "7.22.2-37.1",
         "7.22.2-38.0"
       ],
+      "7.22.2-39.0": [
+        "7.8.4-9.0",
+        "7.8.6-1.0",
+        "7.8.6-1.1",
+        "7.8.6-1.2",
+        "7.8.6-11.0",
+        "7.8.6-13.0",
+        "7.8.6-14.0",
+        "7.8.6-2.2",
+        "7.8.6-3.2",
+        "7.8.6-5.1",
+        "7.8.6-8.1",
+        "7.22.0-11.2",
+        "7.22.0-11.3",
+        "7.22.0-15.0",
+        "7.22.0-16.0",
+        "7.22.0-17.0",
+        "7.22.0-7.0",
+        "7.22.2-21.1",
+        "7.22.2-22.0",
+        "7.22.2-31.1",
+        "7.22.2-32.1",
+        "7.22.2-37.1",
+        "7.22.2-38.0",
+        "7.22.2-39.0"
+      ],
       "7.8.4": [
         "7.8.4-9.0"
       ],
@@ -8798,6 +8858,7 @@
         "7.8.6-1.2",
         "7.8.6-11.0",
         "7.8.6-13.0",
+        "7.8.6-14.0",
         "7.8.6-2.2",
         "7.8.6-3.2",
         "7.8.6-5.1",
@@ -9160,7 +9221,7 @@
       },
       "7.22.2": {
         "minVersion": "7.8.4-9.0",
-        "maxVersion": "7.22.2-38.0"
+        "maxVersion": "7.22.2-39.0"
       },
       "7.22.2-21.1": {
         "minVersion": "7.8.4-9.0",
@@ -9185,6 +9246,10 @@
       "7.22.2-38.0": {
         "minVersion": "7.8.4-9.0",
         "maxVersion": "7.22.2-38.0"
+      },
+      "7.22.2-39.0": {
+        "minVersion": "7.8.4-9.0",
+        "maxVersion": "7.22.2-39.0"
       },
       "7.8.4": {
         "minVersion": "7.8.4-9.0",
@@ -9261,6 +9326,7 @@
       "7.8.6-1.2",
       "7.8.6-11.0",
       "7.8.6-13.0",
+      "7.8.6-14.0",
       "7.8.6-2.2",
       "7.8.6-3.2",
       "7.8.6-5.1",
@@ -9277,6 +9343,7 @@
       "7.22.2-32.1",
       "7.22.2-37.1",
       "7.22.2-38.0",
+      "7.22.2-39.0",
       "8.0.2-2.9",
       "8.0.2-6.1",
       "8.0.6-8.0",
@@ -9506,7 +9573,10 @@
         "1.29.3",
         "1.29.4",
         "1.29.6",
-        "1.29.7"
+        "1.29.7",
+        "1.29.8",
+        "1.29.10",
+        "1.29.11"
       ],
       "stable-v1.26": [
         "1.26.8",
@@ -9561,13 +9631,16 @@
         "1.29.3",
         "1.29.4",
         "1.29.6",
-        "1.29.7"
+        "1.29.7",
+        "1.29.8",
+        "1.29.10",
+        "1.29.11"
       ]
     },
     "channelVersionRanges": {
       "stable-v1": {
         "minVersion": "1.26.8",
-        "maxVersion": "1.29.7"
+        "maxVersion": "1.29.11"
       },
       "stable-v1.26": {
         "minVersion": "1.26.8",
@@ -9583,7 +9656,7 @@
       },
       "stable-v1.29": {
         "minVersion": "1.29.3",
-        "maxVersion": "1.29.7"
+        "maxVersion": "1.29.11"
       }
     },
     "availableVersions": [
@@ -9633,10 +9706,13 @@
       "1.29.3",
       "1.29.4",
       "1.29.6",
-      "1.29.7"
+      "1.29.7",
+      "1.29.8",
+      "1.29.10",
+      "1.29.11"
     ],
     "minVersion": "1.26.8",
-    "maxVersion": "1.29.7",
+    "maxVersion": "1.29.11",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -10750,28 +10826,28 @@
     ],
     "channelVersions": {
       "beta": [
-        "42.102.0-beta.1"
+        "42.102.0-beta.2"
       ],
       "stable": [
-        "42.101.0"
+        "42.102.0"
       ]
     },
     "channelVersionRanges": {
       "beta": {
-        "minVersion": "42.102.0-beta.1",
-        "maxVersion": "42.102.0-beta.1"
+        "minVersion": "42.102.0-beta.2",
+        "maxVersion": "42.102.0-beta.2"
       },
       "stable": {
-        "minVersion": "42.101.0",
-        "maxVersion": "42.101.0"
+        "minVersion": "42.102.0",
+        "maxVersion": "42.102.0"
       }
     },
     "availableVersions": [
-      "42.101.0",
-      "42.102.0-beta.1"
+      "42.102.0",
+      "42.102.0-beta.2"
     ],
-    "minVersion": "42.101.0",
-    "maxVersion": "42.102.0-beta.1",
+    "minVersion": "42.102.0",
+    "maxVersion": "42.102.0-beta.2",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -10874,13 +10950,14 @@
   },
   {
     "name": "tenant-operator",
-    "defaultChannel": "release-1.6",
+    "defaultChannel": "release-1.7",
     "channels": [
       "release-1.2",
       "release-1.3",
       "release-1.4",
       "release-1.5",
-      "release-1.6"
+      "release-1.6",
+      "release-1.7"
     ],
     "channelVersions": {
       "release-1.2": [
@@ -10897,6 +10974,9 @@
       ],
       "release-1.6": [
         "1.6.2"
+      ],
+      "release-1.7": [
+        "1.7.0"
       ]
     },
     "channelVersionRanges": {
@@ -10919,6 +10999,10 @@
       "release-1.6": {
         "minVersion": "1.6.2",
         "maxVersion": "1.6.2"
+      },
+      "release-1.7": {
+        "minVersion": "1.7.0",
+        "maxVersion": "1.7.0"
       }
     },
     "availableVersions": [
@@ -10926,10 +11010,11 @@
       "1.3.0",
       "1.4.2",
       "1.5.2",
-      "1.6.2"
+      "1.6.2",
+      "1.7.0"
     ],
     "minVersion": "1.2.1",
-    "maxVersion": "1.6.2",
+    "maxVersion": "1.7.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -11403,7 +11488,7 @@
   },
   {
     "name": "uma-team-operator",
-    "defaultChannel": "stable",
+    "defaultChannel": "alpha",
     "channels": [
       "2025.10",
       "2025.11",
@@ -11447,7 +11532,7 @@
         "2026.3.1-2"
       ],
       "alpha": [
-        "2025.11.4-3"
+        "2026.4.0-15"
       ],
       "beta": [
         "2026.2.0-10"
@@ -11494,8 +11579,8 @@
         "maxVersion": "2026.3.1-2"
       },
       "alpha": {
-        "minVersion": "2025.11.4-3",
-        "maxVersion": "2025.11.4-3"
+        "minVersion": "2026.4.0-15",
+        "maxVersion": "2026.4.0-15"
       },
       "beta": {
         "minVersion": "2026.2.0-10",
@@ -11514,13 +11599,13 @@
       "2025.9.1-12",
       "2025.10.1-12",
       "2025.11.1-38",
-      "2025.11.4-3",
       "2026.1.1-35",
       "2026.2.0-10",
-      "2026.3.1-2"
+      "2026.3.1-2",
+      "2026.4.0-15"
     ],
     "minVersion": "2025.4.5-5",
-    "maxVersion": "2026.3.1-2",
+    "maxVersion": "2026.4.0-15",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -11675,21 +11760,23 @@
     "channelVersions": {
       "stable": [
         "4.5.1961",
-        "4.6.1984"
+        "4.6.1984",
+        "4.6.2014"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.5.1961",
-        "maxVersion": "4.6.1984"
+        "maxVersion": "4.6.2014"
       }
     },
     "availableVersions": [
       "4.5.1961",
-      "4.6.1984"
+      "4.6.1984",
+      "4.6.2014"
     ],
     "minVersion": "4.5.1961",
-    "maxVersion": "4.6.1984",
+    "maxVersion": "4.6.2014",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"

--- a/catalog-data/certified-operator-index/v4.18/dependencies.json
+++ b/catalog-data/certified-operator-index/v4.18/dependencies.json
@@ -52,7 +52,7 @@
     },
     {
       "packageName": "mto-dependencies-operator",
-      "versionRange": ">=0.0.5"
+      "versionRange": ">=0.0.7"
     },
     {
       "packageName": "template-operator",

--- a/catalog-data/certified-operator-index/v4.18/operators.json
+++ b/catalog-data/certified-operator-index/v4.18/operators.json
@@ -2046,17 +2046,21 @@
   },
   {
     "name": "cp-fko",
-    "defaultChannel": "alpha",
+    "defaultChannel": "stable-v1.14",
     "channels": [
       "alpha",
-      "stable"
+      "stable",
+      "stable-v1.14"
     ],
     "channelVersions": {
       "alpha": [
         "0.0.1"
       ],
       "stable": [
-        "1.13.0-cp2"
+        "1.14.0-cp1"
+      ],
+      "stable-v1.14": [
+        "1.14.0-cp1"
       ]
     },
     "channelVersionRanges": {
@@ -2065,16 +2069,20 @@
         "maxVersion": "0.0.1"
       },
       "stable": {
-        "minVersion": "1.13.0-cp2",
-        "maxVersion": "1.13.0-cp2"
+        "minVersion": "1.14.0-cp1",
+        "maxVersion": "1.14.0-cp1"
+      },
+      "stable-v1.14": {
+        "minVersion": "1.14.0-cp1",
+        "maxVersion": "1.14.0-cp1"
       }
     },
     "availableVersions": [
       "0.0.1",
-      "1.13.0-cp2"
+      "1.14.0-cp1"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.13.0-cp2",
+    "maxVersion": "1.14.0-cp1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -2524,7 +2532,8 @@
         "25.1.5",
         "25.1.6",
         "25.1.8",
-        "25.1.9"
+        "25.1.9",
+        "25.1.10-1"
       ]
     },
     "channelVersionRanges": {
@@ -2546,7 +2555,7 @@
       },
       "stable-v25.1": {
         "minVersion": "25.1.0",
-        "maxVersion": "25.1.9"
+        "maxVersion": "25.1.10-1"
       }
     },
     "availableVersions": [
@@ -2576,6 +2585,7 @@
       "25.1.6",
       "25.1.8",
       "25.1.9",
+      "25.1.10-1",
       "26.1.0"
     ],
     "minVersion": "24.1.10",
@@ -2661,13 +2671,14 @@
         "1.7.2",
         "1.7.3",
         "1.8.0",
-        "1.8.1"
+        "1.8.1",
+        "1.9.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.4.0",
-        "maxVersion": "1.8.1"
+        "maxVersion": "1.9.0"
       }
     },
     "availableVersions": [
@@ -2684,10 +2695,11 @@
       "1.7.2",
       "1.7.3",
       "1.8.0",
-      "1.8.1"
+      "1.8.1",
+      "1.9.0"
     ],
     "minVersion": "1.4.0",
-    "maxVersion": "1.8.1",
+    "maxVersion": "1.9.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -2739,7 +2751,8 @@
         "1.3.3",
         "1.3.4",
         "1.3.5",
-        "1.3.6"
+        "1.3.6",
+        "1.3.7"
       ],
       "innovation": [
         "2025.11.0",
@@ -2753,7 +2766,8 @@
         "1.3.3",
         "1.3.4",
         "1.3.5",
-        "1.3.6"
+        "1.3.6",
+        "1.3.7"
       ],
       "stable": [
         "1.2.0",
@@ -2766,13 +2780,14 @@
         "1.3.3",
         "1.3.4",
         "1.3.5",
-        "1.3.6"
+        "1.3.6",
+        "1.3.7"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.2.0",
-        "maxVersion": "1.3.6"
+        "maxVersion": "1.3.7"
       },
       "innovation": {
         "minVersion": "2025.11.0",
@@ -2780,11 +2795,11 @@
       },
       "lts-v1.3": {
         "minVersion": "1.3.2",
-        "maxVersion": "1.3.6"
+        "maxVersion": "1.3.7"
       },
       "stable": {
         "minVersion": "1.2.0",
-        "maxVersion": "1.3.6"
+        "maxVersion": "1.3.7"
       }
     },
     "availableVersions": [
@@ -2799,6 +2814,7 @@
       "1.3.4",
       "1.3.5",
       "1.3.6",
+      "1.3.7",
       "2025.11.0",
       "2025.12.0",
       "2026.1.0",
@@ -2953,7 +2969,7 @@
         "0.4.3"
       ],
       "stable": [
-        "0.7.0"
+        "0.7.1"
       ]
     },
     "channelVersionRanges": {
@@ -2962,16 +2978,16 @@
         "maxVersion": "0.4.3"
       },
       "stable": {
-        "minVersion": "0.7.0",
-        "maxVersion": "0.7.0"
+        "minVersion": "0.7.1",
+        "maxVersion": "0.7.1"
       }
     },
     "availableVersions": [
       "0.4.3",
-      "0.7.0"
+      "0.7.1"
     ],
     "minVersion": "0.4.3",
-    "maxVersion": "0.7.0",
+    "maxVersion": "0.7.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -3228,33 +3244,33 @@
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.11.0"
       ],
       "unstable": [
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.11.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.9.2",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       },
       "unstable": {
         "minVersion": "2.9.2",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       }
     },
     "availableVersions": [
       "2.9.2",
       "2.10.0",
       "2.10.1",
-      "2.10.2"
+      "2.11.0"
     ],
     "minVersion": "2.9.2",
-    "maxVersion": "2.10.2",
+    "maxVersion": "2.11.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -3275,13 +3291,14 @@
         "1.45.0",
         "1.46.0",
         "1.47.0",
-        "1.47.1"
+        "1.47.1",
+        "1.48.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.42.0",
-        "maxVersion": "1.47.1"
+        "maxVersion": "1.48.0"
       }
     },
     "availableVersions": [
@@ -3293,10 +3310,11 @@
       "1.45.0",
       "1.46.0",
       "1.47.0",
-      "1.47.1"
+      "1.47.1",
+      "1.48.0"
     ],
     "minVersion": "1.42.0",
-    "maxVersion": "1.47.1",
+    "maxVersion": "1.48.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -3641,6 +3659,7 @@
       "1.21",
       "1.22",
       "1.23",
+      "1.24",
       "stable"
     ],
     "channelVersions": {
@@ -3669,6 +3688,9 @@
       "1.23": [
         "1.23.0-695"
       ],
+      "1.24": [
+        "1.24.0-1007"
+      ],
       "stable": [
         "1.20.0-543-4",
         "1.20.0-543-5",
@@ -3686,7 +3708,8 @@
         "1.22.2-32",
         "1.22.2-32-1",
         "1.22.2-32-2",
-        "1.23.0-695"
+        "1.23.0-695",
+        "1.24.0-1007"
       ]
     },
     "channelVersionRanges": {
@@ -3706,9 +3729,13 @@
         "minVersion": "1.23.0-695",
         "maxVersion": "1.23.0-695"
       },
+      "1.24": {
+        "minVersion": "1.24.0-1007",
+        "maxVersion": "1.24.0-1007"
+      },
       "stable": {
         "minVersion": "1.20.0-543-4",
-        "maxVersion": "1.23.0-695"
+        "maxVersion": "1.24.0-1007"
       }
     },
     "availableVersions": [
@@ -3728,10 +3755,11 @@
       "1.22.2-32",
       "1.22.2-32-1",
       "1.22.2-32-2",
-      "1.23.0-695"
+      "1.23.0-695",
+      "1.24.0-1007"
     ],
     "minVersion": "1.20.0-543-4",
-    "maxVersion": "1.23.0-695",
+    "maxVersion": "1.24.0-1007",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -4043,6 +4071,7 @@
     "defaultChannel": "stable",
     "channels": [
       "stable",
+      "stable-1.13.1",
       "stable-v1.12",
       "stable-v1.12.1",
       "stable-v1.12.2",
@@ -4059,7 +4088,17 @@
         "1.12.3",
         "1.12.4",
         "1.12.5",
-        "1.13.0"
+        "1.13.0",
+        "1.13.1"
+      ],
+      "stable-1.13.1": [
+        "1.12.1",
+        "1.12.2",
+        "1.12.3",
+        "1.12.4",
+        "1.12.5",
+        "1.13.0",
+        "1.13.1"
       ],
       "stable-v1.12": [
         "1.12.1",
@@ -4099,7 +4138,8 @@
         "1.12.3",
         "1.12.4",
         "1.12.5",
-        "1.13.0"
+        "1.13.0",
+        "1.13.1"
       ],
       "stable-v1.13.0": [
         "1.12.1",
@@ -4113,7 +4153,11 @@
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.12.1",
-        "maxVersion": "1.13.0"
+        "maxVersion": "1.13.1"
+      },
+      "stable-1.13.1": {
+        "minVersion": "1.12.1",
+        "maxVersion": "1.13.1"
       },
       "stable-v1.12": {
         "minVersion": "1.12.1",
@@ -4141,7 +4185,7 @@
       },
       "stable-v1.13": {
         "minVersion": "1.12.1",
-        "maxVersion": "1.13.0"
+        "maxVersion": "1.13.1"
       },
       "stable-v1.13.0": {
         "minVersion": "1.12.1",
@@ -4154,10 +4198,11 @@
       "1.12.3",
       "1.12.4",
       "1.12.5",
-      "1.13.0"
+      "1.13.0",
+      "1.13.1"
     ],
     "minVersion": "1.12.1",
-    "maxVersion": "1.13.0",
+    "maxVersion": "1.13.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -5128,13 +5173,15 @@
         "2.2.5",
         "2.2.6",
         "2.2.7",
-        "2.2.8"
+        "2.2.8",
+        "2.2.9",
+        "2.2.10"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.0.4",
-        "maxVersion": "2.2.8"
+        "maxVersion": "2.2.10"
       }
     },
     "availableVersions": [
@@ -5197,10 +5244,12 @@
       "2.2.5",
       "2.2.6",
       "2.2.7",
-      "2.2.8"
+      "2.2.8",
+      "2.2.9",
+      "2.2.10"
     ],
     "minVersion": "2.0.4",
-    "maxVersion": "2.2.8",
+    "maxVersion": "2.2.10",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -6444,7 +6493,7 @@
         "8.19.40-beta.1"
       ],
       "stable": [
-        "8.19.30"
+        "8.19.40"
       ]
     },
     "channelVersionRanges": {
@@ -6453,15 +6502,15 @@
         "maxVersion": "8.19.40-beta.1"
       },
       "stable": {
-        "minVersion": "8.19.30",
-        "maxVersion": "8.19.30"
+        "minVersion": "8.19.40",
+        "maxVersion": "8.19.40"
       }
     },
     "availableVersions": [
-      "8.19.30",
+      "8.19.40",
       "8.19.40-beta.1"
     ],
-    "minVersion": "8.19.30",
+    "minVersion": "8.19.40",
     "maxVersion": "8.19.40-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
@@ -6670,26 +6719,35 @@
   },
   {
     "name": "mediation-openstack-operator",
-    "defaultChannel": "alpha",
+    "defaultChannel": "stable",
     "channels": [
-      "alpha"
+      "alpha",
+      "stable"
     ],
     "channelVersions": {
       "alpha": [
-        "8.19.2"
+        "8.19.40-beta.1"
+      ],
+      "stable": [
+        "8.19.40"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
-        "minVersion": "8.19.2",
-        "maxVersion": "8.19.2"
+        "minVersion": "8.19.40-beta.1",
+        "maxVersion": "8.19.40-beta.1"
+      },
+      "stable": {
+        "minVersion": "8.19.40",
+        "maxVersion": "8.19.40"
       }
     },
     "availableVersions": [
-      "8.19.2"
+      "8.19.40",
+      "8.19.40-beta.1"
     ],
-    "minVersion": "8.19.2",
-    "maxVersion": "8.19.2",
+    "minVersion": "8.19.40",
+    "maxVersion": "8.19.40-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -8038,22 +8096,24 @@
       "stable": [
         "1.17.0",
         "1.18.0",
-        "1.19.0"
+        "1.19.0",
+        "1.19.1"
       ],
       "stable-cw": [
         "1.17.0-cw",
         "1.18.0-cw",
-        "1.19.0-cw"
+        "1.19.0-cw",
+        "1.19.1-cw"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.17.0",
-        "maxVersion": "1.19.0"
+        "maxVersion": "1.19.1"
       },
       "stable-cw": {
         "minVersion": "1.17.0-cw",
-        "maxVersion": "1.19.0-cw"
+        "maxVersion": "1.19.1-cw"
       }
     },
     "availableVersions": [
@@ -8062,10 +8122,12 @@
       "1.18.0",
       "1.18.0-cw",
       "1.19.0",
-      "1.19.0-cw"
+      "1.19.0-cw",
+      "1.19.1",
+      "1.19.1-cw"
     ],
     "minVersion": "1.17.0",
-    "maxVersion": "1.19.0-cw",
+    "maxVersion": "1.19.1-cw",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -8335,7 +8397,7 @@
         "8.19.40-beta.1"
       ],
       "stable": [
-        "8.19.30"
+        "8.19.40"
       ]
     },
     "channelVersionRanges": {
@@ -8344,15 +8406,15 @@
         "maxVersion": "8.19.40-beta.1"
       },
       "stable": {
-        "minVersion": "8.19.30",
-        "maxVersion": "8.19.30"
+        "minVersion": "8.19.40",
+        "maxVersion": "8.19.40"
       }
     },
     "availableVersions": [
-      "8.19.30",
+      "8.19.40",
       "8.19.40-beta.1"
     ],
-    "minVersion": "8.19.30",
+    "minVersion": "8.19.40",
     "maxVersion": "8.19.40-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
@@ -8474,6 +8536,7 @@
       "7.22.2-32.1",
       "7.22.2-37.1",
       "7.22.2-38.0",
+      "7.22.2-39.0",
       "7.8.4",
       "7.8.6",
       "8.0.10",
@@ -8527,6 +8590,7 @@
         "7.8.6-1.2",
         "7.8.6-11.0",
         "7.8.6-13.0",
+        "7.8.6-14.0",
         "7.8.6-2.2",
         "7.8.6-3.2",
         "7.8.6-5.1",
@@ -8542,7 +8606,8 @@
         "7.22.2-31.1",
         "7.22.2-32.1",
         "7.22.2-37.1",
-        "7.22.2-38.0"
+        "7.22.2-38.0",
+        "7.22.2-39.0"
       ],
       "7.22.2-21.1": [
         "7.8.4-9.0",
@@ -8664,6 +8729,32 @@
         "7.22.2-37.1",
         "7.22.2-38.0"
       ],
+      "7.22.2-39.0": [
+        "7.8.4-9.0",
+        "7.8.6-1.0",
+        "7.8.6-1.1",
+        "7.8.6-1.2",
+        "7.8.6-11.0",
+        "7.8.6-13.0",
+        "7.8.6-14.0",
+        "7.8.6-2.2",
+        "7.8.6-3.2",
+        "7.8.6-5.1",
+        "7.8.6-8.1",
+        "7.22.0-11.2",
+        "7.22.0-11.3",
+        "7.22.0-15.0",
+        "7.22.0-16.0",
+        "7.22.0-17.0",
+        "7.22.0-7.0",
+        "7.22.2-21.1",
+        "7.22.2-22.0",
+        "7.22.2-31.1",
+        "7.22.2-32.1",
+        "7.22.2-37.1",
+        "7.22.2-38.0",
+        "7.22.2-39.0"
+      ],
       "7.8.4": [
         "7.8.4-9.0"
       ],
@@ -8674,6 +8765,7 @@
         "7.8.6-1.2",
         "7.8.6-11.0",
         "7.8.6-13.0",
+        "7.8.6-14.0",
         "7.8.6-2.2",
         "7.8.6-3.2",
         "7.8.6-5.1",
@@ -9036,7 +9128,7 @@
       },
       "7.22.2": {
         "minVersion": "7.8.4-9.0",
-        "maxVersion": "7.22.2-38.0"
+        "maxVersion": "7.22.2-39.0"
       },
       "7.22.2-21.1": {
         "minVersion": "7.8.4-9.0",
@@ -9061,6 +9153,10 @@
       "7.22.2-38.0": {
         "minVersion": "7.8.4-9.0",
         "maxVersion": "7.22.2-38.0"
+      },
+      "7.22.2-39.0": {
+        "minVersion": "7.8.4-9.0",
+        "maxVersion": "7.22.2-39.0"
       },
       "7.8.4": {
         "minVersion": "7.8.4-9.0",
@@ -9137,6 +9233,7 @@
       "7.8.6-1.2",
       "7.8.6-11.0",
       "7.8.6-13.0",
+      "7.8.6-14.0",
       "7.8.6-2.2",
       "7.8.6-3.2",
       "7.8.6-5.1",
@@ -9153,6 +9250,7 @@
       "7.22.2-32.1",
       "7.22.2-37.1",
       "7.22.2-38.0",
+      "7.22.2-39.0",
       "8.0.2-2.9",
       "8.0.2-6.1",
       "8.0.6-8.0",
@@ -9382,7 +9480,10 @@
         "1.29.3",
         "1.29.4",
         "1.29.6",
-        "1.29.7"
+        "1.29.7",
+        "1.29.8",
+        "1.29.10",
+        "1.29.11"
       ],
       "stable-v1.26": [
         "1.26.8",
@@ -9437,13 +9538,16 @@
         "1.29.3",
         "1.29.4",
         "1.29.6",
-        "1.29.7"
+        "1.29.7",
+        "1.29.8",
+        "1.29.10",
+        "1.29.11"
       ]
     },
     "channelVersionRanges": {
       "stable-v1": {
         "minVersion": "1.26.8",
-        "maxVersion": "1.29.7"
+        "maxVersion": "1.29.11"
       },
       "stable-v1.26": {
         "minVersion": "1.26.8",
@@ -9459,7 +9563,7 @@
       },
       "stable-v1.29": {
         "minVersion": "1.29.3",
-        "maxVersion": "1.29.7"
+        "maxVersion": "1.29.11"
       }
     },
     "availableVersions": [
@@ -9509,10 +9613,13 @@
       "1.29.3",
       "1.29.4",
       "1.29.6",
-      "1.29.7"
+      "1.29.7",
+      "1.29.8",
+      "1.29.10",
+      "1.29.11"
     ],
     "minVersion": "1.26.8",
-    "maxVersion": "1.29.7",
+    "maxVersion": "1.29.11",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -10898,28 +11005,28 @@
     ],
     "channelVersions": {
       "beta": [
-        "42.102.0-beta.1"
+        "42.102.0-beta.2"
       ],
       "stable": [
-        "42.101.0"
+        "42.102.0"
       ]
     },
     "channelVersionRanges": {
       "beta": {
-        "minVersion": "42.102.0-beta.1",
-        "maxVersion": "42.102.0-beta.1"
+        "minVersion": "42.102.0-beta.2",
+        "maxVersion": "42.102.0-beta.2"
       },
       "stable": {
-        "minVersion": "42.101.0",
-        "maxVersion": "42.101.0"
+        "minVersion": "42.102.0",
+        "maxVersion": "42.102.0"
       }
     },
     "availableVersions": [
-      "42.101.0",
-      "42.102.0-beta.1"
+      "42.102.0",
+      "42.102.0-beta.2"
     ],
-    "minVersion": "42.101.0",
-    "maxVersion": "42.102.0-beta.1",
+    "minVersion": "42.102.0",
+    "maxVersion": "42.102.0-beta.2",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -11022,13 +11129,14 @@
   },
   {
     "name": "tenant-operator",
-    "defaultChannel": "release-1.6",
+    "defaultChannel": "release-1.7",
     "channels": [
       "release-1.2",
       "release-1.3",
       "release-1.4",
       "release-1.5",
-      "release-1.6"
+      "release-1.6",
+      "release-1.7"
     ],
     "channelVersions": {
       "release-1.2": [
@@ -11045,6 +11153,9 @@
       ],
       "release-1.6": [
         "1.6.2"
+      ],
+      "release-1.7": [
+        "1.7.0"
       ]
     },
     "channelVersionRanges": {
@@ -11067,6 +11178,10 @@
       "release-1.6": {
         "minVersion": "1.6.2",
         "maxVersion": "1.6.2"
+      },
+      "release-1.7": {
+        "minVersion": "1.7.0",
+        "maxVersion": "1.7.0"
       }
     },
     "availableVersions": [
@@ -11074,10 +11189,11 @@
       "1.3.0",
       "1.4.2",
       "1.5.2",
-      "1.6.2"
+      "1.6.2",
+      "1.7.0"
     ],
     "minVersion": "1.2.1",
-    "maxVersion": "1.6.2",
+    "maxVersion": "1.7.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -11561,7 +11677,7 @@
   },
   {
     "name": "uma-team-operator",
-    "defaultChannel": "stable",
+    "defaultChannel": "alpha",
     "channels": [
       "2025.10",
       "2025.11",
@@ -11605,7 +11721,7 @@
         "2026.3.1-2"
       ],
       "alpha": [
-        "2025.11.4-3"
+        "2026.4.0-15"
       ],
       "beta": [
         "2026.2.0-10"
@@ -11652,8 +11768,8 @@
         "maxVersion": "2026.3.1-2"
       },
       "alpha": {
-        "minVersion": "2025.11.4-3",
-        "maxVersion": "2025.11.4-3"
+        "minVersion": "2026.4.0-15",
+        "maxVersion": "2026.4.0-15"
       },
       "beta": {
         "minVersion": "2026.2.0-10",
@@ -11672,13 +11788,13 @@
       "2025.9.1-12",
       "2025.10.1-12",
       "2025.11.1-38",
-      "2025.11.4-3",
       "2026.1.1-35",
       "2026.2.0-10",
-      "2026.3.1-2"
+      "2026.3.1-2",
+      "2026.4.0-15"
     ],
     "minVersion": "2025.4.5-5",
-    "maxVersion": "2026.3.1-2",
+    "maxVersion": "2026.4.0-15",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -11833,21 +11949,23 @@
     "channelVersions": {
       "stable": [
         "4.5.1961",
-        "4.6.1984"
+        "4.6.1984",
+        "4.6.2014"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.5.1961",
-        "maxVersion": "4.6.1984"
+        "maxVersion": "4.6.2014"
       }
     },
     "availableVersions": [
       "4.5.1961",
-      "4.6.1984"
+      "4.6.1984",
+      "4.6.2014"
     ],
     "minVersion": "4.5.1961",
-    "maxVersion": "4.6.1984",
+    "maxVersion": "4.6.2014",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"

--- a/catalog-data/certified-operator-index/v4.19/dependencies.json
+++ b/catalog-data/certified-operator-index/v4.19/dependencies.json
@@ -46,7 +46,7 @@
     },
     {
       "packageName": "mto-dependencies-operator",
-      "versionRange": ">=0.0.5"
+      "versionRange": ">=0.0.7"
     },
     {
       "packageName": "template-operator",

--- a/catalog-data/certified-operator-index/v4.19/operators.json
+++ b/catalog-data/certified-operator-index/v4.19/operators.json
@@ -1666,17 +1666,21 @@
   },
   {
     "name": "cp-fko",
-    "defaultChannel": "alpha",
+    "defaultChannel": "stable-v1.14",
     "channels": [
       "alpha",
-      "stable"
+      "stable",
+      "stable-v1.14"
     ],
     "channelVersions": {
       "alpha": [
         "0.0.1"
       ],
       "stable": [
-        "1.13.0-cp2"
+        "1.14.0-cp1"
+      ],
+      "stable-v1.14": [
+        "1.14.0-cp1"
       ]
     },
     "channelVersionRanges": {
@@ -1685,16 +1689,20 @@
         "maxVersion": "0.0.1"
       },
       "stable": {
-        "minVersion": "1.13.0-cp2",
-        "maxVersion": "1.13.0-cp2"
+        "minVersion": "1.14.0-cp1",
+        "maxVersion": "1.14.0-cp1"
+      },
+      "stable-v1.14": {
+        "minVersion": "1.14.0-cp1",
+        "maxVersion": "1.14.0-cp1"
       }
     },
     "availableVersions": [
       "0.0.1",
-      "1.13.0-cp2"
+      "1.14.0-cp1"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.13.0-cp2",
+    "maxVersion": "1.14.0-cp1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -2011,7 +2019,8 @@
       "beta",
       "stable",
       "stable-v24.1",
-      "stable-v24.3"
+      "stable-v24.3",
+      "stable-v25.1"
     ],
     "channelVersions": {
       "beta": [
@@ -2028,6 +2037,9 @@
       "stable-v24.3": [
         "24.3.5",
         "24.3.6"
+      ],
+      "stable-v25.1": [
+        "25.1.10-1"
       ]
     },
     "channelVersionRanges": {
@@ -2046,6 +2058,10 @@
       "stable-v24.3": {
         "minVersion": "24.3.5",
         "maxVersion": "24.3.6"
+      },
+      "stable-v25.1": {
+        "minVersion": "25.1.10-1",
+        "maxVersion": "25.1.10-1"
       }
     },
     "availableVersions": [
@@ -2054,10 +2070,11 @@
       "24.1.17",
       "24.3.5",
       "24.3.6",
-      "25.1.0-beta.6"
+      "25.1.0-beta.6",
+      "25.1.10-1"
     ],
     "minVersion": "24.1.10",
-    "maxVersion": "25.1.0-beta.6",
+    "maxVersion": "25.1.10-1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -2139,13 +2156,14 @@
         "1.7.2",
         "1.7.3",
         "1.8.0",
-        "1.8.1"
+        "1.8.1",
+        "1.9.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.4.0",
-        "maxVersion": "1.8.1"
+        "maxVersion": "1.9.0"
       }
     },
     "availableVersions": [
@@ -2162,10 +2180,11 @@
       "1.7.2",
       "1.7.3",
       "1.8.0",
-      "1.8.1"
+      "1.8.1",
+      "1.9.0"
     ],
     "minVersion": "1.4.0",
-    "maxVersion": "1.8.1",
+    "maxVersion": "1.9.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -2216,7 +2235,8 @@
         "1.3.3",
         "1.3.4",
         "1.3.5",
-        "1.3.6"
+        "1.3.6",
+        "1.3.7"
       ],
       "innovation": [
         "2025.11.0",
@@ -2230,7 +2250,8 @@
         "1.3.3",
         "1.3.4",
         "1.3.5",
-        "1.3.6"
+        "1.3.6",
+        "1.3.7"
       ],
       "stable": [
         "1.2.1",
@@ -2242,13 +2263,14 @@
         "1.3.3",
         "1.3.4",
         "1.3.5",
-        "1.3.6"
+        "1.3.6",
+        "1.3.7"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.2.1",
-        "maxVersion": "1.3.6"
+        "maxVersion": "1.3.7"
       },
       "innovation": {
         "minVersion": "2025.11.0",
@@ -2256,11 +2278,11 @@
       },
       "lts-v1.3": {
         "minVersion": "1.3.2",
-        "maxVersion": "1.3.6"
+        "maxVersion": "1.3.7"
       },
       "stable": {
         "minVersion": "1.2.1",
-        "maxVersion": "1.3.6"
+        "maxVersion": "1.3.7"
       }
     },
     "availableVersions": [
@@ -2274,6 +2296,7 @@
       "1.3.4",
       "1.3.5",
       "1.3.6",
+      "1.3.7",
       "2025.11.0",
       "2025.12.0",
       "2026.1.0",
@@ -2428,7 +2451,7 @@
         "0.4.3"
       ],
       "stable": [
-        "0.7.0"
+        "0.7.1"
       ]
     },
     "channelVersionRanges": {
@@ -2437,16 +2460,16 @@
         "maxVersion": "0.4.3"
       },
       "stable": {
-        "minVersion": "0.7.0",
-        "maxVersion": "0.7.0"
+        "minVersion": "0.7.1",
+        "maxVersion": "0.7.1"
       }
     },
     "availableVersions": [
       "0.4.3",
-      "0.7.0"
+      "0.7.1"
     ],
     "minVersion": "0.4.3",
-    "maxVersion": "0.7.0",
+    "maxVersion": "0.7.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -2599,33 +2622,33 @@
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.11.0"
       ],
       "unstable": [
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.11.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.9.2",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       },
       "unstable": {
         "minVersion": "2.9.2",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       }
     },
     "availableVersions": [
       "2.9.2",
       "2.10.0",
       "2.10.1",
-      "2.10.2"
+      "2.11.0"
     ],
     "minVersion": "2.9.2",
-    "maxVersion": "2.10.2",
+    "maxVersion": "2.11.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -2646,13 +2669,14 @@
         "1.45.0",
         "1.46.0",
         "1.47.0",
-        "1.47.1"
+        "1.47.1",
+        "1.48.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.42.0",
-        "maxVersion": "1.47.1"
+        "maxVersion": "1.48.0"
       }
     },
     "availableVersions": [
@@ -2664,10 +2688,11 @@
       "1.45.0",
       "1.46.0",
       "1.47.0",
-      "1.47.1"
+      "1.47.1",
+      "1.48.0"
     ],
     "minVersion": "1.42.0",
-    "maxVersion": "1.47.1",
+    "maxVersion": "1.48.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -3011,6 +3036,7 @@
       "1.21",
       "1.22",
       "1.23",
+      "1.24",
       "stable"
     ],
     "channelVersions": {
@@ -3031,6 +3057,9 @@
       "1.23": [
         "1.23.0-695"
       ],
+      "1.24": [
+        "1.24.0-1007"
+      ],
       "stable": [
         "1.21.4-3",
         "1.21.5-6",
@@ -3042,7 +3071,8 @@
         "1.22.2-32",
         "1.22.2-32-1",
         "1.22.2-32-2",
-        "1.23.0-695"
+        "1.23.0-695",
+        "1.24.0-1007"
       ]
     },
     "channelVersionRanges": {
@@ -3058,9 +3088,13 @@
         "minVersion": "1.23.0-695",
         "maxVersion": "1.23.0-695"
       },
+      "1.24": {
+        "minVersion": "1.24.0-1007",
+        "maxVersion": "1.24.0-1007"
+      },
       "stable": {
         "minVersion": "1.21.4-3",
-        "maxVersion": "1.23.0-695"
+        "maxVersion": "1.24.0-1007"
       }
     },
     "availableVersions": [
@@ -3074,10 +3108,11 @@
       "1.22.2-32",
       "1.22.2-32-1",
       "1.22.2-32-2",
-      "1.23.0-695"
+      "1.23.0-695",
+      "1.24.0-1007"
     ],
     "minVersion": "1.21.4-3",
-    "maxVersion": "1.23.0-695",
+    "maxVersion": "1.24.0-1007",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -3389,6 +3424,7 @@
     "defaultChannel": "stable",
     "channels": [
       "stable",
+      "stable-1.13.1",
       "stable-v1.12",
       "stable-v1.12.4",
       "stable-v1.12.5",
@@ -3399,7 +3435,14 @@
       "stable": [
         "1.12.4",
         "1.12.5",
-        "1.13.0"
+        "1.13.0",
+        "1.13.1"
+      ],
+      "stable-1.13.1": [
+        "1.12.4",
+        "1.12.5",
+        "1.13.0",
+        "1.13.1"
       ],
       "stable-v1.12": [
         "1.12.4",
@@ -3415,7 +3458,8 @@
       "stable-v1.13": [
         "1.12.4",
         "1.12.5",
-        "1.13.0"
+        "1.13.0",
+        "1.13.1"
       ],
       "stable-v1.13.0": [
         "1.12.4",
@@ -3426,7 +3470,11 @@
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.12.4",
-        "maxVersion": "1.13.0"
+        "maxVersion": "1.13.1"
+      },
+      "stable-1.13.1": {
+        "minVersion": "1.12.4",
+        "maxVersion": "1.13.1"
       },
       "stable-v1.12": {
         "minVersion": "1.12.4",
@@ -3442,7 +3490,7 @@
       },
       "stable-v1.13": {
         "minVersion": "1.12.4",
-        "maxVersion": "1.13.0"
+        "maxVersion": "1.13.1"
       },
       "stable-v1.13.0": {
         "minVersion": "1.12.4",
@@ -3452,10 +3500,11 @@
     "availableVersions": [
       "1.12.4",
       "1.12.5",
-      "1.13.0"
+      "1.13.0",
+      "1.13.1"
     ],
     "minVersion": "1.12.4",
-    "maxVersion": "1.13.0",
+    "maxVersion": "1.13.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -4001,13 +4050,15 @@
         "2.2.5",
         "2.2.6",
         "2.2.7",
-        "2.2.8"
+        "2.2.8",
+        "2.2.9",
+        "2.2.10"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.0.4",
-        "maxVersion": "2.2.8"
+        "maxVersion": "2.2.10"
       }
     },
     "availableVersions": [
@@ -4070,10 +4121,12 @@
       "2.2.5",
       "2.2.6",
       "2.2.7",
-      "2.2.8"
+      "2.2.8",
+      "2.2.9",
+      "2.2.10"
     ],
     "minVersion": "2.0.4",
-    "maxVersion": "2.2.8",
+    "maxVersion": "2.2.10",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -4563,7 +4616,7 @@
         "8.19.40-beta.1"
       ],
       "stable": [
-        "8.19.30"
+        "8.19.40"
       ]
     },
     "channelVersionRanges": {
@@ -4572,15 +4625,15 @@
         "maxVersion": "8.19.40-beta.1"
       },
       "stable": {
-        "minVersion": "8.19.30",
-        "maxVersion": "8.19.30"
+        "minVersion": "8.19.40",
+        "maxVersion": "8.19.40"
       }
     },
     "availableVersions": [
-      "8.19.30",
+      "8.19.40",
       "8.19.40-beta.1"
     ],
-    "minVersion": "8.19.30",
+    "minVersion": "8.19.40",
     "maxVersion": "8.19.40-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
@@ -4737,26 +4790,35 @@
   },
   {
     "name": "mediation-openstack-operator",
-    "defaultChannel": "alpha",
+    "defaultChannel": "stable",
     "channels": [
-      "alpha"
+      "alpha",
+      "stable"
     ],
     "channelVersions": {
       "alpha": [
-        "8.19.2"
+        "8.19.40-beta.1"
+      ],
+      "stable": [
+        "8.19.40"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
-        "minVersion": "8.19.2",
-        "maxVersion": "8.19.2"
+        "minVersion": "8.19.40-beta.1",
+        "maxVersion": "8.19.40-beta.1"
+      },
+      "stable": {
+        "minVersion": "8.19.40",
+        "maxVersion": "8.19.40"
       }
     },
     "availableVersions": [
-      "8.19.2"
+      "8.19.40",
+      "8.19.40-beta.1"
     ],
-    "minVersion": "8.19.2",
-    "maxVersion": "8.19.2",
+    "minVersion": "8.19.40",
+    "maxVersion": "8.19.40-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -5904,31 +5966,35 @@
     "channelVersions": {
       "stable": [
         "1.18.0",
-        "1.19.0"
+        "1.19.0",
+        "1.19.1"
       ],
       "stable-cw": [
         "1.18.0-cw",
-        "1.19.0-cw"
+        "1.19.0-cw",
+        "1.19.1-cw"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.18.0",
-        "maxVersion": "1.19.0"
+        "maxVersion": "1.19.1"
       },
       "stable-cw": {
         "minVersion": "1.18.0-cw",
-        "maxVersion": "1.19.0-cw"
+        "maxVersion": "1.19.1-cw"
       }
     },
     "availableVersions": [
       "1.18.0",
       "1.18.0-cw",
       "1.19.0",
-      "1.19.0-cw"
+      "1.19.0-cw",
+      "1.19.1",
+      "1.19.1-cw"
     ],
     "minVersion": "1.18.0",
-    "maxVersion": "1.19.0-cw",
+    "maxVersion": "1.19.1-cw",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -6164,7 +6230,7 @@
         "8.19.40-beta.1"
       ],
       "stable": [
-        "8.19.30"
+        "8.19.40"
       ]
     },
     "channelVersionRanges": {
@@ -6173,15 +6239,15 @@
         "maxVersion": "8.19.40-beta.1"
       },
       "stable": {
-        "minVersion": "8.19.30",
-        "maxVersion": "8.19.30"
+        "minVersion": "8.19.40",
+        "maxVersion": "8.19.40"
       }
     },
     "availableVersions": [
-      "8.19.30",
+      "8.19.40",
       "8.19.40-beta.1"
     ],
-    "minVersion": "8.19.30",
+    "minVersion": "8.19.40",
     "maxVersion": "8.19.40-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
@@ -6301,6 +6367,7 @@
       "7.22.2-32.1",
       "7.22.2-37.1",
       "7.22.2-38.0",
+      "7.22.2-39.0",
       "8.0.10",
       "8.0.10-21.0",
       "8.0.10-22.0",
@@ -6330,7 +6397,8 @@
         "7.22.2-31.1",
         "7.22.2-32.1",
         "7.22.2-37.1",
-        "7.22.2-38.0"
+        "7.22.2-38.0",
+        "7.22.2-39.0"
       ],
       "7.22.2-21.1": [
         "7.22.0-15.0",
@@ -6382,6 +6450,18 @@
         "7.22.2-32.1",
         "7.22.2-37.1",
         "7.22.2-38.0"
+      ],
+      "7.22.2-39.0": [
+        "7.22.0-15.0",
+        "7.22.0-16.0",
+        "7.22.0-17.0",
+        "7.22.2-21.1",
+        "7.22.2-22.0",
+        "7.22.2-31.1",
+        "7.22.2-32.1",
+        "7.22.2-37.1",
+        "7.22.2-38.0",
+        "7.22.2-39.0"
       ],
       "8.0.10": [
         "7.22.0-15.0",
@@ -6574,7 +6654,7 @@
       },
       "7.22.2": {
         "minVersion": "7.22.0-15.0",
-        "maxVersion": "7.22.2-38.0"
+        "maxVersion": "7.22.2-39.0"
       },
       "7.22.2-21.1": {
         "minVersion": "7.22.0-15.0",
@@ -6599,6 +6679,10 @@
       "7.22.2-38.0": {
         "minVersion": "7.22.0-15.0",
         "maxVersion": "7.22.2-38.0"
+      },
+      "7.22.2-39.0": {
+        "minVersion": "7.22.0-15.0",
+        "maxVersion": "7.22.2-39.0"
       },
       "8.0.10": {
         "minVersion": "7.22.0-15.0",
@@ -6663,6 +6747,7 @@
       "7.22.2-32.1",
       "7.22.2-37.1",
       "7.22.2-38.0",
+      "7.22.2-39.0",
       "8.0.2-2.9",
       "8.0.2-6.1",
       "8.0.6-8.0",
@@ -6855,7 +6940,10 @@
         "1.29.3",
         "1.29.4",
         "1.29.6",
-        "1.29.7"
+        "1.29.7",
+        "1.29.8",
+        "1.29.10",
+        "1.29.11"
       ],
       "stable-v1.26": [
         "1.26.8",
@@ -6910,13 +6998,16 @@
         "1.29.3",
         "1.29.4",
         "1.29.6",
-        "1.29.7"
+        "1.29.7",
+        "1.29.8",
+        "1.29.10",
+        "1.29.11"
       ]
     },
     "channelVersionRanges": {
       "stable-v1": {
         "minVersion": "1.26.8",
-        "maxVersion": "1.29.7"
+        "maxVersion": "1.29.11"
       },
       "stable-v1.26": {
         "minVersion": "1.26.8",
@@ -6932,7 +7023,7 @@
       },
       "stable-v1.29": {
         "minVersion": "1.29.3",
-        "maxVersion": "1.29.7"
+        "maxVersion": "1.29.11"
       }
     },
     "availableVersions": [
@@ -6982,10 +7073,13 @@
       "1.29.3",
       "1.29.4",
       "1.29.6",
-      "1.29.7"
+      "1.29.7",
+      "1.29.8",
+      "1.29.10",
+      "1.29.11"
     ],
     "minVersion": "1.26.8",
-    "maxVersion": "1.29.7",
+    "maxVersion": "1.29.11",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -8340,28 +8434,28 @@
     ],
     "channelVersions": {
       "beta": [
-        "42.102.0-beta.1"
+        "42.102.0-beta.2"
       ],
       "stable": [
-        "42.101.0"
+        "42.102.0"
       ]
     },
     "channelVersionRanges": {
       "beta": {
-        "minVersion": "42.102.0-beta.1",
-        "maxVersion": "42.102.0-beta.1"
+        "minVersion": "42.102.0-beta.2",
+        "maxVersion": "42.102.0-beta.2"
       },
       "stable": {
-        "minVersion": "42.101.0",
-        "maxVersion": "42.101.0"
+        "minVersion": "42.102.0",
+        "maxVersion": "42.102.0"
       }
     },
     "availableVersions": [
-      "42.101.0",
-      "42.102.0-beta.1"
+      "42.102.0",
+      "42.102.0-beta.2"
     ],
-    "minVersion": "42.101.0",
-    "maxVersion": "42.102.0-beta.1",
+    "minVersion": "42.102.0",
+    "maxVersion": "42.102.0-beta.2",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -8464,13 +8558,14 @@
   },
   {
     "name": "tenant-operator",
-    "defaultChannel": "release-1.6",
+    "defaultChannel": "release-1.7",
     "channels": [
       "release-1.2",
       "release-1.3",
       "release-1.4",
       "release-1.5",
-      "release-1.6"
+      "release-1.6",
+      "release-1.7"
     ],
     "channelVersions": {
       "release-1.2": [
@@ -8487,6 +8582,9 @@
       ],
       "release-1.6": [
         "1.6.2"
+      ],
+      "release-1.7": [
+        "1.7.0"
       ]
     },
     "channelVersionRanges": {
@@ -8509,6 +8607,10 @@
       "release-1.6": {
         "minVersion": "1.6.2",
         "maxVersion": "1.6.2"
+      },
+      "release-1.7": {
+        "minVersion": "1.7.0",
+        "maxVersion": "1.7.0"
       }
     },
     "availableVersions": [
@@ -8516,10 +8618,11 @@
       "1.3.0",
       "1.4.2",
       "1.5.2",
-      "1.6.2"
+      "1.6.2",
+      "1.7.0"
     ],
     "minVersion": "1.2.1",
-    "maxVersion": "1.6.2",
+    "maxVersion": "1.7.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -8872,7 +8975,7 @@
   },
   {
     "name": "uma-team-operator",
-    "defaultChannel": "stable",
+    "defaultChannel": "alpha",
     "channels": [
       "2025.10",
       "2025.11",
@@ -8896,7 +8999,7 @@
         "2026.3.1-2"
       ],
       "alpha": [
-        "2025.11.4-3"
+        "2026.4.0-15"
       ],
       "beta": [
         "2026.2.0-10"
@@ -8923,8 +9026,8 @@
         "maxVersion": "2026.3.1-2"
       },
       "alpha": {
-        "minVersion": "2025.11.4-3",
-        "maxVersion": "2025.11.4-3"
+        "minVersion": "2026.4.0-15",
+        "maxVersion": "2026.4.0-15"
       },
       "beta": {
         "minVersion": "2026.2.0-10",
@@ -8938,13 +9041,13 @@
     "availableVersions": [
       "2025.10.1-12",
       "2025.11.1-38",
-      "2025.11.4-3",
       "2026.1.1-35",
       "2026.2.0-10",
-      "2026.3.1-2"
+      "2026.3.1-2",
+      "2026.4.0-15"
     ],
     "minVersion": "2025.10.1-12",
-    "maxVersion": "2026.3.1-2",
+    "maxVersion": "2026.4.0-15",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -9099,21 +9202,23 @@
     "channelVersions": {
       "stable": [
         "4.5.1961",
-        "4.6.1984"
+        "4.6.1984",
+        "4.6.2014"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.5.1961",
-        "maxVersion": "4.6.1984"
+        "maxVersion": "4.6.2014"
       }
     },
     "availableVersions": [
       "4.5.1961",
-      "4.6.1984"
+      "4.6.1984",
+      "4.6.2014"
     ],
     "minVersion": "4.5.1961",
-    "maxVersion": "4.6.1984",
+    "maxVersion": "4.6.2014",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"

--- a/catalog-data/certified-operator-index/v4.20/dependencies.json
+++ b/catalog-data/certified-operator-index/v4.20/dependencies.json
@@ -40,7 +40,7 @@
     },
     {
       "packageName": "mto-dependencies-operator",
-      "versionRange": ">=0.0.5"
+      "versionRange": ">=0.0.7"
     },
     {
       "packageName": "template-operator",

--- a/catalog-data/certified-operator-index/v4.20/operators.json
+++ b/catalog-data/certified-operator-index/v4.20/operators.json
@@ -1479,17 +1479,21 @@
   },
   {
     "name": "cp-fko",
-    "defaultChannel": "alpha",
+    "defaultChannel": "stable-v1.14",
     "channels": [
       "alpha",
-      "stable"
+      "stable",
+      "stable-v1.14"
     ],
     "channelVersions": {
       "alpha": [
         "0.0.1"
       ],
       "stable": [
-        "1.13.0-cp2"
+        "1.14.0-cp1"
+      ],
+      "stable-v1.14": [
+        "1.14.0-cp1"
       ]
     },
     "channelVersionRanges": {
@@ -1498,16 +1502,20 @@
         "maxVersion": "0.0.1"
       },
       "stable": {
-        "minVersion": "1.13.0-cp2",
-        "maxVersion": "1.13.0-cp2"
+        "minVersion": "1.14.0-cp1",
+        "maxVersion": "1.14.0-cp1"
+      },
+      "stable-v1.14": {
+        "minVersion": "1.14.0-cp1",
+        "maxVersion": "1.14.0-cp1"
       }
     },
     "availableVersions": [
       "0.0.1",
-      "1.13.0-cp2"
+      "1.14.0-cp1"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.13.0-cp2",
+    "maxVersion": "1.14.0-cp1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -1824,7 +1832,8 @@
       "beta",
       "stable",
       "stable-v24.1",
-      "stable-v24.3"
+      "stable-v24.3",
+      "stable-v25.1"
     ],
     "channelVersions": {
       "beta": [
@@ -1841,6 +1850,9 @@
       "stable-v24.3": [
         "24.3.5",
         "24.3.6"
+      ],
+      "stable-v25.1": [
+        "25.1.10-1"
       ]
     },
     "channelVersionRanges": {
@@ -1859,6 +1871,10 @@
       "stable-v24.3": {
         "minVersion": "24.3.5",
         "maxVersion": "24.3.6"
+      },
+      "stable-v25.1": {
+        "minVersion": "25.1.10-1",
+        "maxVersion": "25.1.10-1"
       }
     },
     "availableVersions": [
@@ -1867,10 +1883,11 @@
       "24.1.17",
       "24.3.5",
       "24.3.6",
-      "25.1.0-beta.6"
+      "25.1.0-beta.6",
+      "25.1.10-1"
     ],
     "minVersion": "24.1.10",
-    "maxVersion": "25.1.0-beta.6",
+    "maxVersion": "25.1.10-1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -1952,13 +1969,14 @@
         "1.7.2",
         "1.7.3",
         "1.8.0",
-        "1.8.1"
+        "1.8.1",
+        "1.9.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.4.0",
-        "maxVersion": "1.8.1"
+        "maxVersion": "1.9.0"
       }
     },
     "availableVersions": [
@@ -1975,10 +1993,11 @@
       "1.7.2",
       "1.7.3",
       "1.8.0",
-      "1.8.1"
+      "1.8.1",
+      "1.9.0"
     ],
     "minVersion": "1.4.0",
-    "maxVersion": "1.8.1",
+    "maxVersion": "1.9.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -2023,7 +2042,8 @@
         "1.3.3",
         "1.3.4",
         "1.3.5",
-        "1.3.6"
+        "1.3.6",
+        "1.3.7"
       ],
       "innovation": [
         "2026.1.0",
@@ -2034,19 +2054,21 @@
         "1.3.3",
         "1.3.4",
         "1.3.5",
-        "1.3.6"
+        "1.3.6",
+        "1.3.7"
       ],
       "stable": [
         "1.3.3",
         "1.3.4",
         "1.3.5",
-        "1.3.6"
+        "1.3.6",
+        "1.3.7"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.3.3",
-        "maxVersion": "1.3.6"
+        "maxVersion": "1.3.7"
       },
       "innovation": {
         "minVersion": "2026.1.0",
@@ -2054,11 +2076,11 @@
       },
       "lts-v1.3": {
         "minVersion": "1.3.3",
-        "maxVersion": "1.3.6"
+        "maxVersion": "1.3.7"
       },
       "stable": {
         "minVersion": "1.3.3",
-        "maxVersion": "1.3.6"
+        "maxVersion": "1.3.7"
       }
     },
     "availableVersions": [
@@ -2066,6 +2088,7 @@
       "1.3.4",
       "1.3.5",
       "1.3.6",
+      "1.3.7",
       "2026.1.0",
       "2026.2.0",
       "2026.3.0"
@@ -2192,7 +2215,7 @@
         "0.4.3"
       ],
       "stable": [
-        "0.7.0"
+        "0.7.1"
       ]
     },
     "channelVersionRanges": {
@@ -2201,16 +2224,16 @@
         "maxVersion": "0.4.3"
       },
       "stable": {
-        "minVersion": "0.7.0",
-        "maxVersion": "0.7.0"
+        "minVersion": "0.7.1",
+        "maxVersion": "0.7.1"
       }
     },
     "availableVersions": [
       "0.4.3",
-      "0.7.0"
+      "0.7.1"
     ],
     "minVersion": "0.4.3",
-    "maxVersion": "0.7.0",
+    "maxVersion": "0.7.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -2335,33 +2358,33 @@
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.11.0"
       ],
       "unstable": [
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.11.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.9.2",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       },
       "unstable": {
         "minVersion": "2.9.2",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       }
     },
     "availableVersions": [
       "2.9.2",
       "2.10.0",
       "2.10.1",
-      "2.10.2"
+      "2.11.0"
     ],
     "minVersion": "2.9.2",
-    "maxVersion": "2.10.2",
+    "maxVersion": "2.11.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -2381,13 +2404,14 @@
         "1.45.0",
         "1.46.0",
         "1.47.0",
-        "1.47.1"
+        "1.47.1",
+        "1.48.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.43.0",
-        "maxVersion": "1.47.1"
+        "maxVersion": "1.48.0"
       }
     },
     "availableVersions": [
@@ -2398,10 +2422,11 @@
       "1.45.0",
       "1.46.0",
       "1.47.0",
-      "1.47.1"
+      "1.47.1",
+      "1.48.0"
     ],
     "minVersion": "1.43.0",
-    "maxVersion": "1.47.1",
+    "maxVersion": "1.48.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -2744,6 +2769,7 @@
     "channels": [
       "1.22",
       "1.23",
+      "1.24",
       "stable"
     ],
     "channelVersions": {
@@ -2757,13 +2783,17 @@
       "1.23": [
         "1.23.0-695"
       ],
+      "1.24": [
+        "1.24.0-1007"
+      ],
       "stable": [
         "1.22.1-6-2",
         "1.22.1-6-3",
         "1.22.2-32",
         "1.22.2-32-1",
         "1.22.2-32-2",
-        "1.23.0-695"
+        "1.23.0-695",
+        "1.24.0-1007"
       ]
     },
     "channelVersionRanges": {
@@ -2775,9 +2805,13 @@
         "minVersion": "1.23.0-695",
         "maxVersion": "1.23.0-695"
       },
+      "1.24": {
+        "minVersion": "1.24.0-1007",
+        "maxVersion": "1.24.0-1007"
+      },
       "stable": {
         "minVersion": "1.22.1-6-2",
-        "maxVersion": "1.23.0-695"
+        "maxVersion": "1.24.0-1007"
       }
     },
     "availableVersions": [
@@ -2786,10 +2820,11 @@
       "1.22.2-32",
       "1.22.2-32-1",
       "1.22.2-32-2",
-      "1.23.0-695"
+      "1.23.0-695",
+      "1.24.0-1007"
     ],
     "minVersion": "1.22.1-6-2",
-    "maxVersion": "1.23.0-695",
+    "maxVersion": "1.24.0-1007",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -3101,15 +3136,22 @@
     "defaultChannel": "stable",
     "channels": [
       "stable",
+      "stable-1.13.1",
       "stable-v1.13",
       "stable-v1.13.0"
     ],
     "channelVersions": {
       "stable": [
-        "1.13.0"
+        "1.13.0",
+        "1.13.1"
+      ],
+      "stable-1.13.1": [
+        "1.13.0",
+        "1.13.1"
       ],
       "stable-v1.13": [
-        "1.13.0"
+        "1.13.0",
+        "1.13.1"
       ],
       "stable-v1.13.0": [
         "1.13.0"
@@ -3118,11 +3160,15 @@
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.13.0",
-        "maxVersion": "1.13.0"
+        "maxVersion": "1.13.1"
+      },
+      "stable-1.13.1": {
+        "minVersion": "1.13.0",
+        "maxVersion": "1.13.1"
       },
       "stable-v1.13": {
         "minVersion": "1.13.0",
-        "maxVersion": "1.13.0"
+        "maxVersion": "1.13.1"
       },
       "stable-v1.13.0": {
         "minVersion": "1.13.0",
@@ -3130,10 +3176,11 @@
       }
     },
     "availableVersions": [
-      "1.13.0"
+      "1.13.0",
+      "1.13.1"
     ],
     "minVersion": "1.13.0",
-    "maxVersion": "1.13.0",
+    "maxVersion": "1.13.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -3653,13 +3700,15 @@
         "2.2.5",
         "2.2.6",
         "2.2.7",
-        "2.2.8"
+        "2.2.8",
+        "2.2.9",
+        "2.2.10"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.0.4",
-        "maxVersion": "2.2.8"
+        "maxVersion": "2.2.10"
       }
     },
     "availableVersions": [
@@ -3722,10 +3771,12 @@
       "2.2.5",
       "2.2.6",
       "2.2.7",
-      "2.2.8"
+      "2.2.8",
+      "2.2.9",
+      "2.2.10"
     ],
     "minVersion": "2.0.4",
-    "maxVersion": "2.2.8",
+    "maxVersion": "2.2.10",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -4163,7 +4214,7 @@
         "8.19.40-beta.1"
       ],
       "stable": [
-        "8.19.30"
+        "8.19.40"
       ]
     },
     "channelVersionRanges": {
@@ -4172,15 +4223,15 @@
         "maxVersion": "8.19.40-beta.1"
       },
       "stable": {
-        "minVersion": "8.19.30",
-        "maxVersion": "8.19.30"
+        "minVersion": "8.19.40",
+        "maxVersion": "8.19.40"
       }
     },
     "availableVersions": [
-      "8.19.30",
+      "8.19.40",
       "8.19.40-beta.1"
     ],
-    "minVersion": "8.19.30",
+    "minVersion": "8.19.40",
     "maxVersion": "8.19.40-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
@@ -4312,26 +4363,35 @@
   },
   {
     "name": "mediation-openstack-operator",
-    "defaultChannel": "alpha",
+    "defaultChannel": "stable",
     "channels": [
-      "alpha"
+      "alpha",
+      "stable"
     ],
     "channelVersions": {
       "alpha": [
-        "8.19.2"
+        "8.19.40-beta.1"
+      ],
+      "stable": [
+        "8.19.40"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
-        "minVersion": "8.19.2",
-        "maxVersion": "8.19.2"
+        "minVersion": "8.19.40-beta.1",
+        "maxVersion": "8.19.40-beta.1"
+      },
+      "stable": {
+        "minVersion": "8.19.40",
+        "maxVersion": "8.19.40"
       }
     },
     "availableVersions": [
-      "8.19.2"
+      "8.19.40",
+      "8.19.40-beta.1"
     ],
-    "minVersion": "8.19.2",
-    "maxVersion": "8.19.2",
+    "minVersion": "8.19.40",
+    "maxVersion": "8.19.40-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -5468,28 +5528,32 @@
     ],
     "channelVersions": {
       "stable": [
-        "1.19.0"
+        "1.19.0",
+        "1.19.1"
       ],
       "stable-cw": [
-        "1.19.0-cw"
+        "1.19.0-cw",
+        "1.19.1-cw"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.19.0",
-        "maxVersion": "1.19.0"
+        "maxVersion": "1.19.1"
       },
       "stable-cw": {
         "minVersion": "1.19.0-cw",
-        "maxVersion": "1.19.0-cw"
+        "maxVersion": "1.19.1-cw"
       }
     },
     "availableVersions": [
       "1.19.0",
-      "1.19.0-cw"
+      "1.19.0-cw",
+      "1.19.1",
+      "1.19.1-cw"
     ],
     "minVersion": "1.19.0",
-    "maxVersion": "1.19.0-cw",
+    "maxVersion": "1.19.1-cw",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -5725,7 +5789,7 @@
         "8.19.40-beta.1"
       ],
       "stable": [
-        "8.19.30"
+        "8.19.40"
       ]
     },
     "channelVersionRanges": {
@@ -5734,15 +5798,15 @@
         "maxVersion": "8.19.40-beta.1"
       },
       "stable": {
-        "minVersion": "8.19.30",
-        "maxVersion": "8.19.30"
+        "minVersion": "8.19.40",
+        "maxVersion": "8.19.40"
       }
     },
     "availableVersions": [
-      "8.19.30",
+      "8.19.40",
       "8.19.40-beta.1"
     ],
-    "minVersion": "8.19.30",
+    "minVersion": "8.19.40",
     "maxVersion": "8.19.40-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
@@ -6200,7 +6264,10 @@
         "1.29.3",
         "1.29.4",
         "1.29.6",
-        "1.29.7"
+        "1.29.7",
+        "1.29.8",
+        "1.29.10",
+        "1.29.11"
       ],
       "stable-v1.26": [
         "1.26.8",
@@ -6255,13 +6322,16 @@
         "1.29.3",
         "1.29.4",
         "1.29.6",
-        "1.29.7"
+        "1.29.7",
+        "1.29.8",
+        "1.29.10",
+        "1.29.11"
       ]
     },
     "channelVersionRanges": {
       "stable-v1": {
         "minVersion": "1.26.8",
-        "maxVersion": "1.29.7"
+        "maxVersion": "1.29.11"
       },
       "stable-v1.26": {
         "minVersion": "1.26.8",
@@ -6277,7 +6347,7 @@
       },
       "stable-v1.29": {
         "minVersion": "1.29.3",
-        "maxVersion": "1.29.7"
+        "maxVersion": "1.29.11"
       }
     },
     "availableVersions": [
@@ -6327,10 +6397,13 @@
       "1.29.3",
       "1.29.4",
       "1.29.6",
-      "1.29.7"
+      "1.29.7",
+      "1.29.8",
+      "1.29.10",
+      "1.29.11"
     ],
     "minVersion": "1.26.8",
-    "maxVersion": "1.29.7",
+    "maxVersion": "1.29.11",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -7352,28 +7425,28 @@
     ],
     "channelVersions": {
       "beta": [
-        "42.102.0-beta.1"
+        "42.102.0-beta.2"
       ],
       "stable": [
-        "42.101.0"
+        "42.102.0"
       ]
     },
     "channelVersionRanges": {
       "beta": {
-        "minVersion": "42.102.0-beta.1",
-        "maxVersion": "42.102.0-beta.1"
+        "minVersion": "42.102.0-beta.2",
+        "maxVersion": "42.102.0-beta.2"
       },
       "stable": {
-        "minVersion": "42.101.0",
-        "maxVersion": "42.101.0"
+        "minVersion": "42.102.0",
+        "maxVersion": "42.102.0"
       }
     },
     "availableVersions": [
-      "42.101.0",
-      "42.102.0-beta.1"
+      "42.102.0",
+      "42.102.0-beta.2"
     ],
-    "minVersion": "42.101.0",
-    "maxVersion": "42.102.0-beta.1",
+    "minVersion": "42.102.0",
+    "maxVersion": "42.102.0-beta.2",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -7476,13 +7549,14 @@
   },
   {
     "name": "tenant-operator",
-    "defaultChannel": "release-1.6",
+    "defaultChannel": "release-1.7",
     "channels": [
       "release-1.2",
       "release-1.3",
       "release-1.4",
       "release-1.5",
-      "release-1.6"
+      "release-1.6",
+      "release-1.7"
     ],
     "channelVersions": {
       "release-1.2": [
@@ -7499,6 +7573,9 @@
       ],
       "release-1.6": [
         "1.6.2"
+      ],
+      "release-1.7": [
+        "1.7.0"
       ]
     },
     "channelVersionRanges": {
@@ -7521,6 +7598,10 @@
       "release-1.6": {
         "minVersion": "1.6.2",
         "maxVersion": "1.6.2"
+      },
+      "release-1.7": {
+        "minVersion": "1.7.0",
+        "maxVersion": "1.7.0"
       }
     },
     "availableVersions": [
@@ -7528,10 +7609,11 @@
       "1.3.0",
       "1.4.2",
       "1.5.2",
-      "1.6.2"
+      "1.6.2",
+      "1.7.0"
     ],
     "minVersion": "1.2.1",
-    "maxVersion": "1.6.2",
+    "maxVersion": "1.7.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -7830,14 +7912,18 @@
   },
   {
     "name": "uma-team-operator",
-    "defaultChannel": "stable",
+    "defaultChannel": "alpha",
     "channels": [
       "2026.3",
+      "alpha",
       "stable"
     ],
     "channelVersions": {
       "2026.3": [
         "2026.3.1-2"
+      ],
+      "alpha": [
+        "2026.4.0-15"
       ],
       "stable": [
         "2026.3.1-2"
@@ -7848,16 +7934,21 @@
         "minVersion": "2026.3.1-2",
         "maxVersion": "2026.3.1-2"
       },
+      "alpha": {
+        "minVersion": "2026.4.0-15",
+        "maxVersion": "2026.4.0-15"
+      },
       "stable": {
         "minVersion": "2026.3.1-2",
         "maxVersion": "2026.3.1-2"
       }
     },
     "availableVersions": [
-      "2026.3.1-2"
+      "2026.3.1-2",
+      "2026.4.0-15"
     ],
     "minVersion": "2026.3.1-2",
-    "maxVersion": "2026.3.1-2",
+    "maxVersion": "2026.4.0-15",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -8012,21 +8103,23 @@
     "channelVersions": {
       "stable": [
         "4.5.1961",
-        "4.6.1984"
+        "4.6.1984",
+        "4.6.2014"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.5.1961",
-        "maxVersion": "4.6.1984"
+        "maxVersion": "4.6.2014"
       }
     },
     "availableVersions": [
       "4.5.1961",
-      "4.6.1984"
+      "4.6.1984",
+      "4.6.2014"
     ],
     "minVersion": "4.5.1961",
-    "maxVersion": "4.6.1984",
+    "maxVersion": "4.6.2014",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"

--- a/catalog-data/certified-operator-index/v4.21/catalog-info.json
+++ b/catalog-data/certified-operator-index/v4.21/catalog-info.json
@@ -2,5 +2,5 @@
   "catalog_type": "certified-operator-index",
   "ocp_version": "v4.21",
   "catalog_url": "registry.redhat.io/redhat/certified-operator-index:v4.21",
-  "operator_count": 137
+  "operator_count": 139
 }

--- a/catalog-data/certified-operator-index/v4.21/dependencies.json
+++ b/catalog-data/certified-operator-index/v4.21/dependencies.json
@@ -24,7 +24,7 @@
     },
     {
       "packageName": "mto-dependencies-operator",
-      "versionRange": ">=0.0.5"
+      "versionRange": ">=0.0.7"
     },
     {
       "packageName": "template-operator",

--- a/catalog-data/certified-operator-index/v4.21/operators.json
+++ b/catalog-data/certified-operator-index/v4.21/operators.json
@@ -1294,17 +1294,21 @@
   },
   {
     "name": "cp-fko",
-    "defaultChannel": "alpha",
+    "defaultChannel": "stable-v1.14",
     "channels": [
       "alpha",
-      "stable"
+      "stable",
+      "stable-v1.14"
     ],
     "channelVersions": {
       "alpha": [
         "0.0.1"
       ],
       "stable": [
-        "1.13.0-cp2"
+        "1.14.0-cp1"
+      ],
+      "stable-v1.14": [
+        "1.14.0-cp1"
       ]
     },
     "channelVersionRanges": {
@@ -1313,16 +1317,20 @@
         "maxVersion": "0.0.1"
       },
       "stable": {
-        "minVersion": "1.13.0-cp2",
-        "maxVersion": "1.13.0-cp2"
+        "minVersion": "1.14.0-cp1",
+        "maxVersion": "1.14.0-cp1"
+      },
+      "stable-v1.14": {
+        "minVersion": "1.14.0-cp1",
+        "maxVersion": "1.14.0-cp1"
       }
     },
     "availableVersions": [
       "0.0.1",
-      "1.13.0-cp2"
+      "1.14.0-cp1"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.13.0-cp2",
+    "maxVersion": "1.14.0-cp1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.21"
@@ -1591,7 +1599,8 @@
       "beta",
       "stable",
       "stable-v24.1",
-      "stable-v24.3"
+      "stable-v24.3",
+      "stable-v25.1"
     ],
     "channelVersions": {
       "beta": [
@@ -1608,6 +1617,9 @@
       "stable-v24.3": [
         "24.3.5",
         "24.3.6"
+      ],
+      "stable-v25.1": [
+        "25.1.10-1"
       ]
     },
     "channelVersionRanges": {
@@ -1626,6 +1638,10 @@
       "stable-v24.3": {
         "minVersion": "24.3.5",
         "maxVersion": "24.3.6"
+      },
+      "stable-v25.1": {
+        "minVersion": "25.1.10-1",
+        "maxVersion": "25.1.10-1"
       }
     },
     "availableVersions": [
@@ -1634,10 +1650,11 @@
       "24.1.17",
       "24.3.5",
       "24.3.6",
-      "25.1.0-beta.6"
+      "25.1.0-beta.6",
+      "25.1.10-1"
     ],
     "minVersion": "24.1.10",
-    "maxVersion": "25.1.0-beta.6",
+    "maxVersion": "25.1.10-1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.21"
@@ -1719,13 +1736,14 @@
         "1.7.2",
         "1.7.3",
         "1.8.0",
-        "1.8.1"
+        "1.8.1",
+        "1.9.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.4.0",
-        "maxVersion": "1.8.1"
+        "maxVersion": "1.9.0"
       }
     },
     "availableVersions": [
@@ -1742,10 +1760,11 @@
       "1.7.2",
       "1.7.3",
       "1.8.0",
-      "1.8.1"
+      "1.8.1",
+      "1.9.0"
     ],
     "minVersion": "1.4.0",
-    "maxVersion": "1.8.1",
+    "maxVersion": "1.9.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.21"
@@ -1918,7 +1937,7 @@
         "0.4.3"
       ],
       "stable": [
-        "0.7.0"
+        "0.7.1"
       ]
     },
     "channelVersionRanges": {
@@ -1927,16 +1946,16 @@
         "maxVersion": "0.4.3"
       },
       "stable": {
-        "minVersion": "0.7.0",
-        "maxVersion": "0.7.0"
+        "minVersion": "0.7.1",
+        "maxVersion": "0.7.1"
       }
     },
     "availableVersions": [
       "0.4.3",
-      "0.7.0"
+      "0.7.1"
     ],
     "minVersion": "0.4.3",
-    "maxVersion": "0.7.0",
+    "maxVersion": "0.7.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.21"
@@ -2060,31 +2079,31 @@
       "stable": [
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.11.0"
       ],
       "unstable": [
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.11.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.10.0",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       },
       "unstable": {
         "minVersion": "2.10.0",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       }
     },
     "availableVersions": [
       "2.10.0",
       "2.10.1",
-      "2.10.2"
+      "2.11.0"
     ],
     "minVersion": "2.10.0",
-    "maxVersion": "2.10.2",
+    "maxVersion": "2.11.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.21"
@@ -2426,14 +2445,19 @@
     "defaultChannel": "stable",
     "channels": [
       "1.23",
+      "1.24",
       "stable"
     ],
     "channelVersions": {
       "1.23": [
         "1.23.0-695"
       ],
+      "1.24": [
+        "1.24.0-1007"
+      ],
       "stable": [
-        "1.23.0-695"
+        "1.23.0-695",
+        "1.24.0-1007"
       ]
     },
     "channelVersionRanges": {
@@ -2441,16 +2465,21 @@
         "minVersion": "1.23.0-695",
         "maxVersion": "1.23.0-695"
       },
+      "1.24": {
+        "minVersion": "1.24.0-1007",
+        "maxVersion": "1.24.0-1007"
+      },
       "stable": {
         "minVersion": "1.23.0-695",
-        "maxVersion": "1.23.0-695"
+        "maxVersion": "1.24.0-1007"
       }
     },
     "availableVersions": [
-      "1.23.0-695"
+      "1.23.0-695",
+      "1.24.0-1007"
     ],
     "minVersion": "1.23.0-695",
-    "maxVersion": "1.23.0-695",
+    "maxVersion": "1.24.0-1007",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.21"
@@ -2643,6 +2672,48 @@
     ],
     "minVersion": "1.18.0",
     "maxVersion": "1.18.0",
+    "catalog": "certified-operator-index",
+    "ocpVersion": "v4.21",
+    "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.21"
+  },
+  {
+    "name": "ibm-block-csi-operator",
+    "defaultChannel": "stable",
+    "channels": [
+      "stable",
+      "stable-1.13.1",
+      "stable-v1.13"
+    ],
+    "channelVersions": {
+      "stable": [
+        "1.13.1"
+      ],
+      "stable-1.13.1": [
+        "1.13.1"
+      ],
+      "stable-v1.13": [
+        "1.13.1"
+      ]
+    },
+    "channelVersionRanges": {
+      "stable": {
+        "minVersion": "1.13.1",
+        "maxVersion": "1.13.1"
+      },
+      "stable-1.13.1": {
+        "minVersion": "1.13.1",
+        "maxVersion": "1.13.1"
+      },
+      "stable-v1.13": {
+        "minVersion": "1.13.1",
+        "maxVersion": "1.13.1"
+      }
+    },
+    "availableVersions": [
+      "1.13.1"
+    ],
+    "minVersion": "1.13.1",
+    "maxVersion": "1.13.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.21"
@@ -3159,13 +3230,15 @@
         "2.2.5",
         "2.2.6",
         "2.2.7",
-        "2.2.8"
+        "2.2.8",
+        "2.2.9",
+        "2.2.10"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.0.4",
-        "maxVersion": "2.2.8"
+        "maxVersion": "2.2.10"
       }
     },
     "availableVersions": [
@@ -3228,10 +3301,12 @@
       "2.2.5",
       "2.2.6",
       "2.2.7",
-      "2.2.8"
+      "2.2.8",
+      "2.2.9",
+      "2.2.10"
     ],
     "minVersion": "2.0.4",
-    "maxVersion": "2.2.8",
+    "maxVersion": "2.2.10",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.21"
@@ -3522,7 +3597,7 @@
         "8.19.40-beta.1"
       ],
       "stable": [
-        "8.19.30"
+        "8.19.40"
       ]
     },
     "channelVersionRanges": {
@@ -3531,15 +3606,15 @@
         "maxVersion": "8.19.40-beta.1"
       },
       "stable": {
-        "minVersion": "8.19.30",
-        "maxVersion": "8.19.30"
+        "minVersion": "8.19.40",
+        "maxVersion": "8.19.40"
       }
     },
     "availableVersions": [
-      "8.19.30",
+      "8.19.40",
       "8.19.40-beta.1"
     ],
-    "minVersion": "8.19.30",
+    "minVersion": "8.19.40",
     "maxVersion": "8.19.40-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.21",
@@ -3671,26 +3746,35 @@
   },
   {
     "name": "mediation-openstack-operator",
-    "defaultChannel": "alpha",
+    "defaultChannel": "stable",
     "channels": [
-      "alpha"
+      "alpha",
+      "stable"
     ],
     "channelVersions": {
       "alpha": [
-        "8.19.2"
+        "8.19.40-beta.1"
+      ],
+      "stable": [
+        "8.19.40"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
-        "minVersion": "8.19.2",
-        "maxVersion": "8.19.2"
+        "minVersion": "8.19.40-beta.1",
+        "maxVersion": "8.19.40-beta.1"
+      },
+      "stable": {
+        "minVersion": "8.19.40",
+        "maxVersion": "8.19.40"
       }
     },
     "availableVersions": [
-      "8.19.2"
+      "8.19.40",
+      "8.19.40-beta.1"
     ],
-    "minVersion": "8.19.2",
-    "maxVersion": "8.19.2",
+    "minVersion": "8.19.40",
+    "maxVersion": "8.19.40-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.21"
@@ -4701,6 +4785,41 @@
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.21"
   },
   {
+    "name": "percona-xtradb-cluster-operator-certified",
+    "defaultChannel": "stable",
+    "channels": [
+      "stable",
+      "stable-cw"
+    ],
+    "channelVersions": {
+      "stable": [
+        "1.19.1"
+      ],
+      "stable-cw": [
+        "1.19.1-cw"
+      ]
+    },
+    "channelVersionRanges": {
+      "stable": {
+        "minVersion": "1.19.1",
+        "maxVersion": "1.19.1"
+      },
+      "stable-cw": {
+        "minVersion": "1.19.1-cw",
+        "maxVersion": "1.19.1-cw"
+      }
+    },
+    "availableVersions": [
+      "1.19.1",
+      "1.19.1-cw"
+    ],
+    "minVersion": "1.19.1",
+    "maxVersion": "1.19.1-cw",
+    "catalog": "certified-operator-index",
+    "ocpVersion": "v4.21",
+    "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.21"
+  },
+  {
     "name": "portworx-certified",
     "defaultChannel": "stable",
     "channels": [
@@ -4875,7 +4994,7 @@
         "8.19.40-beta.1"
       ],
       "stable": [
-        "8.19.30"
+        "8.19.40"
       ]
     },
     "channelVersionRanges": {
@@ -4884,15 +5003,15 @@
         "maxVersion": "8.19.40-beta.1"
       },
       "stable": {
-        "minVersion": "8.19.30",
-        "maxVersion": "8.19.30"
+        "minVersion": "8.19.40",
+        "maxVersion": "8.19.40"
       }
     },
     "availableVersions": [
-      "8.19.30",
+      "8.19.40",
       "8.19.40-beta.1"
     ],
-    "minVersion": "8.19.30",
+    "minVersion": "8.19.40",
     "maxVersion": "8.19.40-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.21",
@@ -5984,28 +6103,28 @@
     ],
     "channelVersions": {
       "beta": [
-        "42.102.0-beta.1"
+        "42.102.0-beta.2"
       ],
       "stable": [
-        "42.101.0"
+        "42.102.0"
       ]
     },
     "channelVersionRanges": {
       "beta": {
-        "minVersion": "42.102.0-beta.1",
-        "maxVersion": "42.102.0-beta.1"
+        "minVersion": "42.102.0-beta.2",
+        "maxVersion": "42.102.0-beta.2"
       },
       "stable": {
-        "minVersion": "42.101.0",
-        "maxVersion": "42.101.0"
+        "minVersion": "42.102.0",
+        "maxVersion": "42.102.0"
       }
     },
     "availableVersions": [
-      "42.101.0",
-      "42.102.0-beta.1"
+      "42.102.0",
+      "42.102.0-beta.2"
     ],
-    "minVersion": "42.101.0",
-    "maxVersion": "42.102.0-beta.1",
+    "minVersion": "42.102.0",
+    "maxVersion": "42.102.0-beta.2",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.21"
@@ -6108,13 +6227,14 @@
   },
   {
     "name": "tenant-operator",
-    "defaultChannel": "release-1.6",
+    "defaultChannel": "release-1.7",
     "channels": [
       "release-1.2",
       "release-1.3",
       "release-1.4",
       "release-1.5",
-      "release-1.6"
+      "release-1.6",
+      "release-1.7"
     ],
     "channelVersions": {
       "release-1.2": [
@@ -6131,6 +6251,9 @@
       ],
       "release-1.6": [
         "1.6.2"
+      ],
+      "release-1.7": [
+        "1.7.0"
       ]
     },
     "channelVersionRanges": {
@@ -6153,6 +6276,10 @@
       "release-1.6": {
         "minVersion": "1.6.2",
         "maxVersion": "1.6.2"
+      },
+      "release-1.7": {
+        "minVersion": "1.7.0",
+        "maxVersion": "1.7.0"
       }
     },
     "availableVersions": [
@@ -6160,10 +6287,11 @@
       "1.3.0",
       "1.4.2",
       "1.5.2",
-      "1.6.2"
+      "1.6.2",
+      "1.7.0"
     ],
     "minVersion": "1.2.1",
-    "maxVersion": "1.6.2",
+    "maxVersion": "1.7.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.21"

--- a/catalog-data/community-operator-index/v4.16/operators.json
+++ b/catalog-data/community-operator-index/v4.16/operators.json
@@ -4991,13 +4991,14 @@
         "1.2.3",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.4.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.4",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.4.0"
       }
     },
     "availableVersions": [
@@ -5044,10 +5045,11 @@
       "1.2.3",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.4.0"
     ],
     "minVersion": "0.0.4",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.4.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -5252,13 +5254,14 @@
         "1.2.0",
         "1.2.1",
         "1.2.2",
-        "1.3.0"
+        "1.3.0",
+        "1.3.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.0"
+        "maxVersion": "1.3.1"
       }
     },
     "availableVersions": [
@@ -5282,10 +5285,11 @@
       "1.2.0",
       "1.2.1",
       "1.2.2",
-      "1.3.0"
+      "1.3.0",
+      "1.3.1"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.0",
+    "maxVersion": "1.3.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -5408,13 +5412,14 @@
         "1.6.0",
         "1.6.1",
         "1.6.2",
-        "1.6.3"
+        "1.6.3",
+        "1.7.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.3.0",
-        "maxVersion": "1.6.3"
+        "maxVersion": "1.7.0"
       }
     },
     "availableVersions": [
@@ -5425,10 +5430,11 @@
       "1.6.0",
       "1.6.1",
       "1.6.2",
-      "1.6.3"
+      "1.6.3",
+      "1.7.0"
     ],
     "minVersion": "1.3.0",
-    "maxVersion": "1.6.3",
+    "maxVersion": "1.7.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -7196,7 +7202,8 @@
         "2.7.0",
         "2.8.0",
         "2.9.0",
-        "2.9.1"
+        "2.9.1",
+        "2.10.0"
       ],
       "stable": [
         "1.4.0",
@@ -7401,7 +7408,8 @@
         "2.7.0",
         "2.8.0",
         "2.9.0",
-        "2.9.1"
+        "2.9.1",
+        "2.10.0"
       ]
     },
     "channelVersionRanges": {
@@ -7411,7 +7419,7 @@
       },
       "latest": {
         "minVersion": "1.4.0",
-        "maxVersion": "2.9.1"
+        "maxVersion": "2.10.0"
       },
       "stable": {
         "minVersion": "1.4.0",
@@ -7455,7 +7463,7 @@
       },
       "stable-v2": {
         "minVersion": "1.4.0",
-        "maxVersion": "2.9.1"
+        "maxVersion": "2.10.0"
       }
     },
     "availableVersions": [
@@ -7496,10 +7504,11 @@
       "2.7.0",
       "2.8.0",
       "2.9.0",
-      "2.9.1"
+      "2.9.1",
+      "2.10.0"
     ],
     "minVersion": "1.4.0",
-    "maxVersion": "2.9.1",
+    "maxVersion": "2.10.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -8312,13 +8321,14 @@
         "0.0.9",
         "0.0.10",
         "0.0.11",
-        "0.0.12"
+        "0.0.12",
+        "0.0.13"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "0.0.12"
+        "maxVersion": "0.0.13"
       }
     },
     "availableVersions": [
@@ -8330,10 +8340,11 @@
       "0.0.9",
       "0.0.10",
       "0.0.11",
-      "0.0.12"
+      "0.0.12",
+      "0.0.13"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "0.0.12",
+    "maxVersion": "0.0.13",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -8812,13 +8823,14 @@
         "1.7.2",
         "1.7.3",
         "1.8.0",
-        "1.8.1"
+        "1.8.1",
+        "1.9.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.5.0",
-        "maxVersion": "1.8.1"
+        "maxVersion": "1.9.0"
       }
     },
     "availableVersions": [
@@ -8841,10 +8853,11 @@
       "1.7.2",
       "1.7.3",
       "1.8.0",
-      "1.8.1"
+      "1.8.1",
+      "1.9.0"
     ],
     "minVersion": "0.5.0",
-    "maxVersion": "1.8.1",
+    "maxVersion": "1.9.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -9820,13 +9833,14 @@
         "0.44.0",
         "0.45.0",
         "0.45.1",
-        "0.46.0"
+        "0.46.0",
+        "0.47.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.18.0",
-        "maxVersion": "0.46.0"
+        "maxVersion": "0.47.0"
       }
     },
     "availableVersions": [
@@ -9857,10 +9871,11 @@
       "0.44.0",
       "0.45.0",
       "0.45.1",
-      "0.46.0"
+      "0.46.0",
+      "0.47.0"
     ],
     "minVersion": "0.18.0",
-    "maxVersion": "0.46.0",
+    "maxVersion": "0.47.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -10029,7 +10044,8 @@
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.10.2",
+        "2.11.0"
       ],
       "unstable": [
         "1.3.0",
@@ -10097,17 +10113,18 @@
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.10.2",
+        "2.11.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.3.0",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       },
       "unstable": {
         "minVersion": "1.3.0",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       }
     },
     "availableVersions": [
@@ -10176,10 +10193,11 @@
       "2.9.2",
       "2.10.0",
       "2.10.1",
-      "2.10.2"
+      "2.10.2",
+      "2.11.0"
     ],
     "minVersion": "1.3.0",
-    "maxVersion": "2.10.2",
+    "maxVersion": "2.11.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -10200,13 +10218,14 @@
         "1.45.0",
         "1.46.0",
         "1.47.0",
-        "1.47.1"
+        "1.47.1",
+        "1.48.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.42.0",
-        "maxVersion": "1.47.1"
+        "maxVersion": "1.48.0"
       }
     },
     "availableVersions": [
@@ -10218,10 +10237,11 @@
       "1.45.0",
       "1.46.0",
       "1.47.0",
-      "1.47.1"
+      "1.47.1",
+      "1.48.0"
     ],
     "minVersion": "1.42.0",
-    "maxVersion": "1.47.1",
+    "maxVersion": "1.48.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -11822,7 +11842,8 @@
         "26.5.5",
         "26.5.6",
         "26.5.7",
-        "26.6.0"
+        "26.6.0",
+        "26.6.1"
       ]
     },
     "channelVersionRanges": {
@@ -11836,7 +11857,7 @@
       },
       "fast": {
         "minVersion": "20.0.0",
-        "maxVersion": "26.6.0"
+        "maxVersion": "26.6.1"
       }
     },
     "availableVersions": [
@@ -11941,10 +11962,11 @@
       "26.5.5",
       "26.5.6",
       "26.5.7",
-      "26.6.0"
+      "26.6.0",
+      "26.6.1"
     ],
     "minVersion": "14.0.0",
-    "maxVersion": "26.6.0",
+    "maxVersion": "26.6.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -12326,7 +12348,7 @@
   },
   {
     "name": "konveyor-operator",
-    "defaultChannel": "rc",
+    "defaultChannel": "konveyor-0.9",
     "channels": [
       "alpha",
       "beta",
@@ -12422,7 +12444,8 @@
       ],
       "konveyor-0.9": [
         "0.9.0",
-        "0.9.1"
+        "0.9.1",
+        "0.9.2"
       ],
       "rc": [
         "0.3.0-rc.1",
@@ -12489,7 +12512,7 @@
       },
       "konveyor-0.9": {
         "minVersion": "0.9.0",
-        "maxVersion": "0.9.1"
+        "maxVersion": "0.9.2"
       },
       "rc": {
         "minVersion": "0.3.0-rc.1",
@@ -12576,6 +12599,7 @@
       "0.9.0-rc.3",
       "0.9.0-rc.5",
       "0.9.1",
+      "0.9.2",
       "0.9.2-rc.1"
     ],
     "minVersion": "0.1.0",
@@ -15201,13 +15225,15 @@
         "0.0.66",
         "0.0.67",
         "0.0.68",
-        "0.0.69"
+        "0.0.69",
+        "0.0.70",
+        "0.0.71"
       ]
     },
     "channelVersionRanges": {
       "fast": {
         "minVersion": "0.0.1",
-        "maxVersion": "0.0.69"
+        "maxVersion": "0.0.71"
       }
     },
     "availableVersions": [
@@ -15279,10 +15305,12 @@
       "0.0.66",
       "0.0.67",
       "0.0.68",
-      "0.0.69"
+      "0.0.69",
+      "0.0.70",
+      "0.0.71"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "0.0.69",
+    "maxVersion": "0.0.71",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -15653,7 +15681,8 @@
         "3.10.16",
         "3.10.17",
         "3.10.18",
-        "3.10.19"
+        "3.10.19",
+        "3.10.20"
       ],
       "stable-3.11": [
         "3.11.0",
@@ -15687,7 +15716,8 @@
         "3.12.12",
         "3.12.13",
         "3.12.14",
-        "3.12.15"
+        "3.12.15",
+        "3.12.16"
       ],
       "stable-3.13": [
         "3.13.0",
@@ -15788,7 +15818,8 @@
         "3.9.16",
         "3.9.17",
         "3.9.18",
-        "3.9.19"
+        "3.9.19",
+        "3.9.20"
       ]
     },
     "channelVersionRanges": {
@@ -15810,7 +15841,7 @@
       },
       "stable-3.10": {
         "minVersion": "3.10.0",
-        "maxVersion": "3.10.19"
+        "maxVersion": "3.10.20"
       },
       "stable-3.11": {
         "minVersion": "3.11.0",
@@ -15818,7 +15849,7 @@
       },
       "stable-3.12": {
         "minVersion": "3.12.0",
-        "maxVersion": "3.12.15"
+        "maxVersion": "3.12.16"
       },
       "stable-3.13": {
         "minVersion": "3.13.0",
@@ -15854,7 +15885,7 @@
       },
       "stable-3.9": {
         "minVersion": "3.9.0",
-        "maxVersion": "3.9.19"
+        "maxVersion": "3.9.20"
       }
     },
     "availableVersions": [
@@ -15925,6 +15956,7 @@
       "3.9.17",
       "3.9.18",
       "3.9.19",
+      "3.9.20",
       "3.10.0",
       "3.10.0-nightly.20230913",
       "3.10.0-nightly.20230914",
@@ -15972,6 +16004,7 @@
       "3.10.17",
       "3.10.18",
       "3.10.19",
+      "3.10.20",
       "3.11.0",
       "3.11.1",
       "3.11.2",
@@ -16002,6 +16035,7 @@
       "3.12.13",
       "3.12.14",
       "3.12.15",
+      "3.12.16",
       "3.13.0",
       "3.13.1",
       "3.13.2",
@@ -16549,9 +16583,6 @@
     ],
     "channelVersions": {
       "1.29-nightly": [
-        "1.29.0-nightly-2026-03-31",
-        "1.29.0-nightly-2026-04-01",
-        "1.29.0-nightly-2026-04-03",
         "1.29.0-nightly-2026-04-04",
         "1.29.0-nightly-2026-04-05",
         "1.29.0-nightly-2026-04-06",
@@ -16563,7 +16594,12 @@
         "1.30.0-nightly-2026-04-10",
         "1.30.0-nightly-2026-04-11",
         "1.30.0-nightly-2026-04-12",
-        "1.30.0-nightly-2026-04-13"
+        "1.30.0-nightly-2026-04-13",
+        "1.30.0-nightly-2026-04-14",
+        "1.30.0-nightly-2026-04-15",
+        "1.30.0-nightly-2026-04-16",
+        "1.30.0-nightly-2026-04-17",
+        "1.30.0-nightly-2026-04-18"
       ],
       "candidates": [
         "0.1.0",
@@ -16621,12 +16657,12 @@
     },
     "channelVersionRanges": {
       "1.29-nightly": {
-        "minVersion": "1.29.0-nightly-2026-03-31",
+        "minVersion": "1.29.0-nightly-2026-04-04",
         "maxVersion": "1.29.0-nightly-2026-04-09"
       },
       "1.30-nightly": {
         "minVersion": "1.30.0-nightly-2026-04-10",
-        "maxVersion": "1.30.0-nightly-2026-04-13"
+        "maxVersion": "1.30.0-nightly-2026-04-18"
       },
       "candidates": {
         "minVersion": "0.1.0",
@@ -16681,9 +16717,6 @@
       "1.28.2",
       "1.28.3",
       "1.29.0",
-      "1.29.0-nightly-2026-03-31",
-      "1.29.0-nightly-2026-04-01",
-      "1.29.0-nightly-2026-04-03",
       "1.29.0-nightly-2026-04-04",
       "1.29.0-nightly-2026-04-05",
       "1.29.0-nightly-2026-04-06",
@@ -16694,10 +16727,15 @@
       "1.30.0-nightly-2026-04-10",
       "1.30.0-nightly-2026-04-11",
       "1.30.0-nightly-2026-04-12",
-      "1.30.0-nightly-2026-04-13"
+      "1.30.0-nightly-2026-04-13",
+      "1.30.0-nightly-2026-04-14",
+      "1.30.0-nightly-2026-04-15",
+      "1.30.0-nightly-2026-04-16",
+      "1.30.0-nightly-2026-04-17",
+      "1.30.0-nightly-2026-04-18"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "1.30.0-nightly-2026-04-13",
+    "maxVersion": "1.30.0-nightly-2026-04-18",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -19674,13 +19712,14 @@
         "0.8.35",
         "0.8.36",
         "0.8.37",
-        "0.8.38"
+        "0.8.38",
+        "0.8.46"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.8.38"
+        "maxVersion": "0.8.46"
       }
     },
     "availableVersions": [
@@ -19735,10 +19774,11 @@
       "0.8.35",
       "0.8.36",
       "0.8.37",
-      "0.8.38"
+      "0.8.38",
+      "0.8.46"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.8.38",
+    "maxVersion": "0.8.46",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"

--- a/catalog-data/community-operator-index/v4.17/operators.json
+++ b/catalog-data/community-operator-index/v4.17/operators.json
@@ -4985,13 +4985,14 @@
         "1.2.3",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.4.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.4",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.4.0"
       }
     },
     "availableVersions": [
@@ -5038,10 +5039,11 @@
       "1.2.3",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.4.0"
     ],
     "minVersion": "0.0.4",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.4.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -5246,13 +5248,14 @@
         "1.2.0",
         "1.2.1",
         "1.2.2",
-        "1.3.0"
+        "1.3.0",
+        "1.3.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.0"
+        "maxVersion": "1.3.1"
       }
     },
     "availableVersions": [
@@ -5276,10 +5279,11 @@
       "1.2.0",
       "1.2.1",
       "1.2.2",
-      "1.3.0"
+      "1.3.0",
+      "1.3.1"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.0",
+    "maxVersion": "1.3.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -5402,13 +5406,14 @@
         "1.6.0",
         "1.6.1",
         "1.6.2",
-        "1.6.3"
+        "1.6.3",
+        "1.7.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.3.0",
-        "maxVersion": "1.6.3"
+        "maxVersion": "1.7.0"
       }
     },
     "availableVersions": [
@@ -5419,10 +5424,11 @@
       "1.6.0",
       "1.6.1",
       "1.6.2",
-      "1.6.3"
+      "1.6.3",
+      "1.7.0"
     ],
     "minVersion": "1.3.0",
-    "maxVersion": "1.6.3",
+    "maxVersion": "1.7.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -7188,7 +7194,8 @@
         "2.7.0",
         "2.8.0",
         "2.9.0",
-        "2.9.1"
+        "2.9.1",
+        "2.10.0"
       ],
       "stable": [
         "1.4.0",
@@ -7393,7 +7400,8 @@
         "2.7.0",
         "2.8.0",
         "2.9.0",
-        "2.9.1"
+        "2.9.1",
+        "2.10.0"
       ]
     },
     "channelVersionRanges": {
@@ -7403,7 +7411,7 @@
       },
       "latest": {
         "minVersion": "1.4.0",
-        "maxVersion": "2.9.1"
+        "maxVersion": "2.10.0"
       },
       "stable": {
         "minVersion": "1.4.0",
@@ -7447,7 +7455,7 @@
       },
       "stable-v2": {
         "minVersion": "1.4.0",
-        "maxVersion": "2.9.1"
+        "maxVersion": "2.10.0"
       }
     },
     "availableVersions": [
@@ -7488,10 +7496,11 @@
       "2.7.0",
       "2.8.0",
       "2.9.0",
-      "2.9.1"
+      "2.9.1",
+      "2.10.0"
     ],
     "minVersion": "1.4.0",
-    "maxVersion": "2.9.1",
+    "maxVersion": "2.10.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -8353,13 +8362,14 @@
         "0.0.9",
         "0.0.10",
         "0.0.11",
-        "0.0.12"
+        "0.0.12",
+        "0.0.13"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "0.0.12"
+        "maxVersion": "0.0.13"
       }
     },
     "availableVersions": [
@@ -8371,10 +8381,11 @@
       "0.0.9",
       "0.0.10",
       "0.0.11",
-      "0.0.12"
+      "0.0.12",
+      "0.0.13"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "0.0.12",
+    "maxVersion": "0.0.13",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -8858,13 +8869,14 @@
         "1.7.2",
         "1.7.3",
         "1.8.0",
-        "1.8.1"
+        "1.8.1",
+        "1.9.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.5.0",
-        "maxVersion": "1.8.1"
+        "maxVersion": "1.9.0"
       }
     },
     "availableVersions": [
@@ -8884,10 +8896,11 @@
       "1.7.2",
       "1.7.3",
       "1.8.0",
-      "1.8.1"
+      "1.8.1",
+      "1.9.0"
     ],
     "minVersion": "0.5.0",
-    "maxVersion": "1.8.1",
+    "maxVersion": "1.9.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -9863,13 +9876,14 @@
         "0.44.0",
         "0.45.0",
         "0.45.1",
-        "0.46.0"
+        "0.46.0",
+        "0.47.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.18.0",
-        "maxVersion": "0.46.0"
+        "maxVersion": "0.47.0"
       }
     },
     "availableVersions": [
@@ -9900,10 +9914,11 @@
       "0.44.0",
       "0.45.0",
       "0.45.1",
-      "0.46.0"
+      "0.46.0",
+      "0.47.0"
     ],
     "minVersion": "0.18.0",
-    "maxVersion": "0.46.0",
+    "maxVersion": "0.47.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -10064,7 +10079,8 @@
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.10.2",
+        "2.11.0"
       ],
       "unstable": [
         "1.6.0",
@@ -10124,17 +10140,18 @@
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.10.2",
+        "2.11.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.6.0",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       },
       "unstable": {
         "minVersion": "1.6.0",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       }
     },
     "availableVersions": [
@@ -10195,10 +10212,11 @@
       "2.9.2",
       "2.10.0",
       "2.10.1",
-      "2.10.2"
+      "2.10.2",
+      "2.11.0"
     ],
     "minVersion": "1.6.0",
-    "maxVersion": "2.10.2",
+    "maxVersion": "2.11.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -10219,13 +10237,14 @@
         "1.45.0",
         "1.46.0",
         "1.47.0",
-        "1.47.1"
+        "1.47.1",
+        "1.48.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.42.0",
-        "maxVersion": "1.47.1"
+        "maxVersion": "1.48.0"
       }
     },
     "availableVersions": [
@@ -10237,10 +10256,11 @@
       "1.45.0",
       "1.46.0",
       "1.47.0",
-      "1.47.1"
+      "1.47.1",
+      "1.48.0"
     ],
     "minVersion": "1.42.0",
-    "maxVersion": "1.47.1",
+    "maxVersion": "1.48.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -11833,7 +11853,8 @@
         "26.5.5",
         "26.5.6",
         "26.5.7",
-        "26.6.0"
+        "26.6.0",
+        "26.6.1"
       ]
     },
     "channelVersionRanges": {
@@ -11847,7 +11868,7 @@
       },
       "fast": {
         "minVersion": "20.0.0",
-        "maxVersion": "26.6.0"
+        "maxVersion": "26.6.1"
       }
     },
     "availableVersions": [
@@ -11952,10 +11973,11 @@
       "26.5.5",
       "26.5.6",
       "26.5.7",
-      "26.6.0"
+      "26.6.0",
+      "26.6.1"
     ],
     "minVersion": "14.0.0",
-    "maxVersion": "26.6.0",
+    "maxVersion": "26.6.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -12337,7 +12359,7 @@
   },
   {
     "name": "konveyor-operator",
-    "defaultChannel": "rc",
+    "defaultChannel": "konveyor-0.9",
     "channels": [
       "alpha",
       "beta",
@@ -12433,7 +12455,8 @@
       ],
       "konveyor-0.9": [
         "0.9.0",
-        "0.9.1"
+        "0.9.1",
+        "0.9.2"
       ],
       "rc": [
         "0.3.0-rc.1",
@@ -12500,7 +12523,7 @@
       },
       "konveyor-0.9": {
         "minVersion": "0.9.0",
-        "maxVersion": "0.9.1"
+        "maxVersion": "0.9.2"
       },
       "rc": {
         "minVersion": "0.3.0-rc.1",
@@ -12587,6 +12610,7 @@
       "0.9.0-rc.3",
       "0.9.0-rc.5",
       "0.9.1",
+      "0.9.2",
       "0.9.2-rc.1"
     ],
     "minVersion": "0.1.0",
@@ -15209,13 +15233,15 @@
         "0.0.66",
         "0.0.67",
         "0.0.68",
-        "0.0.69"
+        "0.0.69",
+        "0.0.70",
+        "0.0.71"
       ]
     },
     "channelVersionRanges": {
       "fast": {
         "minVersion": "0.0.1",
-        "maxVersion": "0.0.69"
+        "maxVersion": "0.0.71"
       }
     },
     "availableVersions": [
@@ -15287,10 +15313,12 @@
       "0.0.66",
       "0.0.67",
       "0.0.68",
-      "0.0.69"
+      "0.0.69",
+      "0.0.70",
+      "0.0.71"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "0.0.69",
+    "maxVersion": "0.0.71",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -15659,7 +15687,8 @@
         "3.10.16",
         "3.10.17",
         "3.10.18",
-        "3.10.19"
+        "3.10.19",
+        "3.10.20"
       ],
       "stable-3.11": [
         "3.11.0",
@@ -15693,7 +15722,8 @@
         "3.12.12",
         "3.12.13",
         "3.12.14",
-        "3.12.15"
+        "3.12.15",
+        "3.12.16"
       ],
       "stable-3.13": [
         "3.13.0",
@@ -15794,7 +15824,8 @@
         "3.9.16",
         "3.9.17",
         "3.9.18",
-        "3.9.19"
+        "3.9.19",
+        "3.9.20"
       ]
     },
     "channelVersionRanges": {
@@ -15816,7 +15847,7 @@
       },
       "stable-3.10": {
         "minVersion": "3.10.0",
-        "maxVersion": "3.10.19"
+        "maxVersion": "3.10.20"
       },
       "stable-3.11": {
         "minVersion": "3.11.0",
@@ -15824,7 +15855,7 @@
       },
       "stable-3.12": {
         "minVersion": "3.12.0",
-        "maxVersion": "3.12.15"
+        "maxVersion": "3.12.16"
       },
       "stable-3.13": {
         "minVersion": "3.13.0",
@@ -15860,7 +15891,7 @@
       },
       "stable-3.9": {
         "minVersion": "3.9.0",
-        "maxVersion": "3.9.19"
+        "maxVersion": "3.9.20"
       }
     },
     "availableVersions": [
@@ -15931,6 +15962,7 @@
       "3.9.17",
       "3.9.18",
       "3.9.19",
+      "3.9.20",
       "3.10.0",
       "3.10.0-nightly.20230913",
       "3.10.0-nightly.20230914",
@@ -15978,6 +16010,7 @@
       "3.10.17",
       "3.10.18",
       "3.10.19",
+      "3.10.20",
       "3.11.0",
       "3.11.1",
       "3.11.2",
@@ -16008,6 +16041,7 @@
       "3.12.13",
       "3.12.14",
       "3.12.15",
+      "3.12.16",
       "3.13.0",
       "3.13.1",
       "3.13.2",
@@ -16299,13 +16333,14 @@
         "2.18.0",
         "2.19.1",
         "2.19.2",
-        "2.20.0"
+        "2.20.0",
+        "2.20.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.14.0",
-        "maxVersion": "2.20.0"
+        "maxVersion": "2.20.1"
       }
     },
     "availableVersions": [
@@ -16324,10 +16359,11 @@
       "2.18.0",
       "2.19.1",
       "2.19.2",
-      "2.20.0"
+      "2.20.0",
+      "2.20.1"
     ],
     "minVersion": "1.14.0",
-    "maxVersion": "2.20.0",
+    "maxVersion": "2.20.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -16658,9 +16694,6 @@
     ],
     "channelVersions": {
       "1.29-nightly": [
-        "1.29.0-nightly-2026-03-31",
-        "1.29.0-nightly-2026-04-01",
-        "1.29.0-nightly-2026-04-03",
         "1.29.0-nightly-2026-04-04",
         "1.29.0-nightly-2026-04-05",
         "1.29.0-nightly-2026-04-06",
@@ -16672,7 +16705,12 @@
         "1.30.0-nightly-2026-04-10",
         "1.30.0-nightly-2026-04-11",
         "1.30.0-nightly-2026-04-12",
-        "1.30.0-nightly-2026-04-13"
+        "1.30.0-nightly-2026-04-13",
+        "1.30.0-nightly-2026-04-14",
+        "1.30.0-nightly-2026-04-15",
+        "1.30.0-nightly-2026-04-16",
+        "1.30.0-nightly-2026-04-17",
+        "1.30.0-nightly-2026-04-18"
       ],
       "candidates": [
         "0.1.0",
@@ -16730,12 +16768,12 @@
     },
     "channelVersionRanges": {
       "1.29-nightly": {
-        "minVersion": "1.29.0-nightly-2026-03-31",
+        "minVersion": "1.29.0-nightly-2026-04-04",
         "maxVersion": "1.29.0-nightly-2026-04-09"
       },
       "1.30-nightly": {
         "minVersion": "1.30.0-nightly-2026-04-10",
-        "maxVersion": "1.30.0-nightly-2026-04-13"
+        "maxVersion": "1.30.0-nightly-2026-04-18"
       },
       "candidates": {
         "minVersion": "0.1.0",
@@ -16790,9 +16828,6 @@
       "1.28.2",
       "1.28.3",
       "1.29.0",
-      "1.29.0-nightly-2026-03-31",
-      "1.29.0-nightly-2026-04-01",
-      "1.29.0-nightly-2026-04-03",
       "1.29.0-nightly-2026-04-04",
       "1.29.0-nightly-2026-04-05",
       "1.29.0-nightly-2026-04-06",
@@ -16803,10 +16838,15 @@
       "1.30.0-nightly-2026-04-10",
       "1.30.0-nightly-2026-04-11",
       "1.30.0-nightly-2026-04-12",
-      "1.30.0-nightly-2026-04-13"
+      "1.30.0-nightly-2026-04-13",
+      "1.30.0-nightly-2026-04-14",
+      "1.30.0-nightly-2026-04-15",
+      "1.30.0-nightly-2026-04-16",
+      "1.30.0-nightly-2026-04-17",
+      "1.30.0-nightly-2026-04-18"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "1.30.0-nightly-2026-04-13",
+    "maxVersion": "1.30.0-nightly-2026-04-18",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -19763,13 +19803,14 @@
         "0.8.35",
         "0.8.36",
         "0.8.37",
-        "0.8.38"
+        "0.8.38",
+        "0.8.46"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.8.38"
+        "maxVersion": "0.8.46"
       }
     },
     "availableVersions": [
@@ -19824,10 +19865,11 @@
       "0.8.35",
       "0.8.36",
       "0.8.37",
-      "0.8.38"
+      "0.8.38",
+      "0.8.46"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.8.38",
+    "maxVersion": "0.8.46",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"

--- a/catalog-data/community-operator-index/v4.18/operators.json
+++ b/catalog-data/community-operator-index/v4.18/operators.json
@@ -4985,13 +4985,14 @@
         "1.2.3",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.4.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.4",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.4.0"
       }
     },
     "availableVersions": [
@@ -5038,10 +5039,11 @@
       "1.2.3",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.4.0"
     ],
     "minVersion": "0.0.4",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.4.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -5246,13 +5248,14 @@
         "1.2.0",
         "1.2.1",
         "1.2.2",
-        "1.3.0"
+        "1.3.0",
+        "1.3.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.0"
+        "maxVersion": "1.3.1"
       }
     },
     "availableVersions": [
@@ -5276,10 +5279,11 @@
       "1.2.0",
       "1.2.1",
       "1.2.2",
-      "1.3.0"
+      "1.3.0",
+      "1.3.1"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.0",
+    "maxVersion": "1.3.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -5402,13 +5406,14 @@
         "1.6.0",
         "1.6.1",
         "1.6.2",
-        "1.6.3"
+        "1.6.3",
+        "1.7.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.3.0",
-        "maxVersion": "1.6.3"
+        "maxVersion": "1.7.0"
       }
     },
     "availableVersions": [
@@ -5419,10 +5424,11 @@
       "1.6.0",
       "1.6.1",
       "1.6.2",
-      "1.6.3"
+      "1.6.3",
+      "1.7.0"
     ],
     "minVersion": "1.3.0",
-    "maxVersion": "1.6.3",
+    "maxVersion": "1.7.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -7214,7 +7220,8 @@
         "2.7.0",
         "2.8.0",
         "2.9.0",
-        "2.9.1"
+        "2.9.1",
+        "2.10.0"
       ],
       "stable": [
         "1.4.0",
@@ -7419,7 +7426,8 @@
         "2.7.0",
         "2.8.0",
         "2.9.0",
-        "2.9.1"
+        "2.9.1",
+        "2.10.0"
       ]
     },
     "channelVersionRanges": {
@@ -7429,7 +7437,7 @@
       },
       "latest": {
         "minVersion": "1.4.0",
-        "maxVersion": "2.9.1"
+        "maxVersion": "2.10.0"
       },
       "stable": {
         "minVersion": "1.4.0",
@@ -7473,7 +7481,7 @@
       },
       "stable-v2": {
         "minVersion": "1.4.0",
-        "maxVersion": "2.9.1"
+        "maxVersion": "2.10.0"
       }
     },
     "availableVersions": [
@@ -7514,10 +7522,11 @@
       "2.7.0",
       "2.8.0",
       "2.9.0",
-      "2.9.1"
+      "2.9.1",
+      "2.10.0"
     ],
     "minVersion": "1.4.0",
-    "maxVersion": "2.9.1",
+    "maxVersion": "2.10.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -8381,13 +8390,14 @@
         "0.0.9",
         "0.0.10",
         "0.0.11",
-        "0.0.12"
+        "0.0.12",
+        "0.0.13"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "0.0.12"
+        "maxVersion": "0.0.13"
       }
     },
     "availableVersions": [
@@ -8399,10 +8409,11 @@
       "0.0.9",
       "0.0.10",
       "0.0.11",
-      "0.0.12"
+      "0.0.12",
+      "0.0.13"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "0.0.12",
+    "maxVersion": "0.0.13",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -8886,13 +8897,14 @@
         "1.7.2",
         "1.7.3",
         "1.8.0",
-        "1.8.1"
+        "1.8.1",
+        "1.9.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.5.0",
-        "maxVersion": "1.8.1"
+        "maxVersion": "1.9.0"
       }
     },
     "availableVersions": [
@@ -8912,10 +8924,11 @@
       "1.7.2",
       "1.7.3",
       "1.8.0",
-      "1.8.1"
+      "1.8.1",
+      "1.9.0"
     ],
     "minVersion": "0.5.0",
-    "maxVersion": "1.8.1",
+    "maxVersion": "1.9.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -9877,13 +9890,14 @@
         "0.44.0",
         "0.45.0",
         "0.45.1",
-        "0.46.0"
+        "0.46.0",
+        "0.47.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.18.0",
-        "maxVersion": "0.46.0"
+        "maxVersion": "0.47.0"
       }
     },
     "availableVersions": [
@@ -9914,10 +9928,11 @@
       "0.44.0",
       "0.45.0",
       "0.45.1",
-      "0.46.0"
+      "0.46.0",
+      "0.47.0"
     ],
     "minVersion": "0.18.0",
-    "maxVersion": "0.46.0",
+    "maxVersion": "0.47.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -10056,7 +10071,8 @@
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.10.2",
+        "2.11.0"
       ],
       "unstable": [
         "2.0.0",
@@ -10094,17 +10110,18 @@
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.10.2",
+        "2.11.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.0.0",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       },
       "unstable": {
         "minVersion": "2.0.0",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       }
     },
     "availableVersions": [
@@ -10143,10 +10160,11 @@
       "2.9.2",
       "2.10.0",
       "2.10.1",
-      "2.10.2"
+      "2.10.2",
+      "2.11.0"
     ],
     "minVersion": "2.0.0",
-    "maxVersion": "2.10.2",
+    "maxVersion": "2.11.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -10167,13 +10185,14 @@
         "1.45.0",
         "1.46.0",
         "1.47.0",
-        "1.47.1"
+        "1.47.1",
+        "1.48.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.42.0",
-        "maxVersion": "1.47.1"
+        "maxVersion": "1.48.0"
       }
     },
     "availableVersions": [
@@ -10185,10 +10204,11 @@
       "1.45.0",
       "1.46.0",
       "1.47.0",
-      "1.47.1"
+      "1.47.1",
+      "1.48.0"
     ],
     "minVersion": "1.42.0",
-    "maxVersion": "1.47.1",
+    "maxVersion": "1.48.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -10839,7 +10859,8 @@
       "stable-v1.12.4",
       "stable-v1.12.5",
       "stable-v1.13",
-      "stable-v1.13.0"
+      "stable-v1.13.0",
+      "stable-v1.13.1"
     ],
     "channelVersions": {
       "stable": [
@@ -10848,7 +10869,8 @@
         "1.12.3",
         "1.12.4",
         "1.12.5",
-        "1.13.0"
+        "1.13.0",
+        "1.13.1"
       ],
       "stable-v1.12": [
         "1.12.1",
@@ -10888,7 +10910,8 @@
         "1.12.3",
         "1.12.4",
         "1.12.5",
-        "1.13.0"
+        "1.13.0",
+        "1.13.1"
       ],
       "stable-v1.13.0": [
         "1.12.1",
@@ -10897,12 +10920,21 @@
         "1.12.4",
         "1.12.5",
         "1.13.0"
+      ],
+      "stable-v1.13.1": [
+        "1.12.1",
+        "1.12.2",
+        "1.12.3",
+        "1.12.4",
+        "1.12.5",
+        "1.13.0",
+        "1.13.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.12.1",
-        "maxVersion": "1.13.0"
+        "maxVersion": "1.13.1"
       },
       "stable-v1.12": {
         "minVersion": "1.12.1",
@@ -10930,11 +10962,15 @@
       },
       "stable-v1.13": {
         "minVersion": "1.12.1",
-        "maxVersion": "1.13.0"
+        "maxVersion": "1.13.1"
       },
       "stable-v1.13.0": {
         "minVersion": "1.12.1",
         "maxVersion": "1.13.0"
+      },
+      "stable-v1.13.1": {
+        "minVersion": "1.12.1",
+        "maxVersion": "1.13.1"
       }
     },
     "availableVersions": [
@@ -10943,10 +10979,11 @@
       "1.12.3",
       "1.12.4",
       "1.12.5",
-      "1.13.0"
+      "1.13.0",
+      "1.13.1"
     ],
     "minVersion": "1.12.1",
-    "maxVersion": "1.13.0",
+    "maxVersion": "1.13.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -11804,7 +11841,8 @@
         "26.5.5",
         "26.5.6",
         "26.5.7",
-        "26.6.0"
+        "26.6.0",
+        "26.6.1"
       ]
     },
     "channelVersionRanges": {
@@ -11818,7 +11856,7 @@
       },
       "fast": {
         "minVersion": "20.0.0",
-        "maxVersion": "26.6.0"
+        "maxVersion": "26.6.1"
       }
     },
     "availableVersions": [
@@ -11923,10 +11961,11 @@
       "26.5.5",
       "26.5.6",
       "26.5.7",
-      "26.6.0"
+      "26.6.0",
+      "26.6.1"
     ],
     "minVersion": "14.0.0",
-    "maxVersion": "26.6.0",
+    "maxVersion": "26.6.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -12308,7 +12347,7 @@
   },
   {
     "name": "konveyor-operator",
-    "defaultChannel": "rc",
+    "defaultChannel": "konveyor-0.9",
     "channels": [
       "alpha",
       "beta",
@@ -12404,7 +12443,8 @@
       ],
       "konveyor-0.9": [
         "0.9.0",
-        "0.9.1"
+        "0.9.1",
+        "0.9.2"
       ],
       "rc": [
         "0.3.0-rc.1",
@@ -12471,7 +12511,7 @@
       },
       "konveyor-0.9": {
         "minVersion": "0.9.0",
-        "maxVersion": "0.9.1"
+        "maxVersion": "0.9.2"
       },
       "rc": {
         "minVersion": "0.3.0-rc.1",
@@ -12558,6 +12598,7 @@
       "0.9.0-rc.3",
       "0.9.0-rc.5",
       "0.9.1",
+      "0.9.2",
       "0.9.2-rc.1"
     ],
     "minVersion": "0.1.0",
@@ -15219,13 +15260,15 @@
         "0.0.66",
         "0.0.67",
         "0.0.68",
-        "0.0.69"
+        "0.0.69",
+        "0.0.70",
+        "0.0.71"
       ]
     },
     "channelVersionRanges": {
       "fast": {
         "minVersion": "0.0.1",
-        "maxVersion": "0.0.69"
+        "maxVersion": "0.0.71"
       }
     },
     "availableVersions": [
@@ -15297,10 +15340,12 @@
       "0.0.66",
       "0.0.67",
       "0.0.68",
-      "0.0.69"
+      "0.0.69",
+      "0.0.70",
+      "0.0.71"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "0.0.69",
+    "maxVersion": "0.0.71",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -15482,23 +15527,25 @@
         "1.9.0",
         "1.17.0",
         "1.18.0",
-        "1.19.0"
+        "1.19.0",
+        "1.19.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.9.0",
-        "maxVersion": "1.19.0"
+        "maxVersion": "1.19.1"
       }
     },
     "availableVersions": [
       "1.9.0",
       "1.17.0",
       "1.18.0",
-      "1.19.0"
+      "1.19.0",
+      "1.19.1"
     ],
     "minVersion": "1.9.0",
-    "maxVersion": "1.19.0",
+    "maxVersion": "1.19.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -15657,7 +15704,8 @@
         "3.10.16",
         "3.10.17",
         "3.10.18",
-        "3.10.19"
+        "3.10.19",
+        "3.10.20"
       ],
       "stable-3.11": [
         "3.11.0",
@@ -15691,7 +15739,8 @@
         "3.12.12",
         "3.12.13",
         "3.12.14",
-        "3.12.15"
+        "3.12.15",
+        "3.12.16"
       ],
       "stable-3.13": [
         "3.13.0",
@@ -15792,7 +15841,8 @@
         "3.9.16",
         "3.9.17",
         "3.9.18",
-        "3.9.19"
+        "3.9.19",
+        "3.9.20"
       ]
     },
     "channelVersionRanges": {
@@ -15814,7 +15864,7 @@
       },
       "stable-3.10": {
         "minVersion": "3.10.0",
-        "maxVersion": "3.10.19"
+        "maxVersion": "3.10.20"
       },
       "stable-3.11": {
         "minVersion": "3.11.0",
@@ -15822,7 +15872,7 @@
       },
       "stable-3.12": {
         "minVersion": "3.12.0",
-        "maxVersion": "3.12.15"
+        "maxVersion": "3.12.16"
       },
       "stable-3.13": {
         "minVersion": "3.13.0",
@@ -15858,7 +15908,7 @@
       },
       "stable-3.9": {
         "minVersion": "3.9.0",
-        "maxVersion": "3.9.19"
+        "maxVersion": "3.9.20"
       }
     },
     "availableVersions": [
@@ -15929,6 +15979,7 @@
       "3.9.17",
       "3.9.18",
       "3.9.19",
+      "3.9.20",
       "3.10.0",
       "3.10.0-nightly.20230913",
       "3.10.0-nightly.20230914",
@@ -15976,6 +16027,7 @@
       "3.10.17",
       "3.10.18",
       "3.10.19",
+      "3.10.20",
       "3.11.0",
       "3.11.1",
       "3.11.2",
@@ -16006,6 +16058,7 @@
       "3.12.13",
       "3.12.14",
       "3.12.15",
+      "3.12.16",
       "3.13.0",
       "3.13.1",
       "3.13.2",
@@ -16297,13 +16350,14 @@
         "2.18.0",
         "2.19.1",
         "2.19.2",
-        "2.20.0"
+        "2.20.0",
+        "2.20.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.14.0",
-        "maxVersion": "2.20.0"
+        "maxVersion": "2.20.1"
       }
     },
     "availableVersions": [
@@ -16322,10 +16376,11 @@
       "2.18.0",
       "2.19.1",
       "2.19.2",
-      "2.20.0"
+      "2.20.0",
+      "2.20.1"
     ],
     "minVersion": "1.14.0",
-    "maxVersion": "2.20.0",
+    "maxVersion": "2.20.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -16656,9 +16711,6 @@
     ],
     "channelVersions": {
       "1.29-nightly": [
-        "1.29.0-nightly-2026-03-31",
-        "1.29.0-nightly-2026-04-01",
-        "1.29.0-nightly-2026-04-03",
         "1.29.0-nightly-2026-04-04",
         "1.29.0-nightly-2026-04-05",
         "1.29.0-nightly-2026-04-06",
@@ -16670,7 +16722,12 @@
         "1.30.0-nightly-2026-04-10",
         "1.30.0-nightly-2026-04-11",
         "1.30.0-nightly-2026-04-12",
-        "1.30.0-nightly-2026-04-13"
+        "1.30.0-nightly-2026-04-13",
+        "1.30.0-nightly-2026-04-14",
+        "1.30.0-nightly-2026-04-15",
+        "1.30.0-nightly-2026-04-16",
+        "1.30.0-nightly-2026-04-17",
+        "1.30.0-nightly-2026-04-18"
       ],
       "candidates": [
         "0.1.0",
@@ -16728,12 +16785,12 @@
     },
     "channelVersionRanges": {
       "1.29-nightly": {
-        "minVersion": "1.29.0-nightly-2026-03-31",
+        "minVersion": "1.29.0-nightly-2026-04-04",
         "maxVersion": "1.29.0-nightly-2026-04-09"
       },
       "1.30-nightly": {
         "minVersion": "1.30.0-nightly-2026-04-10",
-        "maxVersion": "1.30.0-nightly-2026-04-13"
+        "maxVersion": "1.30.0-nightly-2026-04-18"
       },
       "candidates": {
         "minVersion": "0.1.0",
@@ -16788,9 +16845,6 @@
       "1.28.2",
       "1.28.3",
       "1.29.0",
-      "1.29.0-nightly-2026-03-31",
-      "1.29.0-nightly-2026-04-01",
-      "1.29.0-nightly-2026-04-03",
       "1.29.0-nightly-2026-04-04",
       "1.29.0-nightly-2026-04-05",
       "1.29.0-nightly-2026-04-06",
@@ -16801,10 +16855,15 @@
       "1.30.0-nightly-2026-04-10",
       "1.30.0-nightly-2026-04-11",
       "1.30.0-nightly-2026-04-12",
-      "1.30.0-nightly-2026-04-13"
+      "1.30.0-nightly-2026-04-13",
+      "1.30.0-nightly-2026-04-14",
+      "1.30.0-nightly-2026-04-15",
+      "1.30.0-nightly-2026-04-16",
+      "1.30.0-nightly-2026-04-17",
+      "1.30.0-nightly-2026-04-18"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "1.30.0-nightly-2026-04-13",
+    "maxVersion": "1.30.0-nightly-2026-04-18",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -19672,13 +19731,14 @@
         "0.8.35",
         "0.8.36",
         "0.8.37",
-        "0.8.38"
+        "0.8.38",
+        "0.8.46"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.8.38"
+        "maxVersion": "0.8.46"
       }
     },
     "availableVersions": [
@@ -19733,10 +19793,11 @@
       "0.8.35",
       "0.8.36",
       "0.8.37",
-      "0.8.38"
+      "0.8.38",
+      "0.8.46"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.8.38",
+    "maxVersion": "0.8.46",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"

--- a/catalog-data/community-operator-index/v4.19/operators.json
+++ b/catalog-data/community-operator-index/v4.19/operators.json
@@ -4965,13 +4965,14 @@
         "1.2.3",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.4.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.4",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.4.0"
       }
     },
     "availableVersions": [
@@ -5018,10 +5019,11 @@
       "1.2.3",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.4.0"
     ],
     "minVersion": "0.0.4",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.4.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -5226,13 +5228,14 @@
         "1.2.0",
         "1.2.1",
         "1.2.2",
-        "1.3.0"
+        "1.3.0",
+        "1.3.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.0"
+        "maxVersion": "1.3.1"
       }
     },
     "availableVersions": [
@@ -5256,10 +5259,11 @@
       "1.2.0",
       "1.2.1",
       "1.2.2",
-      "1.3.0"
+      "1.3.0",
+      "1.3.1"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.0",
+    "maxVersion": "1.3.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -5382,13 +5386,14 @@
         "1.6.0",
         "1.6.1",
         "1.6.2",
-        "1.6.3"
+        "1.6.3",
+        "1.7.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.3.0",
-        "maxVersion": "1.6.3"
+        "maxVersion": "1.7.0"
       }
     },
     "availableVersions": [
@@ -5399,10 +5404,11 @@
       "1.6.0",
       "1.6.1",
       "1.6.2",
-      "1.6.3"
+      "1.6.3",
+      "1.7.0"
     ],
     "minVersion": "1.3.0",
-    "maxVersion": "1.6.3",
+    "maxVersion": "1.7.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -6995,7 +7001,8 @@
         "0.1.2",
         "1.0.0",
         "1.1.1",
-        "1.1.2"
+        "1.1.2",
+        "1.1.3"
       ],
       "Stable": [
         "0.0.1",
@@ -7005,17 +7012,18 @@
         "0.1.2",
         "1.0.0",
         "1.1.1",
-        "1.1.2"
+        "1.1.2",
+        "1.1.3"
       ]
     },
     "channelVersionRanges": {
       "Fast": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.1.2"
+        "maxVersion": "1.1.3"
       },
       "Stable": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.1.2"
+        "maxVersion": "1.1.3"
       }
     },
     "availableVersions": [
@@ -7026,10 +7034,11 @@
       "0.1.2",
       "1.0.0",
       "1.1.1",
-      "1.1.2"
+      "1.1.2",
+      "1.1.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.1.2",
+    "maxVersion": "1.1.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -7249,7 +7258,8 @@
         "2.7.0",
         "2.8.0",
         "2.9.0",
-        "2.9.1"
+        "2.9.1",
+        "2.10.0"
       ],
       "stable": [
         "1.4.0",
@@ -7454,7 +7464,8 @@
         "2.7.0",
         "2.8.0",
         "2.9.0",
-        "2.9.1"
+        "2.9.1",
+        "2.10.0"
       ]
     },
     "channelVersionRanges": {
@@ -7464,7 +7475,7 @@
       },
       "latest": {
         "minVersion": "1.4.0",
-        "maxVersion": "2.9.1"
+        "maxVersion": "2.10.0"
       },
       "stable": {
         "minVersion": "1.4.0",
@@ -7508,7 +7519,7 @@
       },
       "stable-v2": {
         "minVersion": "1.4.0",
-        "maxVersion": "2.9.1"
+        "maxVersion": "2.10.0"
       }
     },
     "availableVersions": [
@@ -7549,10 +7560,11 @@
       "2.7.0",
       "2.8.0",
       "2.9.0",
-      "2.9.1"
+      "2.9.1",
+      "2.10.0"
     ],
     "minVersion": "1.4.0",
-    "maxVersion": "2.9.1",
+    "maxVersion": "2.10.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -8420,13 +8432,14 @@
         "0.0.9",
         "0.0.10",
         "0.0.11",
-        "0.0.12"
+        "0.0.12",
+        "0.0.13"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "0.0.12"
+        "maxVersion": "0.0.13"
       }
     },
     "availableVersions": [
@@ -8438,10 +8451,11 @@
       "0.0.9",
       "0.0.10",
       "0.0.11",
-      "0.0.12"
+      "0.0.12",
+      "0.0.13"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "0.0.12",
+    "maxVersion": "0.0.13",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -8899,13 +8913,14 @@
         "1.7.2",
         "1.7.3",
         "1.8.0",
-        "1.8.1"
+        "1.8.1",
+        "1.9.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.5.0",
-        "maxVersion": "1.8.1"
+        "maxVersion": "1.9.0"
       }
     },
     "availableVersions": [
@@ -8925,10 +8940,11 @@
       "1.7.2",
       "1.7.3",
       "1.8.0",
-      "1.8.1"
+      "1.8.1",
+      "1.9.0"
     ],
     "minVersion": "0.5.0",
-    "maxVersion": "1.8.1",
+    "maxVersion": "1.9.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -9880,13 +9896,14 @@
         "0.44.0",
         "0.45.0",
         "0.45.1",
-        "0.46.0"
+        "0.46.0",
+        "0.47.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.28.0",
-        "maxVersion": "0.46.0"
+        "maxVersion": "0.47.0"
       }
     },
     "availableVersions": [
@@ -9907,10 +9924,11 @@
       "0.44.0",
       "0.45.0",
       "0.45.1",
-      "0.46.0"
+      "0.46.0",
+      "0.47.0"
     ],
     "minVersion": "0.28.0",
-    "maxVersion": "0.46.0",
+    "maxVersion": "0.47.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -10047,7 +10065,8 @@
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.10.2",
+        "2.11.0"
       ],
       "unstable": [
         "2.2.0",
@@ -10079,17 +10098,18 @@
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.10.2",
+        "2.11.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.2.0",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       },
       "unstable": {
         "minVersion": "2.2.0",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       }
     },
     "availableVersions": [
@@ -10122,10 +10142,11 @@
       "2.9.2",
       "2.10.0",
       "2.10.1",
-      "2.10.2"
+      "2.10.2",
+      "2.11.0"
     ],
     "minVersion": "2.2.0",
-    "maxVersion": "2.10.2",
+    "maxVersion": "2.11.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -10146,13 +10167,14 @@
         "1.45.0",
         "1.46.0",
         "1.47.0",
-        "1.47.1"
+        "1.47.1",
+        "1.48.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.42.0",
-        "maxVersion": "1.47.1"
+        "maxVersion": "1.48.0"
       }
     },
     "availableVersions": [
@@ -10164,10 +10186,11 @@
       "1.45.0",
       "1.46.0",
       "1.47.0",
-      "1.47.1"
+      "1.47.1",
+      "1.48.0"
     ],
     "minVersion": "1.42.0",
-    "maxVersion": "1.47.1",
+    "maxVersion": "1.48.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -10815,13 +10838,15 @@
       "stable-v1.12.4",
       "stable-v1.12.5",
       "stable-v1.13",
-      "stable-v1.13.0"
+      "stable-v1.13.0",
+      "stable-v1.13.1"
     ],
     "channelVersions": {
       "stable": [
         "1.12.4",
         "1.12.5",
-        "1.13.0"
+        "1.13.0",
+        "1.13.1"
       ],
       "stable-v1.12": [
         "1.12.4",
@@ -10837,18 +10862,25 @@
       "stable-v1.13": [
         "1.12.4",
         "1.12.5",
-        "1.13.0"
+        "1.13.0",
+        "1.13.1"
       ],
       "stable-v1.13.0": [
         "1.12.4",
         "1.12.5",
         "1.13.0"
+      ],
+      "stable-v1.13.1": [
+        "1.12.4",
+        "1.12.5",
+        "1.13.0",
+        "1.13.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.12.4",
-        "maxVersion": "1.13.0"
+        "maxVersion": "1.13.1"
       },
       "stable-v1.12": {
         "minVersion": "1.12.4",
@@ -10864,20 +10896,25 @@
       },
       "stable-v1.13": {
         "minVersion": "1.12.4",
-        "maxVersion": "1.13.0"
+        "maxVersion": "1.13.1"
       },
       "stable-v1.13.0": {
         "minVersion": "1.12.4",
         "maxVersion": "1.13.0"
+      },
+      "stable-v1.13.1": {
+        "minVersion": "1.12.4",
+        "maxVersion": "1.13.1"
       }
     },
     "availableVersions": [
       "1.12.4",
       "1.12.5",
-      "1.13.0"
+      "1.13.0",
+      "1.13.1"
     ],
     "minVersion": "1.12.4",
-    "maxVersion": "1.13.0",
+    "maxVersion": "1.13.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -11669,7 +11706,8 @@
         "26.5.5",
         "26.5.6",
         "26.5.7",
-        "26.6.0"
+        "26.6.0",
+        "26.6.1"
       ]
     },
     "channelVersionRanges": {
@@ -11683,7 +11721,7 @@
       },
       "fast": {
         "minVersion": "20.0.0",
-        "maxVersion": "26.6.0"
+        "maxVersion": "26.6.1"
       }
     },
     "availableVersions": [
@@ -11788,10 +11826,11 @@
       "26.5.5",
       "26.5.6",
       "26.5.7",
-      "26.6.0"
+      "26.6.0",
+      "26.6.1"
     ],
     "minVersion": "14.0.0",
-    "maxVersion": "26.6.0",
+    "maxVersion": "26.6.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -12173,7 +12212,7 @@
   },
   {
     "name": "konveyor-operator",
-    "defaultChannel": "rc",
+    "defaultChannel": "konveyor-0.9",
     "channels": [
       "alpha",
       "beta",
@@ -12269,7 +12308,8 @@
       ],
       "konveyor-0.9": [
         "0.9.0",
-        "0.9.1"
+        "0.9.1",
+        "0.9.2"
       ],
       "rc": [
         "0.3.0-rc.1",
@@ -12336,7 +12376,7 @@
       },
       "konveyor-0.9": {
         "minVersion": "0.9.0",
-        "maxVersion": "0.9.1"
+        "maxVersion": "0.9.2"
       },
       "rc": {
         "minVersion": "0.3.0-rc.1",
@@ -12423,6 +12463,7 @@
       "0.9.0-rc.3",
       "0.9.0-rc.5",
       "0.9.1",
+      "0.9.2",
       "0.9.2-rc.1"
     ],
     "minVersion": "0.1.0",
@@ -14177,28 +14218,22 @@
     ],
     "channelVersions": {
       "alpha": [
-        "0.0.4",
-        "0.0.5",
-        "0.0.6",
-        "0.0.7",
-        "0.0.8"
+        "0.0.8",
+        "0.0.9"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
-        "minVersion": "0.0.4",
-        "maxVersion": "0.0.8"
+        "minVersion": "0.0.8",
+        "maxVersion": "0.0.9"
       }
     },
     "availableVersions": [
-      "0.0.4",
-      "0.0.5",
-      "0.0.6",
-      "0.0.7",
-      "0.0.8"
+      "0.0.8",
+      "0.0.9"
     ],
-    "minVersion": "0.0.4",
-    "maxVersion": "0.0.8",
+    "minVersion": "0.0.8",
+    "maxVersion": "0.0.9",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -15051,13 +15086,15 @@
         "0.0.66",
         "0.0.67",
         "0.0.68",
-        "0.0.69"
+        "0.0.69",
+        "0.0.70",
+        "0.0.71"
       ]
     },
     "channelVersionRanges": {
       "fast": {
         "minVersion": "0.0.1",
-        "maxVersion": "0.0.69"
+        "maxVersion": "0.0.71"
       }
     },
     "availableVersions": [
@@ -15129,10 +15166,12 @@
       "0.0.66",
       "0.0.67",
       "0.0.68",
-      "0.0.69"
+      "0.0.69",
+      "0.0.70",
+      "0.0.71"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "0.0.69",
+    "maxVersion": "0.0.71",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -15307,22 +15346,24 @@
       "stable": [
         "1.9.0",
         "1.18.0",
-        "1.19.0"
+        "1.19.0",
+        "1.19.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.9.0",
-        "maxVersion": "1.19.0"
+        "maxVersion": "1.19.1"
       }
     },
     "availableVersions": [
       "1.9.0",
       "1.18.0",
-      "1.19.0"
+      "1.19.0",
+      "1.19.1"
     ],
     "minVersion": "1.9.0",
-    "maxVersion": "1.19.0",
+    "maxVersion": "1.19.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -15481,7 +15522,8 @@
         "3.10.16",
         "3.10.17",
         "3.10.18",
-        "3.10.19"
+        "3.10.19",
+        "3.10.20"
       ],
       "stable-3.11": [
         "3.11.0",
@@ -15515,7 +15557,8 @@
         "3.12.12",
         "3.12.13",
         "3.12.14",
-        "3.12.15"
+        "3.12.15",
+        "3.12.16"
       ],
       "stable-3.13": [
         "3.13.0",
@@ -15616,7 +15659,8 @@
         "3.9.16",
         "3.9.17",
         "3.9.18",
-        "3.9.19"
+        "3.9.19",
+        "3.9.20"
       ]
     },
     "channelVersionRanges": {
@@ -15638,7 +15682,7 @@
       },
       "stable-3.10": {
         "minVersion": "3.10.0",
-        "maxVersion": "3.10.19"
+        "maxVersion": "3.10.20"
       },
       "stable-3.11": {
         "minVersion": "3.11.0",
@@ -15646,7 +15690,7 @@
       },
       "stable-3.12": {
         "minVersion": "3.12.0",
-        "maxVersion": "3.12.15"
+        "maxVersion": "3.12.16"
       },
       "stable-3.13": {
         "minVersion": "3.13.0",
@@ -15682,7 +15726,7 @@
       },
       "stable-3.9": {
         "minVersion": "3.9.0",
-        "maxVersion": "3.9.19"
+        "maxVersion": "3.9.20"
       }
     },
     "availableVersions": [
@@ -15753,6 +15797,7 @@
       "3.9.17",
       "3.9.18",
       "3.9.19",
+      "3.9.20",
       "3.10.0",
       "3.10.0-nightly.20230913",
       "3.10.0-nightly.20230914",
@@ -15800,6 +15845,7 @@
       "3.10.17",
       "3.10.18",
       "3.10.19",
+      "3.10.20",
       "3.11.0",
       "3.11.1",
       "3.11.2",
@@ -15830,6 +15876,7 @@
       "3.12.13",
       "3.12.14",
       "3.12.15",
+      "3.12.16",
       "3.13.0",
       "3.13.1",
       "3.13.2",
@@ -16107,13 +16154,14 @@
         "2.18.0",
         "2.19.1",
         "2.19.2",
-        "2.20.0"
+        "2.20.0",
+        "2.20.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.14.0",
-        "maxVersion": "2.20.0"
+        "maxVersion": "2.20.1"
       }
     },
     "availableVersions": [
@@ -16137,10 +16185,11 @@
       "2.18.0",
       "2.19.1",
       "2.19.2",
-      "2.20.0"
+      "2.20.0",
+      "2.20.1"
     ],
     "minVersion": "1.14.0",
-    "maxVersion": "2.20.0",
+    "maxVersion": "2.20.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -16471,9 +16520,6 @@
     ],
     "channelVersions": {
       "1.29-nightly": [
-        "1.29.0-nightly-2026-03-31",
-        "1.29.0-nightly-2026-04-01",
-        "1.29.0-nightly-2026-04-03",
         "1.29.0-nightly-2026-04-04",
         "1.29.0-nightly-2026-04-05",
         "1.29.0-nightly-2026-04-06",
@@ -16485,7 +16531,12 @@
         "1.30.0-nightly-2026-04-10",
         "1.30.0-nightly-2026-04-11",
         "1.30.0-nightly-2026-04-12",
-        "1.30.0-nightly-2026-04-13"
+        "1.30.0-nightly-2026-04-13",
+        "1.30.0-nightly-2026-04-14",
+        "1.30.0-nightly-2026-04-15",
+        "1.30.0-nightly-2026-04-16",
+        "1.30.0-nightly-2026-04-17",
+        "1.30.0-nightly-2026-04-18"
       ],
       "candidates": [
         "0.1.0",
@@ -16543,12 +16594,12 @@
     },
     "channelVersionRanges": {
       "1.29-nightly": {
-        "minVersion": "1.29.0-nightly-2026-03-31",
+        "minVersion": "1.29.0-nightly-2026-04-04",
         "maxVersion": "1.29.0-nightly-2026-04-09"
       },
       "1.30-nightly": {
         "minVersion": "1.30.0-nightly-2026-04-10",
-        "maxVersion": "1.30.0-nightly-2026-04-13"
+        "maxVersion": "1.30.0-nightly-2026-04-18"
       },
       "candidates": {
         "minVersion": "0.1.0",
@@ -16603,9 +16654,6 @@
       "1.28.2",
       "1.28.3",
       "1.29.0",
-      "1.29.0-nightly-2026-03-31",
-      "1.29.0-nightly-2026-04-01",
-      "1.29.0-nightly-2026-04-03",
       "1.29.0-nightly-2026-04-04",
       "1.29.0-nightly-2026-04-05",
       "1.29.0-nightly-2026-04-06",
@@ -16616,10 +16664,15 @@
       "1.30.0-nightly-2026-04-10",
       "1.30.0-nightly-2026-04-11",
       "1.30.0-nightly-2026-04-12",
-      "1.30.0-nightly-2026-04-13"
+      "1.30.0-nightly-2026-04-13",
+      "1.30.0-nightly-2026-04-14",
+      "1.30.0-nightly-2026-04-15",
+      "1.30.0-nightly-2026-04-16",
+      "1.30.0-nightly-2026-04-17",
+      "1.30.0-nightly-2026-04-18"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "1.30.0-nightly-2026-04-13",
+    "maxVersion": "1.30.0-nightly-2026-04-18",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -19427,13 +19480,14 @@
         "0.8.35",
         "0.8.36",
         "0.8.37",
-        "0.8.38"
+        "0.8.38",
+        "0.8.46"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.8.38"
+        "maxVersion": "0.8.46"
       }
     },
     "availableVersions": [
@@ -19488,10 +19542,11 @@
       "0.8.35",
       "0.8.36",
       "0.8.37",
-      "0.8.38"
+      "0.8.38",
+      "0.8.46"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.8.38",
+    "maxVersion": "0.8.46",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"

--- a/catalog-data/community-operator-index/v4.20/operators.json
+++ b/catalog-data/community-operator-index/v4.20/operators.json
@@ -4793,13 +4793,14 @@
         "1.2.3",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.4.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.1.16",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.4.0"
       }
     },
     "availableVersions": [
@@ -4810,10 +4811,11 @@
       "1.2.3",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.4.0"
     ],
     "minVersion": "1.1.16",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.4.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -5018,13 +5020,14 @@
         "1.2.0",
         "1.2.1",
         "1.2.2",
-        "1.3.0"
+        "1.3.0",
+        "1.3.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.0"
+        "maxVersion": "1.3.1"
       }
     },
     "availableVersions": [
@@ -5048,10 +5051,11 @@
       "1.2.0",
       "1.2.1",
       "1.2.2",
-      "1.3.0"
+      "1.3.0",
+      "1.3.1"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.0",
+    "maxVersion": "1.3.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -5174,13 +5178,14 @@
         "1.6.0",
         "1.6.1",
         "1.6.2",
-        "1.6.3"
+        "1.6.3",
+        "1.7.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.3.0",
-        "maxVersion": "1.6.3"
+        "maxVersion": "1.7.0"
       }
     },
     "availableVersions": [
@@ -5191,10 +5196,11 @@
       "1.6.0",
       "1.6.1",
       "1.6.2",
-      "1.6.3"
+      "1.6.3",
+      "1.7.0"
     ],
     "minVersion": "1.3.0",
-    "maxVersion": "1.6.3",
+    "maxVersion": "1.7.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -6787,7 +6793,8 @@
         "0.1.2",
         "1.0.0",
         "1.1.1",
-        "1.1.2"
+        "1.1.2",
+        "1.1.3"
       ],
       "Stable": [
         "0.0.1",
@@ -6797,17 +6804,18 @@
         "0.1.2",
         "1.0.0",
         "1.1.1",
-        "1.1.2"
+        "1.1.2",
+        "1.1.3"
       ]
     },
     "channelVersionRanges": {
       "Fast": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.1.2"
+        "maxVersion": "1.1.3"
       },
       "Stable": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.1.2"
+        "maxVersion": "1.1.3"
       }
     },
     "availableVersions": [
@@ -6818,10 +6826,11 @@
       "0.1.2",
       "1.0.0",
       "1.1.1",
-      "1.1.2"
+      "1.1.2",
+      "1.1.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.1.2",
+    "maxVersion": "1.1.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -7041,7 +7050,8 @@
         "2.7.0",
         "2.8.0",
         "2.9.0",
-        "2.9.1"
+        "2.9.1",
+        "2.10.0"
       ],
       "stable": [
         "1.4.0",
@@ -7246,7 +7256,8 @@
         "2.7.0",
         "2.8.0",
         "2.9.0",
-        "2.9.1"
+        "2.9.1",
+        "2.10.0"
       ]
     },
     "channelVersionRanges": {
@@ -7256,7 +7267,7 @@
       },
       "latest": {
         "minVersion": "1.4.0",
-        "maxVersion": "2.9.1"
+        "maxVersion": "2.10.0"
       },
       "stable": {
         "minVersion": "1.4.0",
@@ -7300,7 +7311,7 @@
       },
       "stable-v2": {
         "minVersion": "1.4.0",
-        "maxVersion": "2.9.1"
+        "maxVersion": "2.10.0"
       }
     },
     "availableVersions": [
@@ -7341,10 +7352,11 @@
       "2.7.0",
       "2.8.0",
       "2.9.0",
-      "2.9.1"
+      "2.9.1",
+      "2.10.0"
     ],
     "minVersion": "1.4.0",
-    "maxVersion": "2.9.1",
+    "maxVersion": "2.10.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -8214,13 +8226,14 @@
         "0.0.9",
         "0.0.10",
         "0.0.11",
-        "0.0.12"
+        "0.0.12",
+        "0.0.13"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "0.0.12"
+        "maxVersion": "0.0.13"
       }
     },
     "availableVersions": [
@@ -8232,10 +8245,11 @@
       "0.0.9",
       "0.0.10",
       "0.0.11",
-      "0.0.12"
+      "0.0.12",
+      "0.0.13"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "0.0.12",
+    "maxVersion": "0.0.13",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -8693,13 +8707,14 @@
         "1.7.2",
         "1.7.3",
         "1.8.0",
-        "1.8.1"
+        "1.8.1",
+        "1.9.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.5.0",
-        "maxVersion": "1.8.1"
+        "maxVersion": "1.9.0"
       }
     },
     "availableVersions": [
@@ -8719,10 +8734,11 @@
       "1.7.2",
       "1.7.3",
       "1.8.0",
-      "1.8.1"
+      "1.8.1",
+      "1.9.0"
     ],
     "minVersion": "0.5.0",
-    "maxVersion": "1.8.1",
+    "maxVersion": "1.9.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -9662,13 +9678,14 @@
         "0.44.0",
         "0.45.0",
         "0.45.1",
-        "0.46.0"
+        "0.46.0",
+        "0.47.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.39.0",
-        "maxVersion": "0.46.0"
+        "maxVersion": "0.47.0"
       }
     },
     "availableVersions": [
@@ -9681,10 +9698,11 @@
       "0.44.0",
       "0.45.0",
       "0.45.1",
-      "0.46.0"
+      "0.46.0",
+      "0.47.0"
     ],
     "minVersion": "0.39.0",
-    "maxVersion": "0.46.0",
+    "maxVersion": "0.47.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -9807,7 +9825,8 @@
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.10.2",
+        "2.11.0"
       ],
       "unstable": [
         "2.6.0",
@@ -9825,17 +9844,18 @@
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.10.2",
+        "2.11.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.6.0",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       },
       "unstable": {
         "minVersion": "2.6.0",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       }
     },
     "availableVersions": [
@@ -9854,10 +9874,11 @@
       "2.9.2",
       "2.10.0",
       "2.10.1",
-      "2.10.2"
+      "2.10.2",
+      "2.11.0"
     ],
     "minVersion": "2.6.0",
-    "maxVersion": "2.10.2",
+    "maxVersion": "2.11.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -9877,13 +9898,14 @@
         "1.45.0",
         "1.46.0",
         "1.47.0",
-        "1.47.1"
+        "1.47.1",
+        "1.48.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.43.0",
-        "maxVersion": "1.47.1"
+        "maxVersion": "1.48.0"
       }
     },
     "availableVersions": [
@@ -9894,10 +9916,11 @@
       "1.45.0",
       "1.46.0",
       "1.47.0",
-      "1.47.1"
+      "1.47.1",
+      "1.48.0"
     ],
     "minVersion": "1.43.0",
-    "maxVersion": "1.47.1",
+    "maxVersion": "1.48.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -10542,38 +10565,50 @@
     "channels": [
       "stable",
       "stable-v1.13",
-      "stable-v1.13.0"
+      "stable-v1.13.0",
+      "stable-v1.13.1"
     ],
     "channelVersions": {
       "stable": [
-        "1.13.0"
+        "1.13.0",
+        "1.13.1"
       ],
       "stable-v1.13": [
-        "1.13.0"
+        "1.13.0",
+        "1.13.1"
       ],
       "stable-v1.13.0": [
         "1.13.0"
+      ],
+      "stable-v1.13.1": [
+        "1.13.0",
+        "1.13.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.13.0",
-        "maxVersion": "1.13.0"
+        "maxVersion": "1.13.1"
       },
       "stable-v1.13": {
         "minVersion": "1.13.0",
-        "maxVersion": "1.13.0"
+        "maxVersion": "1.13.1"
       },
       "stable-v1.13.0": {
         "minVersion": "1.13.0",
         "maxVersion": "1.13.0"
+      },
+      "stable-v1.13.1": {
+        "minVersion": "1.13.0",
+        "maxVersion": "1.13.1"
       }
     },
     "availableVersions": [
-      "1.13.0"
+      "1.13.0",
+      "1.13.1"
     ],
     "minVersion": "1.13.0",
-    "maxVersion": "1.13.0",
+    "maxVersion": "1.13.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -11365,7 +11400,8 @@
         "26.5.5",
         "26.5.6",
         "26.5.7",
-        "26.6.0"
+        "26.6.0",
+        "26.6.1"
       ]
     },
     "channelVersionRanges": {
@@ -11379,7 +11415,7 @@
       },
       "fast": {
         "minVersion": "20.0.0",
-        "maxVersion": "26.6.0"
+        "maxVersion": "26.6.1"
       }
     },
     "availableVersions": [
@@ -11484,10 +11520,11 @@
       "26.5.5",
       "26.5.6",
       "26.5.7",
-      "26.6.0"
+      "26.6.0",
+      "26.6.1"
     ],
     "minVersion": "14.0.0",
-    "maxVersion": "26.6.0",
+    "maxVersion": "26.6.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -11910,7 +11947,8 @@
         "0.1.4",
         "0.1.5",
         "0.1.7",
-        "0.1.8"
+        "0.1.8",
+        "0.1.9"
       ]
     },
     "channelVersionRanges": {
@@ -11928,7 +11966,7 @@
       },
       "stable-v0.1": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.1.8"
+        "maxVersion": "0.1.9"
       }
     },
     "availableVersions": [
@@ -11958,6 +11996,7 @@
       "0.1.7",
       "0.1.8",
       "0.1.8-rc.0",
+      "0.1.9",
       "0.1.9-rc.0"
     ],
     "minVersion": "0.0.4",
@@ -11968,7 +12007,7 @@
   },
   {
     "name": "konveyor-operator",
-    "defaultChannel": "rc",
+    "defaultChannel": "konveyor-0.9",
     "channels": [
       "alpha",
       "beta",
@@ -12064,7 +12103,8 @@
       ],
       "konveyor-0.9": [
         "0.9.0",
-        "0.9.1"
+        "0.9.1",
+        "0.9.2"
       ],
       "rc": [
         "0.3.0-rc.1",
@@ -12131,7 +12171,7 @@
       },
       "konveyor-0.9": {
         "minVersion": "0.9.0",
-        "maxVersion": "0.9.1"
+        "maxVersion": "0.9.2"
       },
       "rc": {
         "minVersion": "0.3.0-rc.1",
@@ -12218,6 +12258,7 @@
       "0.9.0-rc.3",
       "0.9.0-rc.5",
       "0.9.1",
+      "0.9.2",
       "0.9.2-rc.1"
     ],
     "minVersion": "0.1.0",
@@ -13935,28 +13976,22 @@
     ],
     "channelVersions": {
       "alpha": [
-        "0.0.4",
-        "0.0.5",
-        "0.0.6",
-        "0.0.7",
-        "0.0.8"
+        "0.0.8",
+        "0.0.9"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
-        "minVersion": "0.0.4",
-        "maxVersion": "0.0.8"
+        "minVersion": "0.0.8",
+        "maxVersion": "0.0.9"
       }
     },
     "availableVersions": [
-      "0.0.4",
-      "0.0.5",
-      "0.0.6",
-      "0.0.7",
-      "0.0.8"
+      "0.0.8",
+      "0.0.9"
     ],
-    "minVersion": "0.0.4",
-    "maxVersion": "0.0.8",
+    "minVersion": "0.0.8",
+    "maxVersion": "0.0.9",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -14811,13 +14846,15 @@
         "0.0.66",
         "0.0.67",
         "0.0.68",
-        "0.0.69"
+        "0.0.69",
+        "0.0.70",
+        "0.0.71"
       ]
     },
     "channelVersionRanges": {
       "fast": {
         "minVersion": "0.0.1",
-        "maxVersion": "0.0.69"
+        "maxVersion": "0.0.71"
       }
     },
     "availableVersions": [
@@ -14889,10 +14926,12 @@
       "0.0.66",
       "0.0.67",
       "0.0.68",
-      "0.0.69"
+      "0.0.69",
+      "0.0.70",
+      "0.0.71"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "0.0.69",
+    "maxVersion": "0.0.71",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -15058,21 +15097,23 @@
     "channelVersions": {
       "stable": [
         "1.9.0",
-        "1.19.0"
+        "1.19.0",
+        "1.19.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.9.0",
-        "maxVersion": "1.19.0"
+        "maxVersion": "1.19.1"
       }
     },
     "availableVersions": [
       "1.9.0",
-      "1.19.0"
+      "1.19.0",
+      "1.19.1"
     ],
     "minVersion": "1.9.0",
-    "maxVersion": "1.19.0",
+    "maxVersion": "1.19.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -15231,7 +15272,8 @@
         "3.10.16",
         "3.10.17",
         "3.10.18",
-        "3.10.19"
+        "3.10.19",
+        "3.10.20"
       ],
       "stable-3.11": [
         "3.11.0",
@@ -15265,7 +15307,8 @@
         "3.12.12",
         "3.12.13",
         "3.12.14",
-        "3.12.15"
+        "3.12.15",
+        "3.12.16"
       ],
       "stable-3.13": [
         "3.13.0",
@@ -15366,7 +15409,8 @@
         "3.9.16",
         "3.9.17",
         "3.9.18",
-        "3.9.19"
+        "3.9.19",
+        "3.9.20"
       ]
     },
     "channelVersionRanges": {
@@ -15388,7 +15432,7 @@
       },
       "stable-3.10": {
         "minVersion": "3.10.0",
-        "maxVersion": "3.10.19"
+        "maxVersion": "3.10.20"
       },
       "stable-3.11": {
         "minVersion": "3.11.0",
@@ -15396,7 +15440,7 @@
       },
       "stable-3.12": {
         "minVersion": "3.12.0",
-        "maxVersion": "3.12.15"
+        "maxVersion": "3.12.16"
       },
       "stable-3.13": {
         "minVersion": "3.13.0",
@@ -15432,7 +15476,7 @@
       },
       "stable-3.9": {
         "minVersion": "3.9.0",
-        "maxVersion": "3.9.19"
+        "maxVersion": "3.9.20"
       }
     },
     "availableVersions": [
@@ -15503,6 +15547,7 @@
       "3.9.17",
       "3.9.18",
       "3.9.19",
+      "3.9.20",
       "3.10.0",
       "3.10.0-nightly.20230913",
       "3.10.0-nightly.20230914",
@@ -15550,6 +15595,7 @@
       "3.10.17",
       "3.10.18",
       "3.10.19",
+      "3.10.20",
       "3.11.0",
       "3.11.1",
       "3.11.2",
@@ -15580,6 +15626,7 @@
       "3.12.13",
       "3.12.14",
       "3.12.15",
+      "3.12.16",
       "3.13.0",
       "3.13.1",
       "3.13.2",
@@ -15857,13 +15904,14 @@
         "2.18.0",
         "2.19.1",
         "2.19.2",
-        "2.20.0"
+        "2.20.0",
+        "2.20.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.14.0",
-        "maxVersion": "2.20.0"
+        "maxVersion": "2.20.1"
       }
     },
     "availableVersions": [
@@ -15887,10 +15935,11 @@
       "2.18.0",
       "2.19.1",
       "2.19.2",
-      "2.20.0"
+      "2.20.0",
+      "2.20.1"
     ],
     "minVersion": "1.14.0",
-    "maxVersion": "2.20.0",
+    "maxVersion": "2.20.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -16221,9 +16270,6 @@
     ],
     "channelVersions": {
       "1.29-nightly": [
-        "1.29.0-nightly-2026-03-31",
-        "1.29.0-nightly-2026-04-01",
-        "1.29.0-nightly-2026-04-03",
         "1.29.0-nightly-2026-04-04",
         "1.29.0-nightly-2026-04-05",
         "1.29.0-nightly-2026-04-06",
@@ -16235,7 +16281,12 @@
         "1.30.0-nightly-2026-04-10",
         "1.30.0-nightly-2026-04-11",
         "1.30.0-nightly-2026-04-12",
-        "1.30.0-nightly-2026-04-13"
+        "1.30.0-nightly-2026-04-13",
+        "1.30.0-nightly-2026-04-14",
+        "1.30.0-nightly-2026-04-15",
+        "1.30.0-nightly-2026-04-16",
+        "1.30.0-nightly-2026-04-17",
+        "1.30.0-nightly-2026-04-18"
       ],
       "candidates": [
         "0.1.0",
@@ -16293,12 +16344,12 @@
     },
     "channelVersionRanges": {
       "1.29-nightly": {
-        "minVersion": "1.29.0-nightly-2026-03-31",
+        "minVersion": "1.29.0-nightly-2026-04-04",
         "maxVersion": "1.29.0-nightly-2026-04-09"
       },
       "1.30-nightly": {
         "minVersion": "1.30.0-nightly-2026-04-10",
-        "maxVersion": "1.30.0-nightly-2026-04-13"
+        "maxVersion": "1.30.0-nightly-2026-04-18"
       },
       "candidates": {
         "minVersion": "0.1.0",
@@ -16353,9 +16404,6 @@
       "1.28.2",
       "1.28.3",
       "1.29.0",
-      "1.29.0-nightly-2026-03-31",
-      "1.29.0-nightly-2026-04-01",
-      "1.29.0-nightly-2026-04-03",
       "1.29.0-nightly-2026-04-04",
       "1.29.0-nightly-2026-04-05",
       "1.29.0-nightly-2026-04-06",
@@ -16366,10 +16414,15 @@
       "1.30.0-nightly-2026-04-10",
       "1.30.0-nightly-2026-04-11",
       "1.30.0-nightly-2026-04-12",
-      "1.30.0-nightly-2026-04-13"
+      "1.30.0-nightly-2026-04-13",
+      "1.30.0-nightly-2026-04-14",
+      "1.30.0-nightly-2026-04-15",
+      "1.30.0-nightly-2026-04-16",
+      "1.30.0-nightly-2026-04-17",
+      "1.30.0-nightly-2026-04-18"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "1.30.0-nightly-2026-04-13",
+    "maxVersion": "1.30.0-nightly-2026-04-18",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -19122,13 +19175,14 @@
         "0.8.35",
         "0.8.36",
         "0.8.37",
-        "0.8.38"
+        "0.8.38",
+        "0.8.46"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.8.38"
+        "maxVersion": "0.8.46"
       }
     },
     "availableVersions": [
@@ -19183,10 +19237,11 @@
       "0.8.35",
       "0.8.36",
       "0.8.37",
-      "0.8.38"
+      "0.8.38",
+      "0.8.46"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.8.38",
+    "maxVersion": "0.8.46",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"

--- a/catalog-data/community-operator-index/v4.21/catalog-info.json
+++ b/catalog-data/community-operator-index/v4.21/catalog-info.json
@@ -2,5 +2,5 @@
   "catalog_type": "community-operator-index",
   "ocp_version": "v4.21",
   "catalog_url": "registry.redhat.io/redhat/community-operator-index:v4.21",
-  "operator_count": 269
+  "operator_count": 270
 }

--- a/catalog-data/community-operator-index/v4.21/operators.json
+++ b/catalog-data/community-operator-index/v4.21/operators.json
@@ -4793,13 +4793,14 @@
         "1.2.3",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.4.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.1.16",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.4.0"
       }
     },
     "availableVersions": [
@@ -4810,10 +4811,11 @@
       "1.2.3",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.4.0"
     ],
     "minVersion": "1.1.16",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.4.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -5018,13 +5020,14 @@
         "1.2.0",
         "1.2.1",
         "1.2.2",
-        "1.3.0"
+        "1.3.0",
+        "1.3.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.0"
+        "maxVersion": "1.3.1"
       }
     },
     "availableVersions": [
@@ -5048,10 +5051,11 @@
       "1.2.0",
       "1.2.1",
       "1.2.2",
-      "1.3.0"
+      "1.3.0",
+      "1.3.1"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.0",
+    "maxVersion": "1.3.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -6747,7 +6751,8 @@
         "0.1.2",
         "1.0.0",
         "1.1.1",
-        "1.1.2"
+        "1.1.2",
+        "1.1.3"
       ],
       "Stable": [
         "0.0.1",
@@ -6757,17 +6762,18 @@
         "0.1.2",
         "1.0.0",
         "1.1.1",
-        "1.1.2"
+        "1.1.2",
+        "1.1.3"
       ]
     },
     "channelVersionRanges": {
       "Fast": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.1.2"
+        "maxVersion": "1.1.3"
       },
       "Stable": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.1.2"
+        "maxVersion": "1.1.3"
       }
     },
     "availableVersions": [
@@ -6778,10 +6784,11 @@
       "0.1.2",
       "1.0.0",
       "1.1.1",
-      "1.1.2"
+      "1.1.2",
+      "1.1.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.1.2",
+    "maxVersion": "1.1.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -7001,7 +7008,8 @@
         "2.7.0",
         "2.8.0",
         "2.9.0",
-        "2.9.1"
+        "2.9.1",
+        "2.10.0"
       ],
       "stable": [
         "1.4.0",
@@ -7206,7 +7214,8 @@
         "2.7.0",
         "2.8.0",
         "2.9.0",
-        "2.9.1"
+        "2.9.1",
+        "2.10.0"
       ]
     },
     "channelVersionRanges": {
@@ -7216,7 +7225,7 @@
       },
       "latest": {
         "minVersion": "1.4.0",
-        "maxVersion": "2.9.1"
+        "maxVersion": "2.10.0"
       },
       "stable": {
         "minVersion": "1.4.0",
@@ -7260,7 +7269,7 @@
       },
       "stable-v2": {
         "minVersion": "1.4.0",
-        "maxVersion": "2.9.1"
+        "maxVersion": "2.10.0"
       }
     },
     "availableVersions": [
@@ -7301,10 +7310,11 @@
       "2.7.0",
       "2.8.0",
       "2.9.0",
-      "2.9.1"
+      "2.9.1",
+      "2.10.0"
     ],
     "minVersion": "1.4.0",
-    "maxVersion": "2.9.1",
+    "maxVersion": "2.10.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -8136,13 +8146,14 @@
         "0.0.9",
         "0.0.10",
         "0.0.11",
-        "0.0.12"
+        "0.0.12",
+        "0.0.13"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "0.0.12"
+        "maxVersion": "0.0.13"
       }
     },
     "availableVersions": [
@@ -8154,10 +8165,11 @@
       "0.0.9",
       "0.0.10",
       "0.0.11",
-      "0.0.12"
+      "0.0.12",
+      "0.0.13"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "0.0.12",
+    "maxVersion": "0.0.13",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -8567,13 +8579,14 @@
         "1.7.2",
         "1.7.3",
         "1.8.0",
-        "1.8.1"
+        "1.8.1",
+        "1.9.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.5.0",
-        "maxVersion": "1.8.1"
+        "maxVersion": "1.9.0"
       }
     },
     "availableVersions": [
@@ -8593,10 +8606,11 @@
       "1.7.2",
       "1.7.3",
       "1.8.0",
-      "1.8.1"
+      "1.8.1",
+      "1.9.0"
     ],
     "minVersion": "0.5.0",
-    "maxVersion": "1.8.1",
+    "maxVersion": "1.9.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -9611,31 +9625,34 @@
       "stable": [
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.10.2",
+        "2.11.0"
       ],
       "unstable": [
         "2.10.0",
         "2.10.1",
-        "2.10.2"
+        "2.10.2",
+        "2.11.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.10.0",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       },
       "unstable": {
         "minVersion": "2.10.0",
-        "maxVersion": "2.10.2"
+        "maxVersion": "2.11.0"
       }
     },
     "availableVersions": [
       "2.10.0",
       "2.10.1",
-      "2.10.2"
+      "2.10.2",
+      "2.11.0"
     ],
     "minVersion": "2.10.0",
-    "maxVersion": "2.10.2",
+    "maxVersion": "2.11.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -10270,6 +10287,48 @@
     ],
     "minVersion": "0.15.0",
     "maxVersion": "0.26.0",
+    "catalog": "community-operator-index",
+    "ocpVersion": "v4.21",
+    "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
+  },
+  {
+    "name": "ibm-block-csi-operator-community",
+    "defaultChannel": "stable",
+    "channels": [
+      "stable",
+      "stable-v1.13",
+      "stable-v1.13.1"
+    ],
+    "channelVersions": {
+      "stable": [
+        "1.13.1"
+      ],
+      "stable-v1.13": [
+        "1.13.1"
+      ],
+      "stable-v1.13.1": [
+        "1.13.1"
+      ]
+    },
+    "channelVersionRanges": {
+      "stable": {
+        "minVersion": "1.13.1",
+        "maxVersion": "1.13.1"
+      },
+      "stable-v1.13": {
+        "minVersion": "1.13.1",
+        "maxVersion": "1.13.1"
+      },
+      "stable-v1.13.1": {
+        "minVersion": "1.13.1",
+        "maxVersion": "1.13.1"
+      }
+    },
+    "availableVersions": [
+      "1.13.1"
+    ],
+    "minVersion": "1.13.1",
+    "maxVersion": "1.13.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -11070,7 +11129,8 @@
         "26.5.5",
         "26.5.6",
         "26.5.7",
-        "26.6.0"
+        "26.6.0",
+        "26.6.1"
       ]
     },
     "channelVersionRanges": {
@@ -11084,7 +11144,7 @@
       },
       "fast": {
         "minVersion": "20.0.0",
-        "maxVersion": "26.6.0"
+        "maxVersion": "26.6.1"
       }
     },
     "availableVersions": [
@@ -11189,10 +11249,11 @@
       "26.5.5",
       "26.5.6",
       "26.5.7",
-      "26.6.0"
+      "26.6.0",
+      "26.6.1"
     ],
     "minVersion": "14.0.0",
-    "maxVersion": "26.6.0",
+    "maxVersion": "26.6.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -11615,7 +11676,8 @@
         "0.1.4",
         "0.1.5",
         "0.1.7",
-        "0.1.8"
+        "0.1.8",
+        "0.1.9"
       ]
     },
     "channelVersionRanges": {
@@ -11633,7 +11695,7 @@
       },
       "stable-v0.1": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.1.8"
+        "maxVersion": "0.1.9"
       }
     },
     "availableVersions": [
@@ -11663,6 +11725,7 @@
       "0.1.7",
       "0.1.8",
       "0.1.8-rc.0",
+      "0.1.9",
       "0.1.9-rc.0"
     ],
     "minVersion": "0.0.4",
@@ -11673,7 +11736,7 @@
   },
   {
     "name": "konveyor-operator",
-    "defaultChannel": "rc",
+    "defaultChannel": "konveyor-0.9",
     "channels": [
       "alpha",
       "beta",
@@ -11769,7 +11832,8 @@
       ],
       "konveyor-0.9": [
         "0.9.0",
-        "0.9.1"
+        "0.9.1",
+        "0.9.2"
       ],
       "rc": [
         "0.3.0-rc.1",
@@ -11836,7 +11900,7 @@
       },
       "konveyor-0.9": {
         "minVersion": "0.9.0",
-        "maxVersion": "0.9.1"
+        "maxVersion": "0.9.2"
       },
       "rc": {
         "minVersion": "0.3.0-rc.1",
@@ -11923,6 +11987,7 @@
       "0.9.0-rc.3",
       "0.9.0-rc.5",
       "0.9.1",
+      "0.9.2",
       "0.9.2-rc.1"
     ],
     "minVersion": "0.1.0",
@@ -13491,28 +13556,22 @@
     ],
     "channelVersions": {
       "alpha": [
-        "0.0.4",
-        "0.0.5",
-        "0.0.6",
-        "0.0.7",
-        "0.0.8"
+        "0.0.8",
+        "0.0.9"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
-        "minVersion": "0.0.4",
-        "maxVersion": "0.0.8"
+        "minVersion": "0.0.8",
+        "maxVersion": "0.0.9"
       }
     },
     "availableVersions": [
-      "0.0.4",
-      "0.0.5",
-      "0.0.6",
-      "0.0.7",
-      "0.0.8"
+      "0.0.8",
+      "0.0.9"
     ],
-    "minVersion": "0.0.4",
-    "maxVersion": "0.0.8",
+    "minVersion": "0.0.8",
+    "maxVersion": "0.0.9",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -14373,13 +14432,15 @@
         "0.0.66",
         "0.0.67",
         "0.0.68",
-        "0.0.69"
+        "0.0.69",
+        "0.0.70",
+        "0.0.71"
       ]
     },
     "channelVersionRanges": {
       "fast": {
         "minVersion": "0.0.1",
-        "maxVersion": "0.0.69"
+        "maxVersion": "0.0.71"
       }
     },
     "availableVersions": [
@@ -14451,10 +14512,12 @@
       "0.0.66",
       "0.0.67",
       "0.0.68",
-      "0.0.69"
+      "0.0.69",
+      "0.0.70",
+      "0.0.71"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "0.0.69",
+    "maxVersion": "0.0.71",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -14587,20 +14650,22 @@
     ],
     "channelVersions": {
       "stable": [
-        "1.9.0"
+        "1.9.0",
+        "1.19.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.9.0",
-        "maxVersion": "1.9.0"
+        "maxVersion": "1.19.1"
       }
     },
     "availableVersions": [
-      "1.9.0"
+      "1.9.0",
+      "1.19.1"
     ],
     "minVersion": "1.9.0",
-    "maxVersion": "1.9.0",
+    "maxVersion": "1.19.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -14759,7 +14824,8 @@
         "3.10.16",
         "3.10.17",
         "3.10.18",
-        "3.10.19"
+        "3.10.19",
+        "3.10.20"
       ],
       "stable-3.11": [
         "3.11.0",
@@ -14793,7 +14859,8 @@
         "3.12.12",
         "3.12.13",
         "3.12.14",
-        "3.12.15"
+        "3.12.15",
+        "3.12.16"
       ],
       "stable-3.13": [
         "3.13.0",
@@ -14894,7 +14961,8 @@
         "3.9.16",
         "3.9.17",
         "3.9.18",
-        "3.9.19"
+        "3.9.19",
+        "3.9.20"
       ]
     },
     "channelVersionRanges": {
@@ -14916,7 +14984,7 @@
       },
       "stable-3.10": {
         "minVersion": "3.10.0",
-        "maxVersion": "3.10.19"
+        "maxVersion": "3.10.20"
       },
       "stable-3.11": {
         "minVersion": "3.11.0",
@@ -14924,7 +14992,7 @@
       },
       "stable-3.12": {
         "minVersion": "3.12.0",
-        "maxVersion": "3.12.15"
+        "maxVersion": "3.12.16"
       },
       "stable-3.13": {
         "minVersion": "3.13.0",
@@ -14960,7 +15028,7 @@
       },
       "stable-3.9": {
         "minVersion": "3.9.0",
-        "maxVersion": "3.9.19"
+        "maxVersion": "3.9.20"
       }
     },
     "availableVersions": [
@@ -15031,6 +15099,7 @@
       "3.9.17",
       "3.9.18",
       "3.9.19",
+      "3.9.20",
       "3.10.0",
       "3.10.0-nightly.20230913",
       "3.10.0-nightly.20230914",
@@ -15078,6 +15147,7 @@
       "3.10.17",
       "3.10.18",
       "3.10.19",
+      "3.10.20",
       "3.11.0",
       "3.11.1",
       "3.11.2",
@@ -15108,6 +15178,7 @@
       "3.12.13",
       "3.12.14",
       "3.12.15",
+      "3.12.16",
       "3.13.0",
       "3.13.1",
       "3.13.2",
@@ -15385,13 +15456,14 @@
         "2.18.0",
         "2.19.1",
         "2.19.2",
-        "2.20.0"
+        "2.20.0",
+        "2.20.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.14.0",
-        "maxVersion": "2.20.0"
+        "maxVersion": "2.20.1"
       }
     },
     "availableVersions": [
@@ -15415,10 +15487,11 @@
       "2.18.0",
       "2.19.1",
       "2.19.2",
-      "2.20.0"
+      "2.20.0",
+      "2.20.1"
     ],
     "minVersion": "1.14.0",
-    "maxVersion": "2.20.0",
+    "maxVersion": "2.20.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -15749,9 +15822,6 @@
     ],
     "channelVersions": {
       "1.29-nightly": [
-        "1.29.0-nightly-2026-03-31",
-        "1.29.0-nightly-2026-04-01",
-        "1.29.0-nightly-2026-04-03",
         "1.29.0-nightly-2026-04-04",
         "1.29.0-nightly-2026-04-05",
         "1.29.0-nightly-2026-04-06",
@@ -15763,7 +15833,12 @@
         "1.30.0-nightly-2026-04-10",
         "1.30.0-nightly-2026-04-11",
         "1.30.0-nightly-2026-04-12",
-        "1.30.0-nightly-2026-04-13"
+        "1.30.0-nightly-2026-04-13",
+        "1.30.0-nightly-2026-04-14",
+        "1.30.0-nightly-2026-04-15",
+        "1.30.0-nightly-2026-04-16",
+        "1.30.0-nightly-2026-04-17",
+        "1.30.0-nightly-2026-04-18"
       ],
       "candidates": [
         "0.1.0",
@@ -15821,12 +15896,12 @@
     },
     "channelVersionRanges": {
       "1.29-nightly": {
-        "minVersion": "1.29.0-nightly-2026-03-31",
+        "minVersion": "1.29.0-nightly-2026-04-04",
         "maxVersion": "1.29.0-nightly-2026-04-09"
       },
       "1.30-nightly": {
         "minVersion": "1.30.0-nightly-2026-04-10",
-        "maxVersion": "1.30.0-nightly-2026-04-13"
+        "maxVersion": "1.30.0-nightly-2026-04-18"
       },
       "candidates": {
         "minVersion": "0.1.0",
@@ -15881,9 +15956,6 @@
       "1.28.2",
       "1.28.3",
       "1.29.0",
-      "1.29.0-nightly-2026-03-31",
-      "1.29.0-nightly-2026-04-01",
-      "1.29.0-nightly-2026-04-03",
       "1.29.0-nightly-2026-04-04",
       "1.29.0-nightly-2026-04-05",
       "1.29.0-nightly-2026-04-06",
@@ -15894,10 +15966,15 @@
       "1.30.0-nightly-2026-04-10",
       "1.30.0-nightly-2026-04-11",
       "1.30.0-nightly-2026-04-12",
-      "1.30.0-nightly-2026-04-13"
+      "1.30.0-nightly-2026-04-13",
+      "1.30.0-nightly-2026-04-14",
+      "1.30.0-nightly-2026-04-15",
+      "1.30.0-nightly-2026-04-16",
+      "1.30.0-nightly-2026-04-17",
+      "1.30.0-nightly-2026-04-18"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "1.30.0-nightly-2026-04-13",
+    "maxVersion": "1.30.0-nightly-2026-04-18",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -18468,13 +18545,14 @@
         "0.8.35",
         "0.8.36",
         "0.8.37",
-        "0.8.38"
+        "0.8.38",
+        "0.8.46"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.8.38"
+        "maxVersion": "0.8.46"
       }
     },
     "availableVersions": [
@@ -18529,10 +18607,11 @@
       "0.8.35",
       "0.8.36",
       "0.8.37",
-      "0.8.38"
+      "0.8.38",
+      "0.8.46"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.8.38",
+    "maxVersion": "0.8.46",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"

--- a/catalog-data/redhat-operator-index/v4.16/operators.json
+++ b/catalog-data/redhat-operator-index/v4.16/operators.json
@@ -140,7 +140,8 @@
         "2.13.2",
         "2.13.3",
         "2.13.4",
-        "2.13.5"
+        "2.13.5",
+        "2.13.6"
       ],
       "release-2.14": [
         "2.14.0",
@@ -163,7 +164,7 @@
       },
       "release-2.13": {
         "minVersion": "2.13.0",
-        "maxVersion": "2.13.5"
+        "maxVersion": "2.13.6"
       },
       "release-2.14": {
         "minVersion": "2.14.0",
@@ -206,6 +207,7 @@
       "2.13.3",
       "2.13.4",
       "2.13.5",
+      "2.13.6",
       "2.14.0",
       "2.14.1",
       "2.14.2"
@@ -416,9 +418,10 @@
   },
   {
     "name": "amq-broker-rhel9",
-    "defaultChannel": "7.13.x",
+    "defaultChannel": "7.14.x",
     "channels": [
-      "7.13.x"
+      "7.13.x",
+      "7.14.x"
     ],
     "channelVersions": {
       "7.13.x": [
@@ -448,13 +451,21 @@
         "7.13.4-opr-1+0.1774232950.p",
         "7.13.4-opr-1+0.1774978247.p",
         "7.13.4-opr-1+0.1775649637.p",
-        "7.13.4-opr-1+0.1775651671.p"
+        "7.13.4-opr-1+0.1775651671.p",
+        "7.13.4-opr-1+0.1776062112.p"
+      ],
+      "7.14.x": [
+        "7.14.0-opr-1"
       ]
     },
     "channelVersionRanges": {
       "7.13.x": {
         "minVersion": "7.13.0-opr-1",
-        "maxVersion": "7.13.4-opr-1+0.1775651671.p"
+        "maxVersion": "7.13.4-opr-1+0.1776062112.p"
+      },
+      "7.14.x": {
+        "minVersion": "7.14.0-opr-1",
+        "maxVersion": "7.14.0-opr-1"
       }
     },
     "availableVersions": [
@@ -484,10 +495,12 @@
       "7.13.4-opr-1+0.1774232950.p",
       "7.13.4-opr-1+0.1774978247.p",
       "7.13.4-opr-1+0.1775649637.p",
-      "7.13.4-opr-1+0.1775651671.p"
+      "7.13.4-opr-1+0.1775651671.p",
+      "7.13.4-opr-1+0.1776062112.p",
+      "7.14.0-opr-1"
     ],
     "minVersion": "7.13.0-opr-1",
-    "maxVersion": "7.13.4-opr-1+0.1775651671.p",
+    "maxVersion": "7.14.0-opr-1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -1985,13 +1998,14 @@
         "3.0.15-r1",
         "3.1.0-r1",
         "3.1.6-r1",
-        "3.1.6-r2"
+        "3.1.6-r2",
+        "3.1.6-r3"
       ]
     },
     "channelVersionRanges": {
       "3.x": {
         "minVersion": "3.0.6-beta",
-        "maxVersion": "3.1.6-r2"
+        "maxVersion": "3.1.6-r3"
       }
     },
     "availableVersions": [
@@ -2006,10 +2020,11 @@
       "3.0.15-r1",
       "3.1.0-r1",
       "3.1.6-r1",
-      "3.1.6-r2"
+      "3.1.6-r2",
+      "3.1.6-r3"
     ],
     "minVersion": "3.0.6-beta",
-    "maxVersion": "3.1.6-r2",
+    "maxVersion": "3.1.6-r3",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -2271,13 +2286,14 @@
         "8.0.6-3",
         "8.0.7-1",
         "8.0.7-2",
-        "8.0.8-1"
+        "8.0.8-1",
+        "8.0.9-1"
       ]
     },
     "channelVersionRanges": {
       "8.x-stable": {
         "minVersion": "8.0.0-1",
-        "maxVersion": "8.0.8-1"
+        "maxVersion": "8.0.9-1"
       }
     },
     "availableVersions": [
@@ -2302,10 +2318,11 @@
       "8.0.6-3",
       "8.0.7-1",
       "8.0.7-2",
-      "8.0.8-1"
+      "8.0.8-1",
+      "8.0.9-1"
     ],
     "minVersion": "8.0.0-1",
-    "maxVersion": "8.0.8-1",
+    "maxVersion": "8.0.9-1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -3171,7 +3188,8 @@
         "1.7.1",
         "1.8.0",
         "1.8.1",
-        "1.8.2"
+        "1.8.2",
+        "1.9.0"
       ]
     },
     "channelVersionRanges": {
@@ -3185,7 +3203,7 @@
       },
       "stable": {
         "minVersion": "1.4.0",
-        "maxVersion": "1.8.2"
+        "maxVersion": "1.9.0"
       }
     },
     "availableVersions": [
@@ -3202,10 +3220,11 @@
       "1.7.1",
       "1.8.0",
       "1.8.1",
-      "1.8.2"
+      "1.8.2",
+      "1.9.0"
     ],
     "minVersion": "0.1.32",
-    "maxVersion": "1.8.2",
+    "maxVersion": "1.9.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -3947,7 +3966,8 @@
         "8.5.12",
         "8.5.13",
         "8.5.14",
-        "8.6.0"
+        "8.6.0",
+        "8.6.1"
       ]
     },
     "channelVersionRanges": {
@@ -3965,7 +3985,7 @@
       },
       "stable": {
         "minVersion": "8.2.4",
-        "maxVersion": "8.6.0"
+        "maxVersion": "8.6.1"
       }
     },
     "availableVersions": [
@@ -4015,10 +4035,11 @@
       "8.5.12",
       "8.5.13",
       "8.5.14",
-      "8.6.0"
+      "8.6.0",
+      "8.6.1"
     ],
     "minVersion": "8.2.4",
-    "maxVersion": "8.6.0",
+    "maxVersion": "8.6.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -4535,13 +4556,15 @@
         "3.2.10",
         "3.2.11",
         "3.2.12",
-        "3.2.13"
+        "3.2.13",
+        "3.2.14",
+        "3.2.15"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.2.0",
-        "maxVersion": "3.2.13"
+        "maxVersion": "3.2.15"
       }
     },
     "availableVersions": [
@@ -4589,10 +4612,12 @@
       "3.2.10",
       "3.2.11",
       "3.2.12",
-      "3.2.13"
+      "3.2.13",
+      "3.2.14",
+      "3.2.15"
     ],
     "minVersion": "2.2.0",
-    "maxVersion": "3.2.13",
+    "maxVersion": "3.2.15",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -4713,6 +4738,7 @@
         "1.1.0",
         "1.1.1",
         "1.2.0",
+        "1.2.1",
         "1.3.0",
         "1.3.1",
         "1.3.2",
@@ -4727,7 +4753,8 @@
         "1.1.1"
       ],
       "stable-v1.2": [
-        "1.2.0"
+        "1.2.0",
+        "1.2.1"
       ],
       "stable-v1.3": [
         "1.3.0",
@@ -4751,7 +4778,7 @@
       },
       "stable-v1.2": {
         "minVersion": "1.2.0",
-        "maxVersion": "1.2.0"
+        "maxVersion": "1.2.1"
       },
       "stable-v1.3": {
         "minVersion": "1.3.0",
@@ -4764,6 +4791,7 @@
       "1.1.0",
       "1.1.1",
       "1.2.0",
+      "1.2.1",
       "1.3.0",
       "1.3.1",
       "1.3.2",
@@ -5054,7 +5082,8 @@
         "7.13.0+0.1773844242.p",
         "7.13.0+0.1774370015.p",
         "7.13.0+0.1775139554.p",
-        "7.13.0+0.1775735859.p"
+        "7.13.0+0.1775735859.p",
+        "7.13.0+0.1776065698.p"
       ],
       "fuse-apicurito-7.9.x": [
         "7.9.3"
@@ -5075,7 +5104,7 @@
       },
       "fuse-apicurito-7.13.x": {
         "minVersion": "7.9.3",
-        "maxVersion": "7.13.0+0.1775735859.p"
+        "maxVersion": "7.13.0+0.1776065698.p"
       },
       "fuse-apicurito-7.9.x": {
         "minVersion": "7.9.3",
@@ -5154,10 +5183,11 @@
       "7.13.0+0.1773844242.p",
       "7.13.0+0.1774370015.p",
       "7.13.0+0.1775139554.p",
-      "7.13.0+0.1775735859.p"
+      "7.13.0+0.1775735859.p",
+      "7.13.0+0.1776065698.p"
     ],
     "minVersion": "7.9.3",
-    "maxVersion": "7.13.0+0.1775735859.p",
+    "maxVersion": "7.13.0+0.1776065698.p",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -5224,7 +5254,8 @@
         "7.13.0+0.1769548641.p",
         "7.13.0+0.1771828310.p",
         "7.13.0+0.1773829909.p",
-        "7.13.0+0.1775139556.p"
+        "7.13.0+0.1775139556.p",
+        "7.13.0+0.1776065698.p"
       ],
       "7.9.x": [
         "7.9.0"
@@ -5245,7 +5276,7 @@
       },
       "7.13.x": {
         "minVersion": "7.12.1",
-        "maxVersion": "7.13.0+0.1775139556.p"
+        "maxVersion": "7.13.0+0.1776065698.p"
       },
       "7.9.x": {
         "minVersion": "7.9.0",
@@ -5297,10 +5328,11 @@
       "7.13.0+0.1769548641.p",
       "7.13.0+0.1771828310.p",
       "7.13.0+0.1773829909.p",
-      "7.13.0+0.1775139556.p"
+      "7.13.0+0.1775139556.p",
+      "7.13.0+0.1776065698.p"
     ],
     "minVersion": "7.9.0",
-    "maxVersion": "7.13.0+0.1775139556.p",
+    "maxVersion": "7.13.0+0.1776065698.p",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -6814,7 +6846,8 @@
         "2.17.2",
         "2.17.3",
         "2.17.4",
-        "2.22.1"
+        "2.22.1",
+        "2.22.2"
       ]
     },
     "channelVersionRanges": {
@@ -6824,7 +6857,7 @@
       },
       "stable": {
         "minVersion": "1.57.7",
-        "maxVersion": "2.22.1"
+        "maxVersion": "2.22.2"
       }
     },
     "availableVersions": [
@@ -6859,10 +6892,11 @@
       "2.17.2",
       "2.17.3",
       "2.17.4",
-      "2.22.1"
+      "2.22.1",
+      "2.22.2"
     ],
     "minVersion": "1.57.7",
-    "maxVersion": "2.22.1",
+    "maxVersion": "2.22.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -7025,7 +7059,8 @@
         "4.16.31",
         "4.16.33",
         "4.16.34",
-        "4.16.35"
+        "4.16.35",
+        "4.16.36"
       ],
       "stable": [
         "4.12.0",
@@ -7061,7 +7096,7 @@
     "channelVersionRanges": {
       "candidate": {
         "minVersion": "4.16.8",
-        "maxVersion": "4.16.35"
+        "maxVersion": "4.16.36"
       },
       "stable": {
         "minVersion": "4.12.0",
@@ -7119,10 +7154,11 @@
       "4.16.32",
       "4.16.33",
       "4.16.34",
-      "4.16.35"
+      "4.16.35",
+      "4.16.36"
     ],
     "minVersion": "4.12.0",
-    "maxVersion": "4.16.35",
+    "maxVersion": "4.16.36",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -7187,31 +7223,34 @@
       "alpha": [
         "1.0.8",
         "1.0.9",
-        "1.0.10"
+        "1.0.10",
+        "1.0.11"
       ],
       "stable": [
         "1.0.8",
         "1.0.9",
-        "1.0.10"
+        "1.0.10",
+        "1.0.11"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.8",
-        "maxVersion": "1.0.10"
+        "maxVersion": "1.0.11"
       },
       "stable": {
         "minVersion": "1.0.8",
-        "maxVersion": "1.0.10"
+        "maxVersion": "1.0.11"
       }
     },
     "availableVersions": [
       "1.0.8",
       "1.0.9",
-      "1.0.10"
+      "1.0.10",
+      "1.0.11"
     ],
     "minVersion": "1.0.8",
-    "maxVersion": "1.0.10",
+    "maxVersion": "1.0.11",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -8112,22 +8151,24 @@
       "tech-preview": [
         "0.0.1",
         "0.0.2",
-        "0.0.3"
+        "0.0.3",
+        "0.1.0"
       ]
     },
     "channelVersionRanges": {
       "tech-preview": {
         "minVersion": "0.0.1",
-        "maxVersion": "0.0.3"
+        "maxVersion": "0.1.0"
       }
     },
     "availableVersions": [
       "0.0.1",
       "0.0.2",
-      "0.0.3"
+      "0.0.3",
+      "0.1.0"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "0.0.3",
+    "maxVersion": "0.1.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -8671,7 +8712,8 @@
         "2.8.1",
         "2.8.2",
         "2.8.3",
-        "2.8.4"
+        "2.8.4",
+        "2.8.5"
       ],
       "stable-2.9": [
         "2.9.0",
@@ -8694,7 +8736,7 @@
       },
       "stable-2.8": {
         "minVersion": "2.8.0",
-        "maxVersion": "2.8.4"
+        "maxVersion": "2.8.5"
       },
       "stable-2.9": {
         "minVersion": "2.9.0",
@@ -8738,6 +8780,7 @@
       "2.8.2",
       "2.8.3",
       "2.8.4",
+      "2.8.5",
       "2.9.0",
       "2.9.1",
       "2.9.2"
@@ -11887,17 +11930,33 @@
   },
   {
     "name": "policy-controller-operator",
-    "defaultChannel": "tech-preview",
+    "defaultChannel": "stable",
     "channels": [
+      "stable",
+      "stable-v1.0",
       "tech-preview"
     ],
     "channelVersions": {
+      "stable": [
+        "1.0.0"
+      ],
+      "stable-v1.0": [
+        "1.0.0"
+      ],
       "tech-preview": [
         "0.0.1-techpreview",
         "0.0.2-techpreview"
       ]
     },
     "channelVersionRanges": {
+      "stable": {
+        "minVersion": "1.0.0",
+        "maxVersion": "1.0.0"
+      },
+      "stable-v1.0": {
+        "minVersion": "1.0.0",
+        "maxVersion": "1.0.0"
+      },
       "tech-preview": {
         "minVersion": "0.0.1-techpreview",
         "maxVersion": "0.0.2-techpreview"
@@ -11905,10 +11964,11 @@
     },
     "availableVersions": [
       "0.0.1-techpreview",
-      "0.0.2-techpreview"
+      "0.0.2-techpreview",
+      "1.0.0"
     ],
     "minVersion": "0.0.1-techpreview",
-    "maxVersion": "0.0.2-techpreview",
+    "maxVersion": "1.0.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -13342,7 +13402,8 @@
         "1.2.0+0.1754338551.p",
         "1.2.0+0.1754874242.p",
         "1.2.1",
-        "1.3.0"
+        "1.3.0",
+        "1.3.1"
       ],
       "stable-v1": [
         "1.0.0",
@@ -13363,7 +13424,8 @@
         "1.2.0+0.1754338551.p",
         "1.2.0+0.1754874242.p",
         "1.2.1",
-        "1.3.0"
+        "1.3.0",
+        "1.3.1"
       ],
       "stable-v1.0": [
         "1.0.0",
@@ -13375,11 +13437,11 @@
     "channelVersionRanges": {
       "latest": {
         "minVersion": "1.0.0",
-        "maxVersion": "1.3.0"
+        "maxVersion": "1.3.1"
       },
       "stable-v1": {
         "minVersion": "1.0.0",
-        "maxVersion": "1.3.0"
+        "maxVersion": "1.3.1"
       },
       "stable-v1.0": {
         "minVersion": "1.0.0",
@@ -13405,10 +13467,11 @@
       "1.2.0+0.1754338551.p",
       "1.2.0+0.1754874242.p",
       "1.2.1",
-      "1.3.0"
+      "1.3.0",
+      "1.3.1"
     ],
     "minVersion": "1.0.0",
-    "maxVersion": "1.3.0",
+    "maxVersion": "1.3.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"

--- a/catalog-data/redhat-operator-index/v4.17/operators.json
+++ b/catalog-data/redhat-operator-index/v4.17/operators.json
@@ -117,7 +117,8 @@
         "2.13.2",
         "2.13.3",
         "2.13.4",
-        "2.13.5"
+        "2.13.5",
+        "2.13.6"
       ],
       "release-2.14": [
         "2.14.0",
@@ -140,7 +141,7 @@
       },
       "release-2.13": {
         "minVersion": "2.13.0",
-        "maxVersion": "2.13.5"
+        "maxVersion": "2.13.6"
       },
       "release-2.14": {
         "minVersion": "2.14.0",
@@ -177,6 +178,7 @@
       "2.13.3",
       "2.13.4",
       "2.13.5",
+      "2.13.6",
       "2.14.0",
       "2.14.1",
       "2.14.2",
@@ -389,9 +391,10 @@
   },
   {
     "name": "amq-broker-rhel9",
-    "defaultChannel": "7.13.x",
+    "defaultChannel": "7.14.x",
     "channels": [
-      "7.13.x"
+      "7.13.x",
+      "7.14.x"
     ],
     "channelVersions": {
       "7.13.x": [
@@ -421,13 +424,21 @@
         "7.13.4-opr-1+0.1774232950.p",
         "7.13.4-opr-1+0.1774978247.p",
         "7.13.4-opr-1+0.1775649637.p",
-        "7.13.4-opr-1+0.1775651671.p"
+        "7.13.4-opr-1+0.1775651671.p",
+        "7.13.4-opr-1+0.1776062112.p"
+      ],
+      "7.14.x": [
+        "7.14.0-opr-1"
       ]
     },
     "channelVersionRanges": {
       "7.13.x": {
         "minVersion": "7.13.0-opr-1",
-        "maxVersion": "7.13.4-opr-1+0.1775651671.p"
+        "maxVersion": "7.13.4-opr-1+0.1776062112.p"
+      },
+      "7.14.x": {
+        "minVersion": "7.14.0-opr-1",
+        "maxVersion": "7.14.0-opr-1"
       }
     },
     "availableVersions": [
@@ -457,10 +468,12 @@
       "7.13.4-opr-1+0.1774232950.p",
       "7.13.4-opr-1+0.1774978247.p",
       "7.13.4-opr-1+0.1775649637.p",
-      "7.13.4-opr-1+0.1775651671.p"
+      "7.13.4-opr-1+0.1775651671.p",
+      "7.13.4-opr-1+0.1776062112.p",
+      "7.14.0-opr-1"
     ],
     "minVersion": "7.13.0-opr-1",
-    "maxVersion": "7.13.4-opr-1+0.1775651671.p",
+    "maxVersion": "7.14.0-opr-1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -1908,13 +1921,14 @@
         "3.0.15-r1",
         "3.1.0-r1",
         "3.1.6-r1",
-        "3.1.6-r2"
+        "3.1.6-r2",
+        "3.1.6-r3"
       ]
     },
     "channelVersionRanges": {
       "3.x": {
         "minVersion": "3.0.6-beta",
-        "maxVersion": "3.1.6-r2"
+        "maxVersion": "3.1.6-r3"
       }
     },
     "availableVersions": [
@@ -1929,10 +1943,11 @@
       "3.0.15-r1",
       "3.1.0-r1",
       "3.1.6-r1",
-      "3.1.6-r2"
+      "3.1.6-r2",
+      "3.1.6-r3"
     ],
     "minVersion": "3.0.6-beta",
-    "maxVersion": "3.1.6-r2",
+    "maxVersion": "3.1.6-r3",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -2212,13 +2227,14 @@
         "8.0.6-3",
         "8.0.7-1",
         "8.0.7-2",
-        "8.0.8-1"
+        "8.0.8-1",
+        "8.0.9-1"
       ]
     },
     "channelVersionRanges": {
       "8.x-stable": {
         "minVersion": "8.0.0-1",
-        "maxVersion": "8.0.8-1"
+        "maxVersion": "8.0.9-1"
       }
     },
     "availableVersions": [
@@ -2243,10 +2259,11 @@
       "8.0.6-3",
       "8.0.7-1",
       "8.0.7-2",
-      "8.0.8-1"
+      "8.0.8-1",
+      "8.0.9-1"
     ],
     "minVersion": "8.0.0-1",
-    "maxVersion": "8.0.8-1",
+    "maxVersion": "8.0.9-1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -2996,7 +3013,8 @@
         "1.7.1",
         "1.8.0",
         "1.8.1",
-        "1.8.2"
+        "1.8.2",
+        "1.9.0"
       ]
     },
     "channelVersionRanges": {
@@ -3010,7 +3028,7 @@
       },
       "stable": {
         "minVersion": "1.4.0",
-        "maxVersion": "1.8.2"
+        "maxVersion": "1.9.0"
       }
     },
     "availableVersions": [
@@ -3027,10 +3045,11 @@
       "1.7.1",
       "1.8.0",
       "1.8.1",
-      "1.8.2"
+      "1.8.2",
+      "1.9.0"
     ],
     "minVersion": "0.1.32",
-    "maxVersion": "1.8.2",
+    "maxVersion": "1.9.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -3763,7 +3782,8 @@
         "8.5.12",
         "8.5.13",
         "8.5.14",
-        "8.6.0"
+        "8.6.0",
+        "8.6.1"
       ]
     },
     "channelVersionRanges": {
@@ -3781,7 +3801,7 @@
       },
       "stable": {
         "minVersion": "8.2.4",
-        "maxVersion": "8.6.0"
+        "maxVersion": "8.6.1"
       }
     },
     "availableVersions": [
@@ -3831,10 +3851,11 @@
       "8.5.12",
       "8.5.13",
       "8.5.14",
-      "8.6.0"
+      "8.6.0",
+      "8.6.1"
     ],
     "minVersion": "8.2.4",
-    "maxVersion": "8.6.0",
+    "maxVersion": "8.6.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -4307,13 +4328,15 @@
         "3.2.10",
         "3.2.11",
         "3.2.12",
-        "3.2.13"
+        "3.2.13",
+        "3.2.14",
+        "3.2.15"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.2.0",
-        "maxVersion": "3.2.13"
+        "maxVersion": "3.2.15"
       }
     },
     "availableVersions": [
@@ -4361,10 +4384,12 @@
       "3.2.10",
       "3.2.11",
       "3.2.12",
-      "3.2.13"
+      "3.2.13",
+      "3.2.14",
+      "3.2.15"
     ],
     "minVersion": "2.2.0",
-    "maxVersion": "3.2.13",
+    "maxVersion": "3.2.15",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -4485,6 +4510,7 @@
         "1.1.0",
         "1.1.1",
         "1.2.0",
+        "1.2.1",
         "1.3.0",
         "1.3.1",
         "1.3.2",
@@ -4499,7 +4525,8 @@
         "1.1.1"
       ],
       "stable-v1.2": [
-        "1.2.0"
+        "1.2.0",
+        "1.2.1"
       ],
       "stable-v1.3": [
         "1.3.0",
@@ -4523,7 +4550,7 @@
       },
       "stable-v1.2": {
         "minVersion": "1.2.0",
-        "maxVersion": "1.2.0"
+        "maxVersion": "1.2.1"
       },
       "stable-v1.3": {
         "minVersion": "1.3.0",
@@ -4536,6 +4563,7 @@
       "1.1.0",
       "1.1.1",
       "1.2.0",
+      "1.2.1",
       "1.3.0",
       "1.3.1",
       "1.3.2",
@@ -4826,7 +4854,8 @@
         "7.13.0+0.1773844242.p",
         "7.13.0+0.1774370015.p",
         "7.13.0+0.1775139554.p",
-        "7.13.0+0.1775735859.p"
+        "7.13.0+0.1775735859.p",
+        "7.13.0+0.1776065698.p"
       ],
       "fuse-apicurito-7.9.x": [
         "7.9.3"
@@ -4847,7 +4876,7 @@
       },
       "fuse-apicurito-7.13.x": {
         "minVersion": "7.9.3",
-        "maxVersion": "7.13.0+0.1775735859.p"
+        "maxVersion": "7.13.0+0.1776065698.p"
       },
       "fuse-apicurito-7.9.x": {
         "minVersion": "7.9.3",
@@ -4926,10 +4955,11 @@
       "7.13.0+0.1773844242.p",
       "7.13.0+0.1774370015.p",
       "7.13.0+0.1775139554.p",
-      "7.13.0+0.1775735859.p"
+      "7.13.0+0.1775735859.p",
+      "7.13.0+0.1776065698.p"
     ],
     "minVersion": "7.9.3",
-    "maxVersion": "7.13.0+0.1775735859.p",
+    "maxVersion": "7.13.0+0.1776065698.p",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -4996,7 +5026,8 @@
         "7.13.0+0.1769548641.p",
         "7.13.0+0.1771828310.p",
         "7.13.0+0.1773829909.p",
-        "7.13.0+0.1775139556.p"
+        "7.13.0+0.1775139556.p",
+        "7.13.0+0.1776065698.p"
       ],
       "7.9.x": [
         "7.9.0"
@@ -5017,7 +5048,7 @@
       },
       "7.13.x": {
         "minVersion": "7.12.1",
-        "maxVersion": "7.13.0+0.1775139556.p"
+        "maxVersion": "7.13.0+0.1776065698.p"
       },
       "7.9.x": {
         "minVersion": "7.9.0",
@@ -5069,10 +5100,11 @@
       "7.13.0+0.1769548641.p",
       "7.13.0+0.1771828310.p",
       "7.13.0+0.1773829909.p",
-      "7.13.0+0.1775139556.p"
+      "7.13.0+0.1775139556.p",
+      "7.13.0+0.1776065698.p"
     ],
     "minVersion": "7.9.0",
-    "maxVersion": "7.13.0+0.1775139556.p",
+    "maxVersion": "7.13.0+0.1776065698.p",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -6327,7 +6359,8 @@
         "2.17.2",
         "2.17.3",
         "2.17.4",
-        "2.22.1"
+        "2.22.1",
+        "2.22.2"
       ]
     },
     "channelVersionRanges": {
@@ -6337,7 +6370,7 @@
       },
       "stable": {
         "minVersion": "1.57.7",
-        "maxVersion": "2.22.1"
+        "maxVersion": "2.22.2"
       }
     },
     "availableVersions": [
@@ -6372,10 +6405,11 @@
       "2.17.2",
       "2.17.3",
       "2.17.4",
-      "2.22.1"
+      "2.22.1",
+      "2.22.2"
     ],
     "minVersion": "1.57.7",
-    "maxVersion": "2.22.1",
+    "maxVersion": "2.22.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -6546,7 +6580,8 @@
         "4.17.41",
         "4.17.42",
         "4.17.43",
-        "4.17.44"
+        "4.17.44",
+        "4.17.45"
       ],
       "stable": [
         "4.12.0",
@@ -6585,7 +6620,7 @@
     "channelVersionRanges": {
       "candidate": {
         "minVersion": "4.17.6",
-        "maxVersion": "4.17.44"
+        "maxVersion": "4.17.45"
       },
       "stable": {
         "minVersion": "4.12.0",
@@ -6655,10 +6690,11 @@
       "4.17.41",
       "4.17.42",
       "4.17.43",
-      "4.17.44"
+      "4.17.44",
+      "4.17.45"
     ],
     "minVersion": "4.12.0",
-    "maxVersion": "4.17.44",
+    "maxVersion": "4.17.45",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -6714,31 +6750,34 @@
       "alpha": [
         "1.0.8",
         "1.0.9",
-        "1.0.10"
+        "1.0.10",
+        "1.0.11"
       ],
       "stable": [
         "1.0.8",
         "1.0.9",
-        "1.0.10"
+        "1.0.10",
+        "1.0.11"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.8",
-        "maxVersion": "1.0.10"
+        "maxVersion": "1.0.11"
       },
       "stable": {
         "minVersion": "1.0.8",
-        "maxVersion": "1.0.10"
+        "maxVersion": "1.0.11"
       }
     },
     "availableVersions": [
       "1.0.8",
       "1.0.9",
-      "1.0.10"
+      "1.0.10",
+      "1.0.11"
     ],
     "minVersion": "1.0.8",
-    "maxVersion": "1.0.10",
+    "maxVersion": "1.0.11",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -7482,22 +7521,24 @@
       "tech-preview": [
         "0.0.1",
         "0.0.2",
-        "0.0.3"
+        "0.0.3",
+        "0.1.0"
       ]
     },
     "channelVersionRanges": {
       "tech-preview": {
         "minVersion": "0.0.1",
-        "maxVersion": "0.0.3"
+        "maxVersion": "0.1.0"
       }
     },
     "availableVersions": [
       "0.0.1",
       "0.0.2",
-      "0.0.3"
+      "0.0.3",
+      "0.1.0"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "0.0.3",
+    "maxVersion": "0.1.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -7957,7 +7998,8 @@
         "2.8.1",
         "2.8.2",
         "2.8.3",
-        "2.8.4"
+        "2.8.4",
+        "2.8.5"
       ],
       "stable-2.9": [
         "2.9.0",
@@ -7980,7 +8022,7 @@
       },
       "stable-2.8": {
         "minVersion": "2.8.0",
-        "maxVersion": "2.8.4"
+        "maxVersion": "2.8.5"
       },
       "stable-2.9": {
         "minVersion": "2.9.0",
@@ -8013,6 +8055,7 @@
       "2.8.2",
       "2.8.3",
       "2.8.4",
+      "2.8.5",
       "2.9.0",
       "2.9.1",
       "2.9.2",
@@ -10787,17 +10830,33 @@
   },
   {
     "name": "policy-controller-operator",
-    "defaultChannel": "tech-preview",
+    "defaultChannel": "stable",
     "channels": [
+      "stable",
+      "stable-v1.0",
       "tech-preview"
     ],
     "channelVersions": {
+      "stable": [
+        "1.0.0"
+      ],
+      "stable-v1.0": [
+        "1.0.0"
+      ],
       "tech-preview": [
         "0.0.1-techpreview",
         "0.0.2-techpreview"
       ]
     },
     "channelVersionRanges": {
+      "stable": {
+        "minVersion": "1.0.0",
+        "maxVersion": "1.0.0"
+      },
+      "stable-v1.0": {
+        "minVersion": "1.0.0",
+        "maxVersion": "1.0.0"
+      },
       "tech-preview": {
         "minVersion": "0.0.1-techpreview",
         "maxVersion": "0.0.2-techpreview"
@@ -10805,10 +10864,11 @@
     },
     "availableVersions": [
       "0.0.1-techpreview",
-      "0.0.2-techpreview"
+      "0.0.2-techpreview",
+      "1.0.0"
     ],
     "minVersion": "0.0.1-techpreview",
-    "maxVersion": "0.0.2-techpreview",
+    "maxVersion": "1.0.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -12239,7 +12299,8 @@
         "1.2.0+0.1754338551.p",
         "1.2.0+0.1754874242.p",
         "1.2.1",
-        "1.3.0"
+        "1.3.0",
+        "1.3.1"
       ],
       "stable-v1": [
         "1.0.0",
@@ -12260,7 +12321,8 @@
         "1.2.0+0.1754338551.p",
         "1.2.0+0.1754874242.p",
         "1.2.1",
-        "1.3.0"
+        "1.3.0",
+        "1.3.1"
       ],
       "stable-v1.0": [
         "1.0.0",
@@ -12272,11 +12334,11 @@
     "channelVersionRanges": {
       "latest": {
         "minVersion": "1.0.0",
-        "maxVersion": "1.3.0"
+        "maxVersion": "1.3.1"
       },
       "stable-v1": {
         "minVersion": "1.0.0",
-        "maxVersion": "1.3.0"
+        "maxVersion": "1.3.1"
       },
       "stable-v1.0": {
         "minVersion": "1.0.0",
@@ -12302,10 +12364,11 @@
       "1.2.0+0.1754338551.p",
       "1.2.0+0.1754874242.p",
       "1.2.1",
-      "1.3.0"
+      "1.3.0",
+      "1.3.1"
     ],
     "minVersion": "1.0.0",
-    "maxVersion": "1.3.0",
+    "maxVersion": "1.3.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -15117,7 +15180,8 @@
       "stable",
       "stable-v1.1",
       "stable-v1.2",
-      "stable-v1.3"
+      "stable-v1.3",
+      "stable-v1.4"
     ],
     "channelVersions": {
       "stable": [
@@ -15130,7 +15194,8 @@
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.3.3"
+        "1.3.3",
+        "1.4.0"
       ],
       "stable-v1.1": [
         "1.1.0",
@@ -15147,12 +15212,15 @@
         "1.3.1",
         "1.3.2",
         "1.3.3"
+      ],
+      "stable-v1.4": [
+        "1.4.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.1.0",
-        "maxVersion": "1.3.3"
+        "maxVersion": "1.4.0"
       },
       "stable-v1.1": {
         "minVersion": "1.1.0",
@@ -15165,6 +15233,10 @@
       "stable-v1.3": {
         "minVersion": "1.3.0",
         "maxVersion": "1.3.3"
+      },
+      "stable-v1.4": {
+        "minVersion": "1.4.0",
+        "maxVersion": "1.4.0"
       }
     },
     "availableVersions": [
@@ -15177,10 +15249,11 @@
       "1.3.0",
       "1.3.1",
       "1.3.2",
-      "1.3.3"
+      "1.3.3",
+      "1.4.0"
     ],
     "minVersion": "1.1.0",
-    "maxVersion": "1.3.3",
+    "maxVersion": "1.4.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -17271,13 +17344,14 @@
         "0.4.0",
         "0.4.1",
         "0.4.2",
-        "1.0.0"
+        "1.0.0",
+        "1.1.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.2.0",
-        "maxVersion": "1.0.0"
+        "maxVersion": "1.1.0"
       }
     },
     "availableVersions": [
@@ -17286,10 +17360,11 @@
       "0.4.0",
       "0.4.1",
       "0.4.2",
-      "1.0.0"
+      "1.0.0",
+      "1.1.0"
     ],
     "minVersion": "0.2.0",
-    "maxVersion": "1.0.0",
+    "maxVersion": "1.1.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -17613,7 +17688,8 @@
       ],
       "stable": [
         "10.17.0",
-        "10.17.1"
+        "10.17.1",
+        "10.17.2"
       ]
     },
     "channelVersionRanges": {
@@ -17623,15 +17699,16 @@
       },
       "stable": {
         "minVersion": "10.17.0",
-        "maxVersion": "10.17.1"
+        "maxVersion": "10.17.2"
       }
     },
     "availableVersions": [
       "10.17.0",
-      "10.17.1"
+      "10.17.1",
+      "10.17.2"
     ],
     "minVersion": "10.17.0",
-    "maxVersion": "10.17.1",
+    "maxVersion": "10.17.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"

--- a/catalog-data/redhat-operator-index/v4.18/operators.json
+++ b/catalog-data/redhat-operator-index/v4.18/operators.json
@@ -97,7 +97,8 @@
         "2.13.2",
         "2.13.3",
         "2.13.4",
-        "2.13.5"
+        "2.13.5",
+        "2.13.6"
       ],
       "release-2.14": [
         "2.14.0",
@@ -119,7 +120,7 @@
       },
       "release-2.13": {
         "minVersion": "2.13.0",
-        "maxVersion": "2.13.5"
+        "maxVersion": "2.13.6"
       },
       "release-2.14": {
         "minVersion": "2.14.0",
@@ -150,6 +151,7 @@
       "2.13.3",
       "2.13.4",
       "2.13.5",
+      "2.13.6",
       "2.14.0",
       "2.14.1",
       "2.14.2",
@@ -363,9 +365,10 @@
   },
   {
     "name": "amq-broker-rhel9",
-    "defaultChannel": "7.13.x",
+    "defaultChannel": "7.14.x",
     "channels": [
-      "7.13.x"
+      "7.13.x",
+      "7.14.x"
     ],
     "channelVersions": {
       "7.13.x": [
@@ -395,13 +398,21 @@
         "7.13.4-opr-1+0.1774232950.p",
         "7.13.4-opr-1+0.1774978247.p",
         "7.13.4-opr-1+0.1775649637.p",
-        "7.13.4-opr-1+0.1775651671.p"
+        "7.13.4-opr-1+0.1775651671.p",
+        "7.13.4-opr-1+0.1776062112.p"
+      ],
+      "7.14.x": [
+        "7.14.0-opr-1"
       ]
     },
     "channelVersionRanges": {
       "7.13.x": {
         "minVersion": "7.13.0-opr-1",
-        "maxVersion": "7.13.4-opr-1+0.1775651671.p"
+        "maxVersion": "7.13.4-opr-1+0.1776062112.p"
+      },
+      "7.14.x": {
+        "minVersion": "7.14.0-opr-1",
+        "maxVersion": "7.14.0-opr-1"
       }
     },
     "availableVersions": [
@@ -431,10 +442,12 @@
       "7.13.4-opr-1+0.1774232950.p",
       "7.13.4-opr-1+0.1774978247.p",
       "7.13.4-opr-1+0.1775649637.p",
-      "7.13.4-opr-1+0.1775651671.p"
+      "7.13.4-opr-1+0.1775651671.p",
+      "7.13.4-opr-1+0.1776062112.p",
+      "7.14.0-opr-1"
     ],
     "minVersion": "7.13.0-opr-1",
-    "maxVersion": "7.13.4-opr-1+0.1775651671.p",
+    "maxVersion": "7.14.0-opr-1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -1803,13 +1816,14 @@
         "3.0.15-r1",
         "3.1.0-r1",
         "3.1.6-r1",
-        "3.1.6-r2"
+        "3.1.6-r2",
+        "3.1.6-r3"
       ]
     },
     "channelVersionRanges": {
       "3.x": {
         "minVersion": "3.0.6-beta",
-        "maxVersion": "3.1.6-r2"
+        "maxVersion": "3.1.6-r3"
       }
     },
     "availableVersions": [
@@ -1824,10 +1838,11 @@
       "3.0.15-r1",
       "3.1.0-r1",
       "3.1.6-r1",
-      "3.1.6-r2"
+      "3.1.6-r2",
+      "3.1.6-r3"
     ],
     "minVersion": "3.0.6-beta",
-    "maxVersion": "3.1.6-r2",
+    "maxVersion": "3.1.6-r3",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -2069,13 +2084,14 @@
         "8.0.6-3",
         "8.0.7-1",
         "8.0.7-2",
-        "8.0.8-1"
+        "8.0.8-1",
+        "8.0.9-1"
       ]
     },
     "channelVersionRanges": {
       "8.x-stable": {
         "minVersion": "8.0.0-1",
-        "maxVersion": "8.0.8-1"
+        "maxVersion": "8.0.9-1"
       }
     },
     "availableVersions": [
@@ -2100,10 +2116,11 @@
       "8.0.6-3",
       "8.0.7-1",
       "8.0.7-2",
-      "8.0.8-1"
+      "8.0.8-1",
+      "8.0.9-1"
     ],
     "minVersion": "8.0.0-1",
-    "maxVersion": "8.0.8-1",
+    "maxVersion": "8.0.9-1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -2788,7 +2805,8 @@
         "1.7.1",
         "1.8.0",
         "1.8.1",
-        "1.8.2"
+        "1.8.2",
+        "1.9.0"
       ]
     },
     "channelVersionRanges": {
@@ -2802,7 +2820,7 @@
       },
       "stable": {
         "minVersion": "1.4.0",
-        "maxVersion": "1.8.2"
+        "maxVersion": "1.9.0"
       }
     },
     "availableVersions": [
@@ -2819,10 +2837,11 @@
       "1.7.1",
       "1.8.0",
       "1.8.1",
-      "1.8.2"
+      "1.8.2",
+      "1.9.0"
     ],
     "minVersion": "0.1.32",
-    "maxVersion": "1.8.2",
+    "maxVersion": "1.9.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -3564,7 +3583,8 @@
         "8.5.12",
         "8.5.13",
         "8.5.14",
-        "8.6.0"
+        "8.6.0",
+        "8.6.1"
       ]
     },
     "channelVersionRanges": {
@@ -3582,7 +3602,7 @@
       },
       "stable": {
         "minVersion": "8.2.4",
-        "maxVersion": "8.6.0"
+        "maxVersion": "8.6.1"
       }
     },
     "availableVersions": [
@@ -3632,10 +3652,11 @@
       "8.5.12",
       "8.5.13",
       "8.5.14",
-      "8.6.0"
+      "8.6.0",
+      "8.6.1"
     ],
     "minVersion": "8.2.4",
-    "maxVersion": "8.6.0",
+    "maxVersion": "8.6.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -4084,13 +4105,15 @@
         "3.2.10",
         "3.2.11",
         "3.2.12",
-        "3.2.13"
+        "3.2.13",
+        "3.2.14",
+        "3.2.15"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.2.0",
-        "maxVersion": "3.2.13"
+        "maxVersion": "3.2.15"
       }
     },
     "availableVersions": [
@@ -4138,10 +4161,12 @@
       "3.2.10",
       "3.2.11",
       "3.2.12",
-      "3.2.13"
+      "3.2.13",
+      "3.2.14",
+      "3.2.15"
     ],
     "minVersion": "2.2.0",
-    "maxVersion": "3.2.13",
+    "maxVersion": "3.2.15",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -4260,6 +4285,7 @@
         "1.1.0",
         "1.1.1",
         "1.2.0",
+        "1.2.1",
         "1.3.0",
         "1.3.1",
         "1.3.2",
@@ -4274,7 +4300,8 @@
         "1.1.1"
       ],
       "stable-v1.2": [
-        "1.2.0"
+        "1.2.0",
+        "1.2.1"
       ],
       "stable-v1.3": [
         "1.3.0",
@@ -4298,7 +4325,7 @@
       },
       "stable-v1.2": {
         "minVersion": "1.2.0",
-        "maxVersion": "1.2.0"
+        "maxVersion": "1.2.1"
       },
       "stable-v1.3": {
         "minVersion": "1.3.0",
@@ -4311,6 +4338,7 @@
       "1.1.0",
       "1.1.1",
       "1.2.0",
+      "1.2.1",
       "1.3.0",
       "1.3.1",
       "1.3.2",
@@ -4601,7 +4629,8 @@
         "7.13.0+0.1773844242.p",
         "7.13.0+0.1774370015.p",
         "7.13.0+0.1775139554.p",
-        "7.13.0+0.1775735859.p"
+        "7.13.0+0.1775735859.p",
+        "7.13.0+0.1776065698.p"
       ],
       "fuse-apicurito-7.9.x": [
         "7.9.3"
@@ -4622,7 +4651,7 @@
       },
       "fuse-apicurito-7.13.x": {
         "minVersion": "7.9.3",
-        "maxVersion": "7.13.0+0.1775735859.p"
+        "maxVersion": "7.13.0+0.1776065698.p"
       },
       "fuse-apicurito-7.9.x": {
         "minVersion": "7.9.3",
@@ -4701,10 +4730,11 @@
       "7.13.0+0.1773844242.p",
       "7.13.0+0.1774370015.p",
       "7.13.0+0.1775139554.p",
-      "7.13.0+0.1775735859.p"
+      "7.13.0+0.1775735859.p",
+      "7.13.0+0.1776065698.p"
     ],
     "minVersion": "7.9.3",
-    "maxVersion": "7.13.0+0.1775735859.p",
+    "maxVersion": "7.13.0+0.1776065698.p",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -4771,7 +4801,8 @@
         "7.13.0+0.1769548641.p",
         "7.13.0+0.1771828310.p",
         "7.13.0+0.1773829909.p",
-        "7.13.0+0.1775139556.p"
+        "7.13.0+0.1775139556.p",
+        "7.13.0+0.1776065698.p"
       ],
       "7.9.x": [
         "7.9.0"
@@ -4792,7 +4823,7 @@
       },
       "7.13.x": {
         "minVersion": "7.12.1",
-        "maxVersion": "7.13.0+0.1775139556.p"
+        "maxVersion": "7.13.0+0.1776065698.p"
       },
       "7.9.x": {
         "minVersion": "7.9.0",
@@ -4844,10 +4875,11 @@
       "7.13.0+0.1769548641.p",
       "7.13.0+0.1771828310.p",
       "7.13.0+0.1773829909.p",
-      "7.13.0+0.1775139556.p"
+      "7.13.0+0.1775139556.p",
+      "7.13.0+0.1776065698.p"
     ],
     "minVersion": "7.9.0",
-    "maxVersion": "7.13.0+0.1775139556.p",
+    "maxVersion": "7.13.0+0.1776065698.p",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -6101,7 +6133,8 @@
         "2.17.2",
         "2.17.3",
         "2.17.4",
-        "2.22.1"
+        "2.22.1",
+        "2.22.2"
       ]
     },
     "channelVersionRanges": {
@@ -6111,7 +6144,7 @@
       },
       "stable": {
         "minVersion": "1.57.7",
-        "maxVersion": "2.22.1"
+        "maxVersion": "2.22.2"
       }
     },
     "availableVersions": [
@@ -6146,10 +6179,11 @@
       "2.17.2",
       "2.17.3",
       "2.17.4",
-      "2.22.1"
+      "2.22.1",
+      "2.22.2"
     ],
     "minVersion": "1.57.7",
-    "maxVersion": "2.22.1",
+    "maxVersion": "2.22.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -6281,7 +6315,8 @@
         "4.18.29",
         "4.18.30",
         "4.18.31",
-        "4.18.32"
+        "4.18.32",
+        "4.18.33"
       ],
       "stable": [
         "4.12.0",
@@ -6323,7 +6358,7 @@
     "channelVersionRanges": {
       "candidate": {
         "minVersion": "4.18.3",
-        "maxVersion": "4.18.32"
+        "maxVersion": "4.18.33"
       },
       "stable": {
         "minVersion": "4.12.0",
@@ -6386,10 +6421,11 @@
       "4.18.29",
       "4.18.30",
       "4.18.31",
-      "4.18.32"
+      "4.18.32",
+      "4.18.33"
     ],
     "minVersion": "4.12.0",
-    "maxVersion": "4.18.32",
+    "maxVersion": "4.18.33",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -6548,31 +6584,34 @@
       "alpha": [
         "1.0.8",
         "1.0.9",
-        "1.0.10"
+        "1.0.10",
+        "1.0.11"
       ],
       "stable": [
         "1.0.8",
         "1.0.9",
-        "1.0.10"
+        "1.0.10",
+        "1.0.11"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.8",
-        "maxVersion": "1.0.10"
+        "maxVersion": "1.0.11"
       },
       "stable": {
         "minVersion": "1.0.8",
-        "maxVersion": "1.0.10"
+        "maxVersion": "1.0.11"
       }
     },
     "availableVersions": [
       "1.0.8",
       "1.0.9",
-      "1.0.10"
+      "1.0.10",
+      "1.0.11"
     ],
     "minVersion": "1.0.8",
-    "maxVersion": "1.0.10",
+    "maxVersion": "1.0.11",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -7199,22 +7238,24 @@
       "tech-preview": [
         "0.0.1",
         "0.0.2",
-        "0.0.3"
+        "0.0.3",
+        "0.1.0"
       ]
     },
     "channelVersionRanges": {
       "tech-preview": {
         "minVersion": "0.0.1",
-        "maxVersion": "0.0.3"
+        "maxVersion": "0.1.0"
       }
     },
     "availableVersions": [
       "0.0.1",
       "0.0.2",
-      "0.0.3"
+      "0.0.3",
+      "0.1.0"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "0.0.3",
+    "maxVersion": "0.1.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -7657,7 +7698,8 @@
         "2.8.1",
         "2.8.2",
         "2.8.3",
-        "2.8.4"
+        "2.8.4",
+        "2.8.5"
       ],
       "stable-2.9": [
         "2.9.0",
@@ -7680,7 +7722,7 @@
       },
       "stable-2.8": {
         "minVersion": "2.8.0",
-        "maxVersion": "2.8.4"
+        "maxVersion": "2.8.5"
       },
       "stable-2.9": {
         "minVersion": "2.9.0",
@@ -7703,6 +7745,7 @@
       "2.8.2",
       "2.8.3",
       "2.8.4",
+      "2.8.5",
       "2.9.0",
       "2.9.1",
       "2.9.2",
@@ -10563,17 +10606,33 @@
   },
   {
     "name": "policy-controller-operator",
-    "defaultChannel": "tech-preview",
+    "defaultChannel": "stable",
     "channels": [
+      "stable",
+      "stable-v1.0",
       "tech-preview"
     ],
     "channelVersions": {
+      "stable": [
+        "1.0.0"
+      ],
+      "stable-v1.0": [
+        "1.0.0"
+      ],
       "tech-preview": [
         "0.0.1-techpreview",
         "0.0.2-techpreview"
       ]
     },
     "channelVersionRanges": {
+      "stable": {
+        "minVersion": "1.0.0",
+        "maxVersion": "1.0.0"
+      },
+      "stable-v1.0": {
+        "minVersion": "1.0.0",
+        "maxVersion": "1.0.0"
+      },
       "tech-preview": {
         "minVersion": "0.0.1-techpreview",
         "maxVersion": "0.0.2-techpreview"
@@ -10581,10 +10640,11 @@
     },
     "availableVersions": [
       "0.0.1-techpreview",
-      "0.0.2-techpreview"
+      "0.0.2-techpreview",
+      "1.0.0"
     ],
     "minVersion": "0.0.1-techpreview",
-    "maxVersion": "0.0.2-techpreview",
+    "maxVersion": "1.0.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -11947,7 +12007,8 @@
         "1.2.0+0.1754338551.p",
         "1.2.0+0.1754874242.p",
         "1.2.1",
-        "1.3.0"
+        "1.3.0",
+        "1.3.1"
       ],
       "stable-v1": [
         "1.0.0",
@@ -11968,7 +12029,8 @@
         "1.2.0+0.1754338551.p",
         "1.2.0+0.1754874242.p",
         "1.2.1",
-        "1.3.0"
+        "1.3.0",
+        "1.3.1"
       ],
       "stable-v1.0": [
         "1.0.0",
@@ -11980,11 +12042,11 @@
     "channelVersionRanges": {
       "latest": {
         "minVersion": "1.0.0",
-        "maxVersion": "1.3.0"
+        "maxVersion": "1.3.1"
       },
       "stable-v1": {
         "minVersion": "1.0.0",
-        "maxVersion": "1.3.0"
+        "maxVersion": "1.3.1"
       },
       "stable-v1.0": {
         "minVersion": "1.0.0",
@@ -12010,10 +12072,11 @@
       "1.2.0+0.1754338551.p",
       "1.2.0+0.1754874242.p",
       "1.2.1",
-      "1.3.0"
+      "1.3.0",
+      "1.3.1"
     ],
     "minVersion": "1.0.0",
-    "maxVersion": "1.3.0",
+    "maxVersion": "1.3.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -14821,7 +14884,8 @@
       "stable",
       "stable-v1.1",
       "stable-v1.2",
-      "stable-v1.3"
+      "stable-v1.3",
+      "stable-v1.4"
     ],
     "channelVersions": {
       "stable": [
@@ -14834,7 +14898,8 @@
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.3.3"
+        "1.3.3",
+        "1.4.0"
       ],
       "stable-v1.1": [
         "1.1.0",
@@ -14851,12 +14916,15 @@
         "1.3.1",
         "1.3.2",
         "1.3.3"
+      ],
+      "stable-v1.4": [
+        "1.4.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.1.0",
-        "maxVersion": "1.3.3"
+        "maxVersion": "1.4.0"
       },
       "stable-v1.1": {
         "minVersion": "1.1.0",
@@ -14869,6 +14937,10 @@
       "stable-v1.3": {
         "minVersion": "1.3.0",
         "maxVersion": "1.3.3"
+      },
+      "stable-v1.4": {
+        "minVersion": "1.4.0",
+        "maxVersion": "1.4.0"
       }
     },
     "availableVersions": [
@@ -14881,10 +14953,11 @@
       "1.3.0",
       "1.3.1",
       "1.3.2",
-      "1.3.3"
+      "1.3.3",
+      "1.4.0"
     ],
     "minVersion": "1.1.0",
-    "maxVersion": "1.3.3",
+    "maxVersion": "1.4.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -16695,12 +16768,13 @@
   },
   {
     "name": "submariner",
-    "defaultChannel": "stable-0.22",
+    "defaultChannel": "stable-0.23",
     "channels": [
       "stable-0.19",
       "stable-0.20",
       "stable-0.21",
-      "stable-0.22"
+      "stable-0.22",
+      "stable-0.23"
     ],
     "channelVersions": {
       "stable-0.19": [
@@ -16719,7 +16793,11 @@
         "0.21.2"
       ],
       "stable-0.22": [
-        "0.22.0"
+        "0.22.0",
+        "0.22.1"
+      ],
+      "stable-0.23": [
+        "0.23.1"
       ]
     },
     "channelVersionRanges": {
@@ -16737,7 +16815,11 @@
       },
       "stable-0.22": {
         "minVersion": "0.22.0",
-        "maxVersion": "0.22.0"
+        "maxVersion": "0.22.1"
+      },
+      "stable-0.23": {
+        "minVersion": "0.23.1",
+        "maxVersion": "0.23.1"
       }
     },
     "availableVersions": [
@@ -16750,10 +16832,12 @@
       "0.20.2",
       "0.21.0",
       "0.21.2",
-      "0.22.0"
+      "0.22.0",
+      "0.22.1",
+      "0.23.1"
     ],
     "minVersion": "0.19.0",
-    "maxVersion": "0.22.0",
+    "maxVersion": "0.23.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -16921,13 +17005,14 @@
         "0.4.0",
         "0.4.1",
         "0.4.2",
-        "1.0.0"
+        "1.0.0",
+        "1.1.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.2.0",
-        "maxVersion": "1.0.0"
+        "maxVersion": "1.1.0"
       }
     },
     "availableVersions": [
@@ -16936,10 +17021,11 @@
       "0.4.0",
       "0.4.1",
       "0.4.2",
-      "1.0.0"
+      "1.0.0",
+      "1.1.0"
     ],
     "minVersion": "0.2.0",
-    "maxVersion": "1.0.0",
+    "maxVersion": "1.1.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"

--- a/catalog-data/redhat-operator-index/v4.19/operators.json
+++ b/catalog-data/redhat-operator-index/v4.19/operators.json
@@ -83,7 +83,8 @@
         "2.13.2",
         "2.13.3",
         "2.13.4",
-        "2.13.5"
+        "2.13.5",
+        "2.13.6"
       ],
       "release-2.14": [
         "2.14.0",
@@ -101,7 +102,7 @@
     "channelVersionRanges": {
       "release-2.13": {
         "minVersion": "2.13.0",
-        "maxVersion": "2.13.5"
+        "maxVersion": "2.13.6"
       },
       "release-2.14": {
         "minVersion": "2.14.0",
@@ -123,6 +124,7 @@
       "2.13.3",
       "2.13.4",
       "2.13.5",
+      "2.13.6",
       "2.14.0",
       "2.14.1",
       "2.14.2",
@@ -336,9 +338,10 @@
   },
   {
     "name": "amq-broker-rhel9",
-    "defaultChannel": "7.13.x",
+    "defaultChannel": "7.14.x",
     "channels": [
-      "7.13.x"
+      "7.13.x",
+      "7.14.x"
     ],
     "channelVersions": {
       "7.13.x": [
@@ -368,13 +371,21 @@
         "7.13.4-opr-1+0.1774232950.p",
         "7.13.4-opr-1+0.1774978247.p",
         "7.13.4-opr-1+0.1775649637.p",
-        "7.13.4-opr-1+0.1775651671.p"
+        "7.13.4-opr-1+0.1775651671.p",
+        "7.13.4-opr-1+0.1776062112.p"
+      ],
+      "7.14.x": [
+        "7.14.0-opr-1"
       ]
     },
     "channelVersionRanges": {
       "7.13.x": {
         "minVersion": "7.13.0-opr-1",
-        "maxVersion": "7.13.4-opr-1+0.1775651671.p"
+        "maxVersion": "7.13.4-opr-1+0.1776062112.p"
+      },
+      "7.14.x": {
+        "minVersion": "7.14.0-opr-1",
+        "maxVersion": "7.14.0-opr-1"
       }
     },
     "availableVersions": [
@@ -404,10 +415,12 @@
       "7.13.4-opr-1+0.1774232950.p",
       "7.13.4-opr-1+0.1774978247.p",
       "7.13.4-opr-1+0.1775649637.p",
-      "7.13.4-opr-1+0.1775651671.p"
+      "7.13.4-opr-1+0.1775651671.p",
+      "7.13.4-opr-1+0.1776062112.p",
+      "7.14.0-opr-1"
     ],
     "minVersion": "7.13.0-opr-1",
-    "maxVersion": "7.13.4-opr-1+0.1775651671.p",
+    "maxVersion": "7.14.0-opr-1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -1738,13 +1751,14 @@
         "3.0.15-r1",
         "3.1.0-r1",
         "3.1.6-r1",
-        "3.1.6-r2"
+        "3.1.6-r2",
+        "3.1.6-r3"
       ]
     },
     "channelVersionRanges": {
       "3.x": {
         "minVersion": "3.0.6-beta",
-        "maxVersion": "3.1.6-r2"
+        "maxVersion": "3.1.6-r3"
       }
     },
     "availableVersions": [
@@ -1759,10 +1773,11 @@
       "3.0.15-r1",
       "3.1.0-r1",
       "3.1.6-r1",
-      "3.1.6-r2"
+      "3.1.6-r2",
+      "3.1.6-r3"
     ],
     "minVersion": "3.0.6-beta",
-    "maxVersion": "3.1.6-r2",
+    "maxVersion": "3.1.6-r3",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -1855,13 +1870,14 @@
         "4.19.0-202602091011",
         "4.19.0-202602241916",
         "4.19.0-202603110559",
-        "4.19.0-202603250318"
+        "4.19.0-202603250318",
+        "4.19.0-202604070811"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.19.0-202506020913",
-        "maxVersion": "4.19.0-202603250318"
+        "maxVersion": "4.19.0-202604070811"
       }
     },
     "availableVersions": [
@@ -1889,10 +1905,11 @@
       "4.19.0-202602091011",
       "4.19.0-202602241916",
       "4.19.0-202603110559",
-      "4.19.0-202603250318"
+      "4.19.0-202603250318",
+      "4.19.0-202604070811"
     ],
     "minVersion": "4.19.0-202506020913",
-    "maxVersion": "4.19.0-202603250318",
+    "maxVersion": "4.19.0-202604070811",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -1996,13 +2013,14 @@
         "8.0.6-3",
         "8.0.7-1",
         "8.0.7-2",
-        "8.0.8-1"
+        "8.0.8-1",
+        "8.0.9-1"
       ]
     },
     "channelVersionRanges": {
       "8.x-stable": {
         "minVersion": "8.0.0-1",
-        "maxVersion": "8.0.8-1"
+        "maxVersion": "8.0.9-1"
       }
     },
     "availableVersions": [
@@ -2027,10 +2045,11 @@
       "8.0.6-3",
       "8.0.7-1",
       "8.0.7-2",
-      "8.0.8-1"
+      "8.0.8-1",
+      "8.0.9-1"
     ],
     "minVersion": "8.0.0-1",
-    "maxVersion": "8.0.8-1",
+    "maxVersion": "8.0.9-1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -2621,13 +2640,14 @@
         "4.19.0-202602091011",
         "4.19.0-202602241916",
         "4.19.0-202602262001",
-        "4.19.0-202603231313"
+        "4.19.0-202603231313",
+        "4.19.0-202604070811"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.19.0-202505200051",
-        "maxVersion": "4.19.0-202603231313"
+        "maxVersion": "4.19.0-202604070811"
       }
     },
     "availableVersions": [
@@ -2652,10 +2672,11 @@
       "4.19.0-202602091011",
       "4.19.0-202602241916",
       "4.19.0-202602262001",
-      "4.19.0-202603231313"
+      "4.19.0-202603231313",
+      "4.19.0-202604070811"
     ],
     "minVersion": "4.19.0-202505200051",
-    "maxVersion": "4.19.0-202603231313",
+    "maxVersion": "4.19.0-202604070811",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -2687,7 +2708,8 @@
         "1.7.1",
         "1.8.0",
         "1.8.1",
-        "1.8.2"
+        "1.8.2",
+        "1.9.0"
       ]
     },
     "channelVersionRanges": {
@@ -2701,7 +2723,7 @@
       },
       "stable": {
         "minVersion": "1.4.0",
-        "maxVersion": "1.8.2"
+        "maxVersion": "1.9.0"
       }
     },
     "availableVersions": [
@@ -2718,10 +2740,11 @@
       "1.7.1",
       "1.8.0",
       "1.8.1",
-      "1.8.2"
+      "1.8.2",
+      "1.9.0"
     ],
     "minVersion": "0.1.32",
-    "maxVersion": "1.8.2",
+    "maxVersion": "1.9.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -3489,7 +3512,8 @@
         "8.5.12",
         "8.5.13",
         "8.5.14",
-        "8.6.0"
+        "8.6.0",
+        "8.6.1"
       ]
     },
     "channelVersionRanges": {
@@ -3507,7 +3531,7 @@
       },
       "stable": {
         "minVersion": "8.2.4",
-        "maxVersion": "8.6.0"
+        "maxVersion": "8.6.1"
       }
     },
     "availableVersions": [
@@ -3557,10 +3581,11 @@
       "8.5.12",
       "8.5.13",
       "8.5.14",
-      "8.6.0"
+      "8.6.0",
+      "8.6.1"
     ],
     "minVersion": "8.2.4",
-    "maxVersion": "8.6.0",
+    "maxVersion": "8.6.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -3889,13 +3914,14 @@
         "4.19.0-202602091011",
         "4.19.0-202602251047",
         "4.19.0-202602270748",
-        "4.19.0-202603231313"
+        "4.19.0-202603231313",
+        "4.19.0-202604072219"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.19.0-202506020743",
-        "maxVersion": "4.19.0-202603231313"
+        "maxVersion": "4.19.0-202604072219"
       }
     },
     "availableVersions": [
@@ -3921,10 +3947,11 @@
       "4.19.0-202602091011",
       "4.19.0-202602251047",
       "4.19.0-202602270748",
-      "4.19.0-202603231313"
+      "4.19.0-202603231313",
+      "4.19.0-202604072219"
     ],
     "minVersion": "4.19.0-202506020743",
-    "maxVersion": "4.19.0-202603231313",
+    "maxVersion": "4.19.0-202604072219",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -3981,13 +4008,15 @@
         "3.2.10",
         "3.2.11",
         "3.2.12",
-        "3.2.13"
+        "3.2.13",
+        "3.2.14",
+        "3.2.15"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.2.0",
-        "maxVersion": "3.2.13"
+        "maxVersion": "3.2.15"
       }
     },
     "availableVersions": [
@@ -4035,10 +4064,12 @@
       "3.2.10",
       "3.2.11",
       "3.2.12",
-      "3.2.13"
+      "3.2.13",
+      "3.2.14",
+      "3.2.15"
     ],
     "minVersion": "2.2.0",
-    "maxVersion": "3.2.13",
+    "maxVersion": "3.2.15",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -4060,6 +4091,7 @@
         "1.1.0",
         "1.1.1",
         "1.2.0",
+        "1.2.1",
         "1.3.0",
         "1.3.1",
         "1.3.2",
@@ -4074,7 +4106,8 @@
         "1.1.1"
       ],
       "stable-v1.2": [
-        "1.2.0"
+        "1.2.0",
+        "1.2.1"
       ],
       "stable-v1.3": [
         "1.3.0",
@@ -4098,7 +4131,7 @@
       },
       "stable-v1.2": {
         "minVersion": "1.2.0",
-        "maxVersion": "1.2.0"
+        "maxVersion": "1.2.1"
       },
       "stable-v1.3": {
         "minVersion": "1.3.0",
@@ -4111,6 +4144,7 @@
       "1.1.0",
       "1.1.1",
       "1.2.0",
+      "1.2.1",
       "1.3.0",
       "1.3.1",
       "1.3.2",
@@ -4401,7 +4435,8 @@
         "7.13.0+0.1773844242.p",
         "7.13.0+0.1774370015.p",
         "7.13.0+0.1775139554.p",
-        "7.13.0+0.1775735859.p"
+        "7.13.0+0.1775735859.p",
+        "7.13.0+0.1776065698.p"
       ],
       "fuse-apicurito-7.9.x": [
         "7.9.3"
@@ -4422,7 +4457,7 @@
       },
       "fuse-apicurito-7.13.x": {
         "minVersion": "7.9.3",
-        "maxVersion": "7.13.0+0.1775735859.p"
+        "maxVersion": "7.13.0+0.1776065698.p"
       },
       "fuse-apicurito-7.9.x": {
         "minVersion": "7.9.3",
@@ -4501,10 +4536,11 @@
       "7.13.0+0.1773844242.p",
       "7.13.0+0.1774370015.p",
       "7.13.0+0.1775139554.p",
-      "7.13.0+0.1775735859.p"
+      "7.13.0+0.1775735859.p",
+      "7.13.0+0.1776065698.p"
     ],
     "minVersion": "7.9.3",
-    "maxVersion": "7.13.0+0.1775735859.p",
+    "maxVersion": "7.13.0+0.1776065698.p",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -4571,7 +4607,8 @@
         "7.13.0+0.1769548641.p",
         "7.13.0+0.1771828310.p",
         "7.13.0+0.1773829909.p",
-        "7.13.0+0.1775139556.p"
+        "7.13.0+0.1775139556.p",
+        "7.13.0+0.1776065698.p"
       ],
       "7.9.x": [
         "7.9.0"
@@ -4592,7 +4629,7 @@
       },
       "7.13.x": {
         "minVersion": "7.12.1",
-        "maxVersion": "7.13.0+0.1775139556.p"
+        "maxVersion": "7.13.0+0.1776065698.p"
       },
       "7.9.x": {
         "minVersion": "7.9.0",
@@ -4644,10 +4681,11 @@
       "7.13.0+0.1769548641.p",
       "7.13.0+0.1771828310.p",
       "7.13.0+0.1773829909.p",
-      "7.13.0+0.1775139556.p"
+      "7.13.0+0.1775139556.p",
+      "7.13.0+0.1776065698.p"
     ],
     "minVersion": "7.9.0",
-    "maxVersion": "7.13.0+0.1775139556.p",
+    "maxVersion": "7.13.0+0.1776065698.p",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -5207,13 +5245,14 @@
         "4.19.0-202602091011",
         "4.19.0-202602241916",
         "4.19.0-202603060017",
-        "4.19.0-202603231313"
+        "4.19.0-202603231313",
+        "4.19.0-202604070811"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.19.0-202505200051",
-        "maxVersion": "4.19.0-202603231313"
+        "maxVersion": "4.19.0-202604070811"
       }
     },
     "availableVersions": [
@@ -5237,10 +5276,11 @@
       "4.19.0-202602091011",
       "4.19.0-202602241916",
       "4.19.0-202603060017",
-      "4.19.0-202603231313"
+      "4.19.0-202603231313",
+      "4.19.0-202604070811"
     ],
     "minVersion": "4.19.0-202505200051",
-    "maxVersion": "4.19.0-202603231313",
+    "maxVersion": "4.19.0-202604070811",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -5274,13 +5314,14 @@
         "4.19.0-202602091011",
         "4.19.0-202602241916",
         "4.19.0-202602262001",
-        "4.19.0-202603241553"
+        "4.19.0-202603241553",
+        "4.19.0-202604070811"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.19.0-202505200051",
-        "maxVersion": "4.19.0-202603241553"
+        "maxVersion": "4.19.0-202604070811"
       }
     },
     "availableVersions": [
@@ -5305,10 +5346,11 @@
       "4.19.0-202602091011",
       "4.19.0-202602241916",
       "4.19.0-202602262001",
-      "4.19.0-202603241553"
+      "4.19.0-202603241553",
+      "4.19.0-202604070811"
     ],
     "minVersion": "4.19.0-202505200051",
-    "maxVersion": "4.19.0-202603241553",
+    "maxVersion": "4.19.0-202604070811",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -5789,7 +5831,8 @@
         "2.17.2",
         "2.17.3",
         "2.17.4",
-        "2.22.1"
+        "2.22.1",
+        "2.22.2"
       ]
     },
     "channelVersionRanges": {
@@ -5799,7 +5842,7 @@
       },
       "stable": {
         "minVersion": "1.57.7",
-        "maxVersion": "2.22.1"
+        "maxVersion": "2.22.2"
       }
     },
     "availableVersions": [
@@ -5834,10 +5877,11 @@
       "2.17.2",
       "2.17.3",
       "2.17.4",
-      "2.22.1"
+      "2.22.1",
+      "2.22.2"
     ],
     "minVersion": "1.57.7",
-    "maxVersion": "2.22.1",
+    "maxVersion": "2.22.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -5872,13 +5916,14 @@
         "4.19.0-202602091011",
         "4.19.0-202602241916",
         "4.19.0-202602262001",
-        "4.19.0-202603231313"
+        "4.19.0-202603231313",
+        "4.19.0-202604072219"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.19.0-202506020913",
-        "maxVersion": "4.19.0-202603231313"
+        "maxVersion": "4.19.0-202604072219"
       }
     },
     "availableVersions": [
@@ -5904,10 +5949,11 @@
       "4.19.0-202602091011",
       "4.19.0-202602241916",
       "4.19.0-202602262001",
-      "4.19.0-202603231313"
+      "4.19.0-202603231313",
+      "4.19.0-202604072219"
     ],
     "minVersion": "4.19.0-202506020913",
-    "maxVersion": "4.19.0-202603231313",
+    "maxVersion": "4.19.0-202604072219",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -5940,7 +5986,8 @@
         "4.19.17",
         "4.19.18",
         "4.19.19",
-        "4.19.20"
+        "4.19.20",
+        "4.19.21"
       ],
       "stable": [
         "4.12.0",
@@ -5977,17 +6024,18 @@
         "4.19.6",
         "4.19.12",
         "4.19.15",
-        "4.19.18"
+        "4.19.18",
+        "4.19.19"
       ]
     },
     "channelVersionRanges": {
       "candidate": {
         "minVersion": "4.19.1",
-        "maxVersion": "4.19.20"
+        "maxVersion": "4.19.21"
       },
       "stable": {
         "minVersion": "4.12.0",
-        "maxVersion": "4.19.18"
+        "maxVersion": "4.19.19"
       }
     },
     "availableVersions": [
@@ -6039,10 +6087,11 @@
       "4.19.17",
       "4.19.18",
       "4.19.19",
-      "4.19.20"
+      "4.19.20",
+      "4.19.21"
     ],
     "minVersion": "4.12.0",
-    "maxVersion": "4.19.20",
+    "maxVersion": "4.19.21",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -6201,31 +6250,34 @@
       "alpha": [
         "1.0.8",
         "1.0.9",
-        "1.0.10"
+        "1.0.10",
+        "1.0.11"
       ],
       "stable": [
         "1.0.8",
         "1.0.9",
-        "1.0.10"
+        "1.0.10",
+        "1.0.11"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.8",
-        "maxVersion": "1.0.10"
+        "maxVersion": "1.0.11"
       },
       "stable": {
         "minVersion": "1.0.8",
-        "maxVersion": "1.0.10"
+        "maxVersion": "1.0.11"
       }
     },
     "availableVersions": [
       "1.0.8",
       "1.0.9",
-      "1.0.10"
+      "1.0.10",
+      "1.0.11"
     ],
     "minVersion": "1.0.8",
-    "maxVersion": "1.0.10",
+    "maxVersion": "1.0.11",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -6293,13 +6345,14 @@
         "4.19.0-202602091011",
         "4.19.0-202602241916",
         "4.19.0-202602262001",
-        "4.19.0-202603231313"
+        "4.19.0-202603231313",
+        "4.19.0-202604070811"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.19.0-202505210330",
-        "maxVersion": "4.19.0-202603231313"
+        "maxVersion": "4.19.0-202604070811"
       }
     },
     "availableVersions": [
@@ -6324,10 +6377,11 @@
       "4.19.0-202602091011",
       "4.19.0-202602241916",
       "4.19.0-202602262001",
-      "4.19.0-202603231313"
+      "4.19.0-202603231313",
+      "4.19.0-202604070811"
     ],
     "minVersion": "4.19.0-202505210330",
-    "maxVersion": "4.19.0-202603231313",
+    "maxVersion": "4.19.0-202604070811",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -6733,13 +6787,14 @@
         "4.19.0-202602091011",
         "4.19.0-202602251047",
         "4.19.0-202602262001",
-        "4.19.0-202603231313"
+        "4.19.0-202603231313",
+        "4.19.0-202604072219"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.19.0-202505201714",
-        "maxVersion": "4.19.0-202603231313"
+        "maxVersion": "4.19.0-202604072219"
       }
     },
     "availableVersions": [
@@ -6766,10 +6821,11 @@
       "4.19.0-202602091011",
       "4.19.0-202602251047",
       "4.19.0-202602262001",
-      "4.19.0-202603231313"
+      "4.19.0-202603231313",
+      "4.19.0-202604072219"
     ],
     "minVersion": "4.19.0-202505201714",
-    "maxVersion": "4.19.0-202603231313",
+    "maxVersion": "4.19.0-202604072219",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -6784,22 +6840,24 @@
       "tech-preview": [
         "0.0.1",
         "0.0.2",
-        "0.0.3"
+        "0.0.3",
+        "0.1.0"
       ]
     },
     "channelVersionRanges": {
       "tech-preview": {
         "minVersion": "0.0.1",
-        "maxVersion": "0.0.3"
+        "maxVersion": "0.1.0"
       }
     },
     "availableVersions": [
       "0.0.1",
       "0.0.2",
-      "0.0.3"
+      "0.0.3",
+      "0.1.0"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "0.0.3",
+    "maxVersion": "0.1.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -7106,7 +7164,8 @@
       "release-v2.11": [
         "2.11.0",
         "2.11.1",
-        "2.11.2"
+        "2.11.2",
+        "2.11.3"
       ],
       "release-v2.9": [
         "2.9.0",
@@ -7126,7 +7185,7 @@
       },
       "release-v2.11": {
         "minVersion": "2.11.0",
-        "maxVersion": "2.11.2"
+        "maxVersion": "2.11.3"
       },
       "release-v2.9": {
         "minVersion": "2.9.0",
@@ -7151,10 +7210,11 @@
       "2.10.6",
       "2.11.0",
       "2.11.1",
-      "2.11.2"
+      "2.11.2",
+      "2.11.3"
     ],
     "minVersion": "2.9.0",
-    "maxVersion": "2.11.2",
+    "maxVersion": "2.11.3",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -7219,7 +7279,8 @@
         "2.8.1",
         "2.8.2",
         "2.8.3",
-        "2.8.4"
+        "2.8.4",
+        "2.8.5"
       ],
       "stable-2.9": [
         "2.9.0",
@@ -7238,7 +7299,7 @@
       },
       "stable-2.8": {
         "minVersion": "2.8.0",
-        "maxVersion": "2.8.4"
+        "maxVersion": "2.8.5"
       },
       "stable-2.9": {
         "minVersion": "2.9.0",
@@ -7251,6 +7312,7 @@
       "2.8.2",
       "2.8.3",
       "2.8.4",
+      "2.8.5",
       "2.9.0",
       "2.9.1",
       "2.9.2",
@@ -7428,13 +7490,14 @@
         "4.19.0-202602091011",
         "4.19.0-202602241916",
         "4.19.0-202603041418",
-        "4.19.0-202603231313"
+        "4.19.0-202603231313",
+        "4.19.0-202604070811"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.19.0-202506021915",
-        "maxVersion": "4.19.0-202603231313"
+        "maxVersion": "4.19.0-202604070811"
       }
     },
     "availableVersions": [
@@ -7459,10 +7522,11 @@
       "4.19.0-202602091011",
       "4.19.0-202602241916",
       "4.19.0-202603041418",
-      "4.19.0-202603231313"
+      "4.19.0-202603231313",
+      "4.19.0-202604070811"
     ],
     "minVersion": "4.19.0-202506021915",
-    "maxVersion": "4.19.0-202603231313",
+    "maxVersion": "4.19.0-202604070811",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -9851,13 +9915,14 @@
         "4.19.0-202602091011",
         "4.19.0-202602241916",
         "4.19.0-202602262001",
-        "4.19.0-202603231313"
+        "4.19.0-202603231313",
+        "4.19.0-202604070811"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.19.0-202505200051",
-        "maxVersion": "4.19.0-202603231313"
+        "maxVersion": "4.19.0-202604070811"
       }
     },
     "availableVersions": [
@@ -9877,27 +9942,44 @@
       "4.19.0-202602091011",
       "4.19.0-202602241916",
       "4.19.0-202602262001",
-      "4.19.0-202603231313"
+      "4.19.0-202603231313",
+      "4.19.0-202604070811"
     ],
     "minVersion": "4.19.0-202505200051",
-    "maxVersion": "4.19.0-202603231313",
+    "maxVersion": "4.19.0-202604070811",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
   },
   {
     "name": "policy-controller-operator",
-    "defaultChannel": "tech-preview",
+    "defaultChannel": "stable",
     "channels": [
+      "stable",
+      "stable-v1.0",
       "tech-preview"
     ],
     "channelVersions": {
+      "stable": [
+        "1.0.0"
+      ],
+      "stable-v1.0": [
+        "1.0.0"
+      ],
       "tech-preview": [
         "0.0.1-techpreview",
         "0.0.2-techpreview"
       ]
     },
     "channelVersionRanges": {
+      "stable": {
+        "minVersion": "1.0.0",
+        "maxVersion": "1.0.0"
+      },
+      "stable-v1.0": {
+        "minVersion": "1.0.0",
+        "maxVersion": "1.0.0"
+      },
       "tech-preview": {
         "minVersion": "0.0.1-techpreview",
         "maxVersion": "0.0.2-techpreview"
@@ -9905,10 +9987,11 @@
     },
     "availableVersions": [
       "0.0.1-techpreview",
-      "0.0.2-techpreview"
+      "0.0.2-techpreview",
+      "1.0.0"
     ],
     "minVersion": "0.0.1-techpreview",
-    "maxVersion": "0.0.2-techpreview",
+    "maxVersion": "1.0.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -9977,13 +10060,14 @@
         "4.19.0-202602091011",
         "4.19.0-202602241916",
         "4.19.0-202603031419",
-        "4.19.0-202603231313"
+        "4.19.0-202603231313",
+        "4.19.0-202604070811"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.19.0-202505292015",
-        "maxVersion": "4.19.0-202603231313"
+        "maxVersion": "4.19.0-202604070811"
       }
     },
     "availableVersions": [
@@ -10009,10 +10093,11 @@
       "4.19.0-202602091011",
       "4.19.0-202602241916",
       "4.19.0-202603031419",
-      "4.19.0-202603231313"
+      "4.19.0-202603231313",
+      "4.19.0-202604070811"
     ],
     "minVersion": "4.19.0-202505292015",
-    "maxVersion": "4.19.0-202603231313",
+    "maxVersion": "4.19.0-202604070811",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -11241,7 +11326,8 @@
         "1.2.0+0.1754338551.p",
         "1.2.0+0.1754874242.p",
         "1.2.1",
-        "1.3.0"
+        "1.3.0",
+        "1.3.1"
       ],
       "stable-v1": [
         "1.0.0",
@@ -11262,7 +11348,8 @@
         "1.2.0+0.1754338551.p",
         "1.2.0+0.1754874242.p",
         "1.2.1",
-        "1.3.0"
+        "1.3.0",
+        "1.3.1"
       ],
       "stable-v1.0": [
         "1.0.0",
@@ -11274,11 +11361,11 @@
     "channelVersionRanges": {
       "latest": {
         "minVersion": "1.0.0",
-        "maxVersion": "1.3.0"
+        "maxVersion": "1.3.1"
       },
       "stable-v1": {
         "minVersion": "1.0.0",
-        "maxVersion": "1.3.0"
+        "maxVersion": "1.3.1"
       },
       "stable-v1.0": {
         "minVersion": "1.0.0",
@@ -11304,10 +11391,11 @@
       "1.2.0+0.1754338551.p",
       "1.2.0+0.1754874242.p",
       "1.2.1",
-      "1.3.0"
+      "1.3.0",
+      "1.3.1"
     ],
     "minVersion": "1.0.0",
-    "maxVersion": "1.3.0",
+    "maxVersion": "1.3.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -13178,7 +13266,8 @@
       "stable-2.25",
       "stable-2.8",
       "stable-3.3",
-      "stable-3.x"
+      "stable-3.x",
+      "support-required-upgrade"
     ],
     "channelVersions": {
       "3.2-exception-support": [
@@ -13736,11 +13825,16 @@
       ],
       "stable-3.3": [
         "3.3.0",
-        "3.3.1"
+        "3.3.1",
+        "3.3.2"
       ],
       "stable-3.x": [
         "3.3.0",
-        "3.3.1"
+        "3.3.1",
+        "3.3.2"
+      ],
+      "support-required-upgrade": [
+        "3.3.2"
       ]
     },
     "channelVersionRanges": {
@@ -13814,11 +13908,15 @@
       },
       "stable-3.3": {
         "minVersion": "3.3.0",
-        "maxVersion": "3.3.1"
+        "maxVersion": "3.3.2"
       },
       "stable-3.x": {
         "minVersion": "3.3.0",
-        "maxVersion": "3.3.1"
+        "maxVersion": "3.3.2"
+      },
+      "support-required-upgrade": {
+        "minVersion": "3.3.2",
+        "maxVersion": "3.3.2"
       }
     },
     "availableVersions": [
@@ -13890,6 +13988,7 @@
       "3.2.1",
       "3.3.0",
       "3.3.1",
+      "3.3.2",
       "3.4.0-ea.1"
     ],
     "minVersion": "1.20.1-8",
@@ -14154,7 +14253,8 @@
       "stable",
       "stable-v1.1",
       "stable-v1.2",
-      "stable-v1.3"
+      "stable-v1.3",
+      "stable-v1.4"
     ],
     "channelVersions": {
       "stable": [
@@ -14167,7 +14267,8 @@
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.3.3"
+        "1.3.3",
+        "1.4.0"
       ],
       "stable-v1.1": [
         "1.1.0",
@@ -14184,12 +14285,15 @@
         "1.3.1",
         "1.3.2",
         "1.3.3"
+      ],
+      "stable-v1.4": [
+        "1.4.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.1.0",
-        "maxVersion": "1.3.3"
+        "maxVersion": "1.4.0"
       },
       "stable-v1.1": {
         "minVersion": "1.1.0",
@@ -14202,6 +14306,10 @@
       "stable-v1.3": {
         "minVersion": "1.3.0",
         "maxVersion": "1.3.3"
+      },
+      "stable-v1.4": {
+        "minVersion": "1.4.0",
+        "maxVersion": "1.4.0"
       }
     },
     "availableVersions": [
@@ -14214,10 +14322,11 @@
       "1.3.0",
       "1.3.1",
       "1.3.2",
-      "1.3.3"
+      "1.3.3",
+      "1.4.0"
     ],
     "minVersion": "1.1.0",
-    "maxVersion": "1.3.3",
+    "maxVersion": "1.4.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -14486,7 +14595,8 @@
         "1.10.2",
         "1.10.3",
         "1.11.0",
-        "1.11.1"
+        "1.11.1",
+        "1.12.0"
       ],
       "stable-1.2": [
         "1.2.2"
@@ -14506,7 +14616,7 @@
       },
       "stable": {
         "minVersion": "1.5.0",
-        "maxVersion": "1.11.1"
+        "maxVersion": "1.12.0"
       },
       "stable-1.2": {
         "minVersion": "1.2.2",
@@ -14535,10 +14645,11 @@
       "1.10.2",
       "1.10.3",
       "1.11.0",
-      "1.11.1"
+      "1.11.1",
+      "1.12.0"
     ],
     "minVersion": "1.0.2",
-    "maxVersion": "1.11.1",
+    "maxVersion": "1.12.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -14571,13 +14682,14 @@
         "4.19.0-202602091011",
         "4.19.0-202602241916",
         "4.19.0-202602262001",
-        "4.19.0-202603231313"
+        "4.19.0-202603231313",
+        "4.19.0-202604070811"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.19.0-202505210330",
-        "maxVersion": "4.19.0-202603231313"
+        "maxVersion": "4.19.0-202604070811"
       }
     },
     "availableVersions": [
@@ -14601,10 +14713,11 @@
       "4.19.0-202602091011",
       "4.19.0-202602241916",
       "4.19.0-202602262001",
-      "4.19.0-202603231313"
+      "4.19.0-202603231313",
+      "4.19.0-202604070811"
     ],
     "minVersion": "4.19.0-202505210330",
-    "maxVersion": "4.19.0-202603231313",
+    "maxVersion": "4.19.0-202604070811",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -15806,13 +15919,14 @@
         "4.19.0-202602091011",
         "4.19.0-202602241916",
         "4.19.0-202602262001",
-        "4.19.0-202603231313"
+        "4.19.0-202603231313",
+        "4.19.0-202604070811"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.19.0-202505301615",
-        "maxVersion": "4.19.0-202603231313"
+        "maxVersion": "4.19.0-202604070811"
       }
     },
     "availableVersions": [
@@ -15836,10 +15950,11 @@
       "4.19.0-202602091011",
       "4.19.0-202602241916",
       "4.19.0-202602262001",
-      "4.19.0-202603231313"
+      "4.19.0-202603231313",
+      "4.19.0-202604070811"
     ],
     "minVersion": "4.19.0-202505301615",
-    "maxVersion": "4.19.0-202603231313",
+    "maxVersion": "4.19.0-202604070811",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -15875,13 +15990,14 @@
         "4.19.0-202602091011",
         "4.19.0-202602241916",
         "4.19.0-202603100922",
-        "4.19.0-202603231313"
+        "4.19.0-202603231313",
+        "4.19.0-202604072219"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.19.0-202506041351",
-        "maxVersion": "4.19.0-202603231313"
+        "maxVersion": "4.19.0-202604072219"
       }
     },
     "availableVersions": [
@@ -15908,10 +16024,11 @@
       "4.19.0-202602091011",
       "4.19.0-202602241916",
       "4.19.0-202603100922",
-      "4.19.0-202603231313"
+      "4.19.0-202603231313",
+      "4.19.0-202604072219"
     ],
     "minVersion": "4.19.0-202506041351",
-    "maxVersion": "4.19.0-202603231313",
+    "maxVersion": "4.19.0-202604072219",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -15936,7 +16053,8 @@
         "0.21.2"
       ],
       "stable-0.22": [
-        "0.22.0"
+        "0.22.0",
+        "0.22.1"
       ],
       "stable-0.23": [
         "0.23.1"
@@ -15953,7 +16071,7 @@
       },
       "stable-0.22": {
         "minVersion": "0.22.0",
-        "maxVersion": "0.22.0"
+        "maxVersion": "0.22.1"
       },
       "stable-0.23": {
         "minVersion": "0.23.1",
@@ -15967,6 +16085,7 @@
       "0.21.0",
       "0.21.2",
       "0.22.0",
+      "0.22.1",
       "0.23.1"
     ],
     "minVersion": "0.20.0",
@@ -16137,13 +16256,14 @@
         "0.4.0",
         "0.4.1",
         "0.4.2",
-        "1.0.0"
+        "1.0.0",
+        "1.1.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.3.0",
-        "maxVersion": "1.0.0"
+        "maxVersion": "1.1.0"
       }
     },
     "availableVersions": [
@@ -16151,10 +16271,11 @@
       "0.4.0",
       "0.4.1",
       "0.4.2",
-      "1.0.0"
+      "1.0.0",
+      "1.1.0"
     ],
     "minVersion": "0.3.0",
-    "maxVersion": "1.0.0",
+    "maxVersion": "1.1.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -16189,13 +16310,14 @@
         "4.19.0-202602091011",
         "4.19.0-202602241916",
         "4.19.0-202602270748",
-        "4.19.0-202603231313"
+        "4.19.0-202603231313",
+        "4.19.0-202604072219"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.19.0-202505200051",
-        "maxVersion": "4.19.0-202603231313"
+        "maxVersion": "4.19.0-202604072219"
       }
     },
     "availableVersions": [
@@ -16221,10 +16343,11 @@
       "4.19.0-202602091011",
       "4.19.0-202602241916",
       "4.19.0-202602270748",
-      "4.19.0-202603231313"
+      "4.19.0-202603231313",
+      "4.19.0-202604072219"
     ],
     "minVersion": "4.19.0-202505200051",
-    "maxVersion": "4.19.0-202603231313",
+    "maxVersion": "4.19.0-202604072219",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -16418,21 +16541,23 @@
     "channelVersions": {
       "stable": [
         "10.19.0",
-        "10.19.1"
+        "10.19.1",
+        "10.19.2"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "10.19.0",
-        "maxVersion": "10.19.1"
+        "maxVersion": "10.19.2"
       }
     },
     "availableVersions": [
       "10.19.0",
-      "10.19.1"
+      "10.19.1",
+      "10.19.2"
     ],
     "minVersion": "10.19.0",
-    "maxVersion": "10.19.1",
+    "maxVersion": "10.19.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"

--- a/catalog-data/redhat-operator-index/v4.20/operators.json
+++ b/catalog-data/redhat-operator-index/v4.20/operators.json
@@ -302,9 +302,10 @@
   },
   {
     "name": "amq-broker-rhel9",
-    "defaultChannel": "7.13.x",
+    "defaultChannel": "7.14.x",
     "channels": [
-      "7.13.x"
+      "7.13.x",
+      "7.14.x"
     ],
     "channelVersions": {
       "7.13.x": [
@@ -334,13 +335,21 @@
         "7.13.4-opr-1+0.1774232950.p",
         "7.13.4-opr-1+0.1774978247.p",
         "7.13.4-opr-1+0.1775649637.p",
-        "7.13.4-opr-1+0.1775651671.p"
+        "7.13.4-opr-1+0.1775651671.p",
+        "7.13.4-opr-1+0.1776062112.p"
+      ],
+      "7.14.x": [
+        "7.14.0-opr-1"
       ]
     },
     "channelVersionRanges": {
       "7.13.x": {
         "minVersion": "7.13.0-opr-1",
-        "maxVersion": "7.13.4-opr-1+0.1775651671.p"
+        "maxVersion": "7.13.4-opr-1+0.1776062112.p"
+      },
+      "7.14.x": {
+        "minVersion": "7.14.0-opr-1",
+        "maxVersion": "7.14.0-opr-1"
       }
     },
     "availableVersions": [
@@ -370,10 +379,12 @@
       "7.13.4-opr-1+0.1774232950.p",
       "7.13.4-opr-1+0.1774978247.p",
       "7.13.4-opr-1+0.1775649637.p",
-      "7.13.4-opr-1+0.1775651671.p"
+      "7.13.4-opr-1+0.1775651671.p",
+      "7.13.4-opr-1+0.1776062112.p",
+      "7.14.0-opr-1"
     ],
     "minVersion": "7.13.0-opr-1",
-    "maxVersion": "7.13.4-opr-1+0.1775651671.p",
+    "maxVersion": "7.14.0-opr-1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -1689,13 +1700,14 @@
         "3.0.15-r1",
         "3.1.0-r1",
         "3.1.6-r1",
-        "3.1.6-r2"
+        "3.1.6-r2",
+        "3.1.6-r3"
       ]
     },
     "channelVersionRanges": {
       "3.x": {
         "minVersion": "3.0.6-beta",
-        "maxVersion": "3.1.6-r2"
+        "maxVersion": "3.1.6-r3"
       }
     },
     "availableVersions": [
@@ -1710,10 +1722,11 @@
       "3.0.15-r1",
       "3.1.0-r1",
       "3.1.6-r1",
-      "3.1.6-r2"
+      "3.1.6-r2",
+      "3.1.6-r3"
     ],
     "minVersion": "3.0.6-beta",
-    "maxVersion": "3.1.6-r2",
+    "maxVersion": "3.1.6-r3",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -1927,13 +1940,14 @@
         "8.0.6-3",
         "8.0.7-1",
         "8.0.7-2",
-        "8.0.8-1"
+        "8.0.8-1",
+        "8.0.9-1"
       ]
     },
     "channelVersionRanges": {
       "8.x-stable": {
         "minVersion": "8.0.0-1",
-        "maxVersion": "8.0.8-1"
+        "maxVersion": "8.0.9-1"
       }
     },
     "availableVersions": [
@@ -1958,10 +1972,11 @@
       "8.0.6-3",
       "8.0.7-1",
       "8.0.7-2",
-      "8.0.8-1"
+      "8.0.8-1",
+      "8.0.9-1"
     ],
     "minVersion": "8.0.0-1",
-    "maxVersion": "8.0.8-1",
+    "maxVersion": "8.0.9-1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -2596,7 +2611,8 @@
         "1.7.1",
         "1.8.0",
         "1.8.1",
-        "1.8.2"
+        "1.8.2",
+        "1.9.0"
       ]
     },
     "channelVersionRanges": {
@@ -2610,7 +2626,7 @@
       },
       "stable": {
         "minVersion": "1.4.0",
-        "maxVersion": "1.8.2"
+        "maxVersion": "1.9.0"
       }
     },
     "availableVersions": [
@@ -2627,10 +2643,11 @@
       "1.7.1",
       "1.8.0",
       "1.8.1",
-      "1.8.2"
+      "1.8.2",
+      "1.9.0"
     ],
     "minVersion": "0.1.32",
-    "maxVersion": "1.8.2",
+    "maxVersion": "1.9.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -3372,7 +3389,8 @@
         "8.5.12",
         "8.5.13",
         "8.5.14",
-        "8.6.0"
+        "8.6.0",
+        "8.6.1"
       ]
     },
     "channelVersionRanges": {
@@ -3390,7 +3408,7 @@
       },
       "stable": {
         "minVersion": "8.2.4",
-        "maxVersion": "8.6.0"
+        "maxVersion": "8.6.1"
       }
     },
     "availableVersions": [
@@ -3440,10 +3458,11 @@
       "8.5.12",
       "8.5.13",
       "8.5.14",
-      "8.6.0"
+      "8.6.0",
+      "8.6.1"
     ],
     "minVersion": "8.2.4",
-    "maxVersion": "8.6.0",
+    "maxVersion": "8.6.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -3832,13 +3851,15 @@
         "3.2.10",
         "3.2.11",
         "3.2.12",
-        "3.2.13"
+        "3.2.13",
+        "3.2.14",
+        "3.2.15"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.2.0",
-        "maxVersion": "3.2.13"
+        "maxVersion": "3.2.15"
       }
     },
     "availableVersions": [
@@ -3886,10 +3907,12 @@
       "3.2.10",
       "3.2.11",
       "3.2.12",
-      "3.2.13"
+      "3.2.13",
+      "3.2.14",
+      "3.2.15"
     ],
     "minVersion": "2.2.0",
-    "maxVersion": "3.2.13",
+    "maxVersion": "3.2.15",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -3911,6 +3934,7 @@
         "1.1.0",
         "1.1.1",
         "1.2.0",
+        "1.2.1",
         "1.3.0",
         "1.3.1",
         "1.3.2",
@@ -3925,7 +3949,8 @@
         "1.1.1"
       ],
       "stable-v1.2": [
-        "1.2.0"
+        "1.2.0",
+        "1.2.1"
       ],
       "stable-v1.3": [
         "1.3.0",
@@ -3949,7 +3974,7 @@
       },
       "stable-v1.2": {
         "minVersion": "1.2.0",
-        "maxVersion": "1.2.0"
+        "maxVersion": "1.2.1"
       },
       "stable-v1.3": {
         "minVersion": "1.3.0",
@@ -3962,6 +3987,7 @@
       "1.1.0",
       "1.1.1",
       "1.2.0",
+      "1.2.1",
       "1.3.0",
       "1.3.1",
       "1.3.2",
@@ -4205,7 +4231,8 @@
         "7.13.0+0.1773844242.p",
         "7.13.0+0.1774370015.p",
         "7.13.0+0.1775139554.p",
-        "7.13.0+0.1775735859.p"
+        "7.13.0+0.1775735859.p",
+        "7.13.0+0.1776065698.p"
       ],
       "fuse-apicurito-7.9.x": [
         "7.9.3"
@@ -4226,7 +4253,7 @@
       },
       "fuse-apicurito-7.13.x": {
         "minVersion": "7.9.3",
-        "maxVersion": "7.13.0+0.1775735859.p"
+        "maxVersion": "7.13.0+0.1776065698.p"
       },
       "fuse-apicurito-7.9.x": {
         "minVersion": "7.9.3",
@@ -4305,10 +4332,11 @@
       "7.13.0+0.1773844242.p",
       "7.13.0+0.1774370015.p",
       "7.13.0+0.1775139554.p",
-      "7.13.0+0.1775735859.p"
+      "7.13.0+0.1775735859.p",
+      "7.13.0+0.1776065698.p"
     ],
     "minVersion": "7.9.3",
-    "maxVersion": "7.13.0+0.1775735859.p",
+    "maxVersion": "7.13.0+0.1776065698.p",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -4375,7 +4403,8 @@
         "7.13.0+0.1769548641.p",
         "7.13.0+0.1771828310.p",
         "7.13.0+0.1773829909.p",
-        "7.13.0+0.1775139556.p"
+        "7.13.0+0.1775139556.p",
+        "7.13.0+0.1776065698.p"
       ],
       "7.9.x": [
         "7.9.0"
@@ -4396,7 +4425,7 @@
       },
       "7.13.x": {
         "minVersion": "7.12.1",
-        "maxVersion": "7.13.0+0.1775139556.p"
+        "maxVersion": "7.13.0+0.1776065698.p"
       },
       "7.9.x": {
         "minVersion": "7.9.0",
@@ -4448,10 +4477,11 @@
       "7.13.0+0.1769548641.p",
       "7.13.0+0.1771828310.p",
       "7.13.0+0.1773829909.p",
-      "7.13.0+0.1775139556.p"
+      "7.13.0+0.1775139556.p",
+      "7.13.0+0.1776065698.p"
     ],
     "minVersion": "7.9.0",
-    "maxVersion": "7.13.0+0.1775139556.p",
+    "maxVersion": "7.13.0+0.1776065698.p",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -5417,7 +5447,8 @@
         "2.17.2",
         "2.17.3",
         "2.17.4",
-        "2.22.1"
+        "2.22.1",
+        "2.22.2"
       ]
     },
     "channelVersionRanges": {
@@ -5427,7 +5458,7 @@
       },
       "stable": {
         "minVersion": "1.57.7",
-        "maxVersion": "2.22.1"
+        "maxVersion": "2.22.2"
       }
     },
     "availableVersions": [
@@ -5462,10 +5493,11 @@
       "2.17.2",
       "2.17.3",
       "2.17.4",
-      "2.22.1"
+      "2.22.1",
+      "2.22.2"
     ],
     "minVersion": "1.57.7",
-    "maxVersion": "2.22.1",
+    "maxVersion": "2.22.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -5541,7 +5573,8 @@
         "4.20.8",
         "4.20.9",
         "4.20.10",
-        "4.20.11"
+        "4.20.11",
+        "4.20.12"
       ],
       "stable": [
         "4.12.0",
@@ -5586,7 +5619,7 @@
     "channelVersionRanges": {
       "candidate": {
         "minVersion": "4.20.1",
-        "maxVersion": "4.20.11"
+        "maxVersion": "4.20.12"
       },
       "stable": {
         "minVersion": "4.12.0",
@@ -5637,10 +5670,11 @@
       "4.20.8",
       "4.20.9",
       "4.20.10",
-      "4.20.11"
+      "4.20.11",
+      "4.20.12"
     ],
     "minVersion": "4.12.0",
-    "maxVersion": "4.20.11",
+    "maxVersion": "4.20.12",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -5768,31 +5802,34 @@
       "alpha": [
         "1.0.8",
         "1.0.9",
-        "1.0.10"
+        "1.0.10",
+        "1.0.11"
       ],
       "stable": [
         "1.0.8",
         "1.0.9",
-        "1.0.10"
+        "1.0.10",
+        "1.0.11"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.8",
-        "maxVersion": "1.0.10"
+        "maxVersion": "1.0.11"
       },
       "stable": {
         "minVersion": "1.0.8",
-        "maxVersion": "1.0.10"
+        "maxVersion": "1.0.11"
       }
     },
     "availableVersions": [
       "1.0.8",
       "1.0.9",
-      "1.0.10"
+      "1.0.10",
+      "1.0.11"
     ],
     "minVersion": "1.0.8",
-    "maxVersion": "1.0.10",
+    "maxVersion": "1.0.11",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -6242,22 +6279,24 @@
       "tech-preview": [
         "0.0.1",
         "0.0.2",
-        "0.0.3"
+        "0.0.3",
+        "0.1.0"
       ]
     },
     "channelVersionRanges": {
       "tech-preview": {
         "minVersion": "0.0.1",
-        "maxVersion": "0.0.3"
+        "maxVersion": "0.1.0"
       }
     },
     "availableVersions": [
       "0.0.1",
       "0.0.2",
-      "0.0.3"
+      "0.0.3",
+      "0.1.0"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "0.0.3",
+    "maxVersion": "0.1.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -6559,7 +6598,8 @@
       "release-v2.11": [
         "2.11.0",
         "2.11.1",
-        "2.11.2"
+        "2.11.2",
+        "2.11.3"
       ]
     },
     "channelVersionRanges": {
@@ -6569,7 +6609,7 @@
       },
       "release-v2.11": {
         "minVersion": "2.11.0",
-        "maxVersion": "2.11.2"
+        "maxVersion": "2.11.3"
       }
     },
     "availableVersions": [
@@ -6582,10 +6622,11 @@
       "2.10.6",
       "2.11.0",
       "2.11.1",
-      "2.11.2"
+      "2.11.2",
+      "2.11.3"
     ],
     "minVersion": "2.10.0",
-    "maxVersion": "2.11.2",
+    "maxVersion": "2.11.3",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -8939,17 +8980,33 @@
   },
   {
     "name": "policy-controller-operator",
-    "defaultChannel": "tech-preview",
+    "defaultChannel": "stable",
     "channels": [
+      "stable",
+      "stable-v1.0",
       "tech-preview"
     ],
     "channelVersions": {
+      "stable": [
+        "1.0.0"
+      ],
+      "stable-v1.0": [
+        "1.0.0"
+      ],
       "tech-preview": [
         "0.0.1-techpreview",
         "0.0.2-techpreview"
       ]
     },
     "channelVersionRanges": {
+      "stable": {
+        "minVersion": "1.0.0",
+        "maxVersion": "1.0.0"
+      },
+      "stable-v1.0": {
+        "minVersion": "1.0.0",
+        "maxVersion": "1.0.0"
+      },
       "tech-preview": {
         "minVersion": "0.0.1-techpreview",
         "maxVersion": "0.0.2-techpreview"
@@ -8957,10 +9014,11 @@
     },
     "availableVersions": [
       "0.0.1-techpreview",
-      "0.0.2-techpreview"
+      "0.0.2-techpreview",
+      "1.0.0"
     ],
     "minVersion": "0.0.1-techpreview",
-    "maxVersion": "0.0.2-techpreview",
+    "maxVersion": "1.0.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -10257,7 +10315,8 @@
         "1.2.0+0.1754338551.p",
         "1.2.0+0.1754874242.p",
         "1.2.1",
-        "1.3.0"
+        "1.3.0",
+        "1.3.1"
       ],
       "stable-v1": [
         "1.0.0",
@@ -10278,7 +10337,8 @@
         "1.2.0+0.1754338551.p",
         "1.2.0+0.1754874242.p",
         "1.2.1",
-        "1.3.0"
+        "1.3.0",
+        "1.3.1"
       ],
       "stable-v1.0": [
         "1.0.0",
@@ -10290,11 +10350,11 @@
     "channelVersionRanges": {
       "latest": {
         "minVersion": "1.0.0",
-        "maxVersion": "1.3.0"
+        "maxVersion": "1.3.1"
       },
       "stable-v1": {
         "minVersion": "1.0.0",
-        "maxVersion": "1.3.0"
+        "maxVersion": "1.3.1"
       },
       "stable-v1.0": {
         "minVersion": "1.0.0",
@@ -10320,10 +10380,11 @@
       "1.2.0+0.1754338551.p",
       "1.2.0+0.1754874242.p",
       "1.2.1",
-      "1.3.0"
+      "1.3.0",
+      "1.3.1"
     ],
     "minVersion": "1.0.0",
-    "maxVersion": "1.3.0",
+    "maxVersion": "1.3.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -12194,7 +12255,8 @@
       "stable-2.25",
       "stable-2.8",
       "stable-3.3",
-      "stable-3.x"
+      "stable-3.x",
+      "support-required-upgrade"
     ],
     "channelVersions": {
       "3.2-exception-support": [
@@ -12747,11 +12809,16 @@
       ],
       "stable-3.3": [
         "3.3.0",
-        "3.3.1"
+        "3.3.1",
+        "3.3.2"
       ],
       "stable-3.x": [
         "3.3.0",
-        "3.3.1"
+        "3.3.1",
+        "3.3.2"
+      ],
+      "support-required-upgrade": [
+        "3.3.2"
       ]
     },
     "channelVersionRanges": {
@@ -12825,11 +12892,15 @@
       },
       "stable-3.3": {
         "minVersion": "3.3.0",
-        "maxVersion": "3.3.1"
+        "maxVersion": "3.3.2"
       },
       "stable-3.x": {
         "minVersion": "3.3.0",
-        "maxVersion": "3.3.1"
+        "maxVersion": "3.3.2"
+      },
+      "support-required-upgrade": {
+        "minVersion": "3.3.2",
+        "maxVersion": "3.3.2"
       }
     },
     "availableVersions": [
@@ -12898,6 +12969,7 @@
       "3.2.1",
       "3.3.0",
       "3.3.1",
+      "3.3.2",
       "3.4.0-ea.1"
     ],
     "minVersion": "1.20.1-8",
@@ -13162,7 +13234,8 @@
       "stable",
       "stable-v1.1",
       "stable-v1.2",
-      "stable-v1.3"
+      "stable-v1.3",
+      "stable-v1.4"
     ],
     "channelVersions": {
       "stable": [
@@ -13174,7 +13247,8 @@
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.3.3"
+        "1.3.3",
+        "1.4.0"
       ],
       "stable-v1.1": [
         "1.1.0",
@@ -13190,12 +13264,15 @@
         "1.3.1",
         "1.3.2",
         "1.3.3"
+      ],
+      "stable-v1.4": [
+        "1.4.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.1.0",
-        "maxVersion": "1.3.3"
+        "maxVersion": "1.4.0"
       },
       "stable-v1.1": {
         "minVersion": "1.1.0",
@@ -13208,6 +13285,10 @@
       "stable-v1.3": {
         "minVersion": "1.3.0",
         "maxVersion": "1.3.3"
+      },
+      "stable-v1.4": {
+        "minVersion": "1.4.0",
+        "maxVersion": "1.4.0"
       }
     },
     "availableVersions": [
@@ -13219,10 +13300,11 @@
       "1.3.0",
       "1.3.1",
       "1.3.2",
-      "1.3.3"
+      "1.3.3",
+      "1.4.0"
     ],
     "minVersion": "1.1.0",
-    "maxVersion": "1.3.3",
+    "maxVersion": "1.4.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -14874,7 +14956,8 @@
         "0.21.2"
       ],
       "stable-0.22": [
-        "0.22.0"
+        "0.22.0",
+        "0.22.1"
       ],
       "stable-0.23": [
         "0.23.1"
@@ -14887,7 +14970,7 @@
       },
       "stable-0.22": {
         "minVersion": "0.22.0",
-        "maxVersion": "0.22.0"
+        "maxVersion": "0.22.1"
       },
       "stable-0.23": {
         "minVersion": "0.23.1",
@@ -14898,6 +14981,7 @@
       "0.21.0",
       "0.21.2",
       "0.22.0",
+      "0.22.1",
       "0.23.1"
     ],
     "minVersion": "0.21.0",
@@ -15117,13 +15201,14 @@
         "0.4.0",
         "0.4.1",
         "0.4.2",
-        "1.0.0"
+        "1.0.0",
+        "1.1.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.3.0",
-        "maxVersion": "1.0.0"
+        "maxVersion": "1.1.0"
       }
     },
     "availableVersions": [
@@ -15131,10 +15216,11 @@
       "0.4.0",
       "0.4.1",
       "0.4.2",
-      "1.0.0"
+      "1.0.0",
+      "1.1.0"
     ],
     "minVersion": "0.3.0",
-    "maxVersion": "1.0.0",
+    "maxVersion": "1.1.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"

--- a/catalog-data/redhat-operator-index/v4.21/catalog-info.json
+++ b/catalog-data/redhat-operator-index/v4.21/catalog-info.json
@@ -2,5 +2,5 @@
   "catalog_type": "redhat-operator-index",
   "ocp_version": "v4.21",
   "catalog_url": "registry.redhat.io/redhat/redhat-operator-index:v4.21",
-  "operator_count": 141
+  "operator_count": 143
 }

--- a/catalog-data/redhat-operator-index/v4.21/dependencies.json
+++ b/catalog-data/redhat-operator-index/v4.21/dependencies.json
@@ -14,63 +14,63 @@
   "ocs-client-operator": [
     {
       "packageName": "cephcsi-operator",
-      "versionRange": "4.21.1-rhodf"
+      "versionRange": "4.21.2-rhodf"
     },
     {
       "packageName": "odf-csi-addons-operator",
-      "versionRange": "4.21.1-rhodf"
+      "versionRange": "4.21.2-rhodf"
     },
     {
       "packageName": "odf-external-snapshotter-operator",
-      "versionRange": "4.21.1-rhodf"
+      "versionRange": "4.21.2-rhodf"
     },
     {
       "packageName": "recipe",
-      "versionRange": "4.21.1-rhodf"
+      "versionRange": "4.21.2-rhodf"
     }
   ],
   "odf-dependencies": [
     {
       "packageName": "cephcsi-operator",
-      "versionRange": "4.21.1-rhodf"
+      "versionRange": "4.21.2-rhodf"
     },
     {
       "packageName": "mcg-operator",
-      "versionRange": "4.21.1-rhodf"
+      "versionRange": "4.21.2-rhodf"
     },
     {
       "packageName": "ocs-client-operator",
-      "versionRange": "4.21.1-rhodf"
+      "versionRange": "4.21.2-rhodf"
     },
     {
       "packageName": "ocs-operator",
-      "versionRange": "4.21.1-rhodf"
+      "versionRange": "4.21.2-rhodf"
     },
     {
       "packageName": "odf-csi-addons-operator",
-      "versionRange": "4.21.1-rhodf"
+      "versionRange": "4.21.2-rhodf"
     },
     {
       "packageName": "odf-external-snapshotter-operator",
-      "versionRange": "4.21.1-rhodf"
+      "versionRange": "4.21.2-rhodf"
     },
     {
       "packageName": "odf-prometheus-operator",
-      "versionRange": "4.21.1-rhodf"
+      "versionRange": "4.21.2-rhodf"
     },
     {
       "packageName": "recipe",
-      "versionRange": "4.21.1-rhodf"
+      "versionRange": "4.21.2-rhodf"
     },
     {
       "packageName": "rook-ceph-operator",
-      "versionRange": "4.21.1-rhodf"
+      "versionRange": "4.21.2-rhodf"
     }
   ],
   "odf-multicluster-orchestrator": [
     {
       "packageName": "odr-hub-operator",
-      "versionRange": "<=4.21.1"
+      "versionRange": "<=4.21.2"
     }
   ],
   "rhcl-operator": [

--- a/catalog-data/redhat-operator-index/v4.21/operators.json
+++ b/catalog-data/redhat-operator-index/v4.21/operators.json
@@ -296,9 +296,10 @@
   },
   {
     "name": "amq-broker-rhel9",
-    "defaultChannel": "7.13.x",
+    "defaultChannel": "7.14.x",
     "channels": [
-      "7.13.x"
+      "7.13.x",
+      "7.14.x"
     ],
     "channelVersions": {
       "7.13.x": [
@@ -328,13 +329,21 @@
         "7.13.4-opr-1+0.1774232950.p",
         "7.13.4-opr-1+0.1774978247.p",
         "7.13.4-opr-1+0.1775649637.p",
-        "7.13.4-opr-1+0.1775651671.p"
+        "7.13.4-opr-1+0.1775651671.p",
+        "7.13.4-opr-1+0.1776062112.p"
+      ],
+      "7.14.x": [
+        "7.14.0-opr-1"
       ]
     },
     "channelVersionRanges": {
       "7.13.x": {
         "minVersion": "7.13.0-opr-1",
-        "maxVersion": "7.13.4-opr-1+0.1775651671.p"
+        "maxVersion": "7.13.4-opr-1+0.1776062112.p"
+      },
+      "7.14.x": {
+        "minVersion": "7.14.0-opr-1",
+        "maxVersion": "7.14.0-opr-1"
       }
     },
     "availableVersions": [
@@ -364,10 +373,12 @@
       "7.13.4-opr-1+0.1774232950.p",
       "7.13.4-opr-1+0.1774978247.p",
       "7.13.4-opr-1+0.1775649637.p",
-      "7.13.4-opr-1+0.1775651671.p"
+      "7.13.4-opr-1+0.1775651671.p",
+      "7.13.4-opr-1+0.1776062112.p",
+      "7.14.0-opr-1"
     ],
     "minVersion": "7.13.0-opr-1",
-    "maxVersion": "7.13.4-opr-1+0.1775651671.p",
+    "maxVersion": "7.14.0-opr-1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -1635,13 +1646,14 @@
         "3.0.15-r1",
         "3.1.0-r1",
         "3.1.6-r1",
-        "3.1.6-r2"
+        "3.1.6-r2",
+        "3.1.6-r3"
       ]
     },
     "channelVersionRanges": {
       "3.x": {
         "minVersion": "3.0.6-beta",
-        "maxVersion": "3.1.6-r2"
+        "maxVersion": "3.1.6-r3"
       }
     },
     "availableVersions": [
@@ -1656,10 +1668,11 @@
       "3.0.15-r1",
       "3.1.0-r1",
       "3.1.6-r1",
-      "3.1.6-r2"
+      "3.1.6-r2",
+      "3.1.6-r3"
     ],
     "minVersion": "3.0.6-beta",
-    "maxVersion": "3.1.6-r2",
+    "maxVersion": "3.1.6-r3",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -1737,13 +1750,14 @@
         "4.21.0-202603111554",
         "4.21.0-202603181245",
         "4.21.0-202603251225",
-        "4.21.0-202604012149"
+        "4.21.0-202604012149",
+        "4.21.0-202604080925"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601121715",
-        "maxVersion": "4.21.0-202604012149"
+        "maxVersion": "4.21.0-202604080925"
       }
     },
     "availableVersions": [
@@ -1756,10 +1770,11 @@
       "4.21.0-202603111554",
       "4.21.0-202603181245",
       "4.21.0-202603251225",
-      "4.21.0-202604012149"
+      "4.21.0-202604012149",
+      "4.21.0-202604080925"
     ],
     "minVersion": "4.21.0-202601121715",
-    "maxVersion": "4.21.0-202604012149",
+    "maxVersion": "4.21.0-202604080925",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -1863,13 +1878,14 @@
         "8.0.6-3",
         "8.0.7-1",
         "8.0.7-2",
-        "8.0.8-1"
+        "8.0.8-1",
+        "8.0.9-1"
       ]
     },
     "channelVersionRanges": {
       "8.x-stable": {
         "minVersion": "8.0.0-1",
-        "maxVersion": "8.0.8-1"
+        "maxVersion": "8.0.9-1"
       }
     },
     "availableVersions": [
@@ -1894,10 +1910,11 @@
       "8.0.6-3",
       "8.0.7-1",
       "8.0.7-2",
-      "8.0.8-1"
+      "8.0.8-1",
+      "8.0.9-1"
     ],
     "minVersion": "8.0.0-1",
-    "maxVersion": "8.0.8-1",
+    "maxVersion": "8.0.9-1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -2148,7 +2165,8 @@
       ],
       "stable-4.21": [
         "4.21.0-rhodf",
-        "4.21.1-rhodf"
+        "4.21.1-rhodf",
+        "4.21.2-rhodf"
       ]
     },
     "channelVersionRanges": {
@@ -2158,7 +2176,7 @@
       },
       "stable-4.21": {
         "minVersion": "4.21.0-rhodf",
-        "maxVersion": "4.21.1-rhodf"
+        "maxVersion": "4.21.2-rhodf"
       }
     },
     "availableVersions": [
@@ -2173,10 +2191,11 @@
       "4.20.8-rhodf",
       "4.20.9-rhodf",
       "4.21.0-rhodf",
-      "4.21.1-rhodf"
+      "4.21.1-rhodf",
+      "4.21.2-rhodf"
     ],
     "minVersion": "4.20.0-rhodf",
-    "maxVersion": "4.21.1-rhodf",
+    "maxVersion": "4.21.2-rhodf",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -2387,13 +2406,14 @@
         "4.21.0-202603092144",
         "4.21.0-202603181245",
         "4.21.0-202603230446",
-        "4.21.0-202603300221"
+        "4.21.0-202603300221",
+        "4.21.0-202604060715"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601292040",
-        "maxVersion": "4.21.0-202603300221"
+        "maxVersion": "4.21.0-202604060715"
       }
     },
     "availableVersions": [
@@ -2404,10 +2424,11 @@
       "4.21.0-202603092144",
       "4.21.0-202603181245",
       "4.21.0-202603230446",
-      "4.21.0-202603300221"
+      "4.21.0-202603300221",
+      "4.21.0-202604060715"
     ],
     "minVersion": "4.21.0-202601292040",
-    "maxVersion": "4.21.0-202603300221",
+    "maxVersion": "4.21.0-202604060715",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -2439,7 +2460,8 @@
         "1.7.1",
         "1.8.0",
         "1.8.1",
-        "1.8.2"
+        "1.8.2",
+        "1.9.0"
       ]
     },
     "channelVersionRanges": {
@@ -2453,7 +2475,7 @@
       },
       "stable": {
         "minVersion": "1.4.0",
-        "maxVersion": "1.8.2"
+        "maxVersion": "1.9.0"
       }
     },
     "availableVersions": [
@@ -2470,10 +2492,11 @@
       "1.7.1",
       "1.8.0",
       "1.8.1",
-      "1.8.2"
+      "1.8.2",
+      "1.9.0"
     ],
     "minVersion": "0.1.32",
-    "maxVersion": "1.8.2",
+    "maxVersion": "1.9.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -3215,7 +3238,8 @@
         "8.5.12",
         "8.5.13",
         "8.5.14",
-        "8.6.0"
+        "8.6.0",
+        "8.6.1"
       ]
     },
     "channelVersionRanges": {
@@ -3233,7 +3257,7 @@
       },
       "stable": {
         "minVersion": "8.2.4",
-        "maxVersion": "8.6.0"
+        "maxVersion": "8.6.1"
       }
     },
     "availableVersions": [
@@ -3283,10 +3307,11 @@
       "8.5.12",
       "8.5.13",
       "8.5.14",
-      "8.6.0"
+      "8.6.0",
+      "8.6.1"
     ],
     "minVersion": "8.2.4",
-    "maxVersion": "8.6.0",
+    "maxVersion": "8.6.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -3617,13 +3642,15 @@
         "3.2.10",
         "3.2.11",
         "3.2.12",
-        "3.2.13"
+        "3.2.13",
+        "3.2.14",
+        "3.2.15"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.2.0",
-        "maxVersion": "3.2.13"
+        "maxVersion": "3.2.15"
       }
     },
     "availableVersions": [
@@ -3671,10 +3698,12 @@
       "3.2.10",
       "3.2.11",
       "3.2.12",
-      "3.2.13"
+      "3.2.13",
+      "3.2.14",
+      "3.2.15"
     ],
     "minVersion": "2.2.0",
-    "maxVersion": "3.2.13",
+    "maxVersion": "3.2.15",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -3696,6 +3725,7 @@
         "1.1.0",
         "1.1.1",
         "1.2.0",
+        "1.2.1",
         "1.3.0",
         "1.3.1",
         "1.3.2",
@@ -3710,7 +3740,8 @@
         "1.1.1"
       ],
       "stable-v1.2": [
-        "1.2.0"
+        "1.2.0",
+        "1.2.1"
       ],
       "stable-v1.3": [
         "1.3.0",
@@ -3734,7 +3765,7 @@
       },
       "stable-v1.2": {
         "minVersion": "1.2.0",
-        "maxVersion": "1.2.0"
+        "maxVersion": "1.2.1"
       },
       "stable-v1.3": {
         "minVersion": "1.3.0",
@@ -3747,6 +3778,7 @@
       "1.1.0",
       "1.1.1",
       "1.2.0",
+      "1.2.1",
       "1.3.0",
       "1.3.1",
       "1.3.2",
@@ -3944,13 +3976,14 @@
         "4.21.0-202603092144",
         "4.21.0-202603181245",
         "4.21.0-202603250756",
-        "4.21.0-202603300623"
+        "4.21.0-202603300623",
+        "4.21.0-202604061320"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601121715",
-        "maxVersion": "4.21.0-202603300623"
+        "maxVersion": "4.21.0-202604061320"
       }
     },
     "availableVersions": [
@@ -3962,10 +3995,11 @@
       "4.21.0-202603092144",
       "4.21.0-202603181245",
       "4.21.0-202603250756",
-      "4.21.0-202603300623"
+      "4.21.0-202603300623",
+      "4.21.0-202604061320"
     ],
     "minVersion": "4.21.0-202601121715",
-    "maxVersion": "4.21.0-202603300623",
+    "maxVersion": "4.21.0-202604061320",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -3986,13 +4020,14 @@
         "4.21.0-202603092144",
         "4.21.0-202603181245",
         "4.21.0-202603250027",
-        "4.21.0-202603300221"
+        "4.21.0-202603300221",
+        "4.21.0-202604061320"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601121715",
-        "maxVersion": "4.21.0-202603300221"
+        "maxVersion": "4.21.0-202604061320"
       }
     },
     "availableVersions": [
@@ -4004,10 +4039,11 @@
       "4.21.0-202603092144",
       "4.21.0-202603181245",
       "4.21.0-202603250027",
-      "4.21.0-202603300221"
+      "4.21.0-202603300221",
+      "4.21.0-202604061320"
     ],
     "minVersion": "4.21.0-202601121715",
-    "maxVersion": "4.21.0-202603300221",
+    "maxVersion": "4.21.0-202604061320",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -4488,7 +4524,8 @@
         "2.17.2",
         "2.17.3",
         "2.17.4",
-        "2.22.1"
+        "2.22.1",
+        "2.22.2"
       ]
     },
     "channelVersionRanges": {
@@ -4498,7 +4535,7 @@
       },
       "stable": {
         "minVersion": "1.57.7",
-        "maxVersion": "2.22.1"
+        "maxVersion": "2.22.2"
       }
     },
     "availableVersions": [
@@ -4533,10 +4570,11 @@
       "2.17.2",
       "2.17.3",
       "2.17.4",
-      "2.22.1"
+      "2.22.1",
+      "2.22.2"
     ],
     "minVersion": "1.57.7",
-    "maxVersion": "2.22.1",
+    "maxVersion": "2.22.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -4558,13 +4596,14 @@
         "4.21.0-202603092144",
         "4.21.0-202603181245",
         "4.21.0-202603251225",
-        "4.21.0-202604012149"
+        "4.21.0-202604012149",
+        "4.21.0-202604080925"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601121715",
-        "maxVersion": "4.21.0-202604012149"
+        "maxVersion": "4.21.0-202604080925"
       }
     },
     "availableVersions": [
@@ -4577,10 +4616,11 @@
       "4.21.0-202603092144",
       "4.21.0-202603181245",
       "4.21.0-202603251225",
-      "4.21.0-202604012149"
+      "4.21.0-202604012149",
+      "4.21.0-202604080925"
     ],
     "minVersion": "4.21.0-202601121715",
-    "maxVersion": "4.21.0-202604012149",
+    "maxVersion": "4.21.0-202604080925",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -4636,7 +4676,8 @@
         "4.20.1",
         "4.20.3",
         "4.21.0",
-        "4.21.1"
+        "4.21.1",
+        "4.21.3"
       ]
     },
     "channelVersionRanges": {
@@ -4646,7 +4687,7 @@
       },
       "stable": {
         "minVersion": "4.12.0",
-        "maxVersion": "4.21.1"
+        "maxVersion": "4.21.3"
       }
     },
     "availableVersions": [
@@ -4808,31 +4849,34 @@
       "alpha": [
         "1.0.8",
         "1.0.9",
-        "1.0.10"
+        "1.0.10",
+        "1.0.11"
       ],
       "stable": [
         "1.0.8",
         "1.0.9",
-        "1.0.10"
+        "1.0.10",
+        "1.0.11"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.8",
-        "maxVersion": "1.0.10"
+        "maxVersion": "1.0.11"
       },
       "stable": {
         "minVersion": "1.0.8",
-        "maxVersion": "1.0.10"
+        "maxVersion": "1.0.11"
       }
     },
     "availableVersions": [
       "1.0.8",
       "1.0.9",
-      "1.0.10"
+      "1.0.10",
+      "1.0.11"
     ],
     "minVersion": "1.0.8",
-    "maxVersion": "1.0.10",
+    "maxVersion": "1.0.11",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -4879,13 +4923,14 @@
         "4.21.0-202603092144",
         "4.21.0-202603181245",
         "4.21.0-202603241611",
-        "4.21.0-202603300623"
+        "4.21.0-202603300623",
+        "4.21.0-202604061320"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601121715",
-        "maxVersion": "4.21.0-202603300623"
+        "maxVersion": "4.21.0-202604061320"
       }
     },
     "availableVersions": [
@@ -4897,10 +4942,11 @@
       "4.21.0-202603092144",
       "4.21.0-202603181245",
       "4.21.0-202603241611",
-      "4.21.0-202603300623"
+      "4.21.0-202603300623",
+      "4.21.0-202604061320"
     ],
     "minVersion": "4.21.0-202601121715",
-    "maxVersion": "4.21.0-202603300623",
+    "maxVersion": "4.21.0-202604061320",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -5095,7 +5141,8 @@
       ],
       "stable-4.21": [
         "4.21.0-rhodf",
-        "4.21.1-rhodf"
+        "4.21.1-rhodf",
+        "4.21.2-rhodf"
       ]
     },
     "channelVersionRanges": {
@@ -5105,7 +5152,7 @@
       },
       "stable-4.21": {
         "minVersion": "4.21.0-rhodf",
-        "maxVersion": "4.21.1-rhodf"
+        "maxVersion": "4.21.2-rhodf"
       }
     },
     "availableVersions": [
@@ -5120,10 +5167,11 @@
       "4.20.8-rhodf",
       "4.20.9-rhodf",
       "4.21.0-rhodf",
-      "4.21.1-rhodf"
+      "4.21.1-rhodf",
+      "4.21.2-rhodf"
     ],
     "minVersion": "4.20.0-rhodf",
-    "maxVersion": "4.21.1-rhodf",
+    "maxVersion": "4.21.2-rhodf",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -5144,13 +5192,14 @@
         "4.21.0-202603092144",
         "4.21.0-202603181245",
         "4.21.0-202603240526",
-        "4.21.0-202603300221"
+        "4.21.0-202603300221",
+        "4.21.0-202604061320"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601121715",
-        "maxVersion": "4.21.0-202603300221"
+        "maxVersion": "4.21.0-202604061320"
       }
     },
     "availableVersions": [
@@ -5162,10 +5211,11 @@
       "4.21.0-202603092144",
       "4.21.0-202603181245",
       "4.21.0-202603240526",
-      "4.21.0-202603300221"
+      "4.21.0-202603300221",
+      "4.21.0-202604061320"
     ],
     "minVersion": "4.21.0-202601121715",
-    "maxVersion": "4.21.0-202603300221",
+    "maxVersion": "4.21.0-202604061320",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -5180,22 +5230,24 @@
       "tech-preview": [
         "0.0.1",
         "0.0.2",
-        "0.0.3"
+        "0.0.3",
+        "0.1.0"
       ]
     },
     "channelVersionRanges": {
       "tech-preview": {
         "minVersion": "0.0.1",
-        "maxVersion": "0.0.3"
+        "maxVersion": "0.1.0"
       }
     },
     "availableVersions": [
       "0.0.1",
       "0.0.2",
-      "0.0.3"
+      "0.0.3",
+      "0.1.0"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "0.0.3",
+    "maxVersion": "0.1.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -5404,7 +5456,8 @@
       "release-v2.11": [
         "2.11.0",
         "2.11.1",
-        "2.11.2"
+        "2.11.2",
+        "2.11.3"
       ]
     },
     "channelVersionRanges": {
@@ -5414,17 +5467,18 @@
       },
       "release-v2.11": {
         "minVersion": "2.11.0",
-        "maxVersion": "2.11.2"
+        "maxVersion": "2.11.3"
       }
     },
     "availableVersions": [
       "2.10.5",
       "2.11.0",
       "2.11.1",
-      "2.11.2"
+      "2.11.2",
+      "2.11.3"
     ],
     "minVersion": "2.10.5",
-    "maxVersion": "2.11.2",
+    "maxVersion": "2.11.3",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -5625,13 +5679,14 @@
         "4.21.0-202603092144",
         "4.21.0-202603181245",
         "4.21.0-202603230446",
-        "4.21.0-202603300623"
+        "4.21.0-202603300623",
+        "4.21.0-202604061320"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601121715",
-        "maxVersion": "4.21.0-202603300623"
+        "maxVersion": "4.21.0-202604061320"
       }
     },
     "availableVersions": [
@@ -5643,10 +5698,11 @@
       "4.21.0-202603092144",
       "4.21.0-202603181245",
       "4.21.0-202603230446",
-      "4.21.0-202603300623"
+      "4.21.0-202603300623",
+      "4.21.0-202604061320"
     ],
     "minVersion": "4.21.0-202601121715",
-    "maxVersion": "4.21.0-202603300623",
+    "maxVersion": "4.21.0-202604061320",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -5779,7 +5835,8 @@
         "4.21.2",
         "4.21.3",
         "4.21.4",
-        "4.21.5"
+        "4.21.5",
+        "4.21.6"
       ],
       "stable": [
         "4.21.0",
@@ -5787,17 +5844,18 @@
         "4.21.2",
         "4.21.3",
         "4.21.4",
-        "4.21.5"
+        "4.21.5",
+        "4.21.6"
       ]
     },
     "channelVersionRanges": {
       "4.21": {
         "minVersion": "4.21.0",
-        "maxVersion": "4.21.5"
+        "maxVersion": "4.21.6"
       },
       "stable": {
         "minVersion": "4.21.0",
-        "maxVersion": "4.21.5"
+        "maxVersion": "4.21.6"
       }
     },
     "availableVersions": [
@@ -5806,10 +5864,11 @@
       "4.21.2",
       "4.21.3",
       "4.21.4",
-      "4.21.5"
+      "4.21.5",
+      "4.21.6"
     ],
     "minVersion": "4.21.0",
-    "maxVersion": "4.21.5",
+    "maxVersion": "4.21.6",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -5836,7 +5895,8 @@
       ],
       "stable-4.21": [
         "4.21.0-rhodf",
-        "4.21.1-rhodf"
+        "4.21.1-rhodf",
+        "4.21.2-rhodf"
       ]
     },
     "channelVersionRanges": {
@@ -5846,7 +5906,7 @@
       },
       "stable-4.21": {
         "minVersion": "4.21.0-rhodf",
-        "maxVersion": "4.21.1-rhodf"
+        "maxVersion": "4.21.2-rhodf"
       }
     },
     "availableVersions": [
@@ -5861,10 +5921,11 @@
       "4.20.8-rhodf",
       "4.20.9-rhodf",
       "4.21.0-rhodf",
-      "4.21.1-rhodf"
+      "4.21.1-rhodf",
+      "4.21.2-rhodf"
     ],
     "minVersion": "4.20.0-rhodf",
-    "maxVersion": "4.21.1-rhodf",
+    "maxVersion": "4.21.2-rhodf",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -5891,7 +5952,8 @@
       ],
       "stable-4.21": [
         "4.21.0-rhodf",
-        "4.21.1-rhodf"
+        "4.21.1-rhodf",
+        "4.21.2-rhodf"
       ]
     },
     "channelVersionRanges": {
@@ -5901,7 +5963,7 @@
       },
       "stable-4.21": {
         "minVersion": "4.21.0-rhodf",
-        "maxVersion": "4.21.1-rhodf"
+        "maxVersion": "4.21.2-rhodf"
       }
     },
     "availableVersions": [
@@ -5916,10 +5978,11 @@
       "4.20.8-rhodf",
       "4.20.9-rhodf",
       "4.21.0-rhodf",
-      "4.21.1-rhodf"
+      "4.21.1-rhodf",
+      "4.21.2-rhodf"
     ],
     "minVersion": "4.20.0-rhodf",
-    "maxVersion": "4.21.1-rhodf",
+    "maxVersion": "4.21.2-rhodf",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -5946,7 +6009,8 @@
       ],
       "stable-4.21": [
         "4.21.0-rhodf",
-        "4.21.1-rhodf"
+        "4.21.1-rhodf",
+        "4.21.2-rhodf"
       ]
     },
     "channelVersionRanges": {
@@ -5956,7 +6020,7 @@
       },
       "stable-4.21": {
         "minVersion": "4.21.0-rhodf",
-        "maxVersion": "4.21.1-rhodf"
+        "maxVersion": "4.21.2-rhodf"
       }
     },
     "availableVersions": [
@@ -5971,10 +6035,11 @@
       "4.20.8-rhodf",
       "4.20.9-rhodf",
       "4.21.0-rhodf",
-      "4.21.1-rhodf"
+      "4.21.1-rhodf",
+      "4.21.2-rhodf"
     ],
     "minVersion": "4.20.0-rhodf",
-    "maxVersion": "4.21.1-rhodf",
+    "maxVersion": "4.21.2-rhodf",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -6001,7 +6066,8 @@
       ],
       "stable-4.21": [
         "4.21.0-rhodf",
-        "4.21.1-rhodf"
+        "4.21.1-rhodf",
+        "4.21.2-rhodf"
       ]
     },
     "channelVersionRanges": {
@@ -6011,7 +6077,7 @@
       },
       "stable-4.21": {
         "minVersion": "4.21.0-rhodf",
-        "maxVersion": "4.21.1-rhodf"
+        "maxVersion": "4.21.2-rhodf"
       }
     },
     "availableVersions": [
@@ -6026,10 +6092,11 @@
       "4.20.8-rhodf",
       "4.20.9-rhodf",
       "4.21.0-rhodf",
-      "4.21.1-rhodf"
+      "4.21.1-rhodf",
+      "4.21.2-rhodf"
     ],
     "minVersion": "4.20.0-rhodf",
-    "maxVersion": "4.21.1-rhodf",
+    "maxVersion": "4.21.2-rhodf",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -6056,7 +6123,8 @@
       ],
       "stable-4.21": [
         "4.21.0-rhodf",
-        "4.21.1-rhodf"
+        "4.21.1-rhodf",
+        "4.21.2-rhodf"
       ]
     },
     "channelVersionRanges": {
@@ -6066,7 +6134,7 @@
       },
       "stable-4.21": {
         "minVersion": "4.21.0-rhodf",
-        "maxVersion": "4.21.1-rhodf"
+        "maxVersion": "4.21.2-rhodf"
       }
     },
     "availableVersions": [
@@ -6081,10 +6149,11 @@
       "4.20.8-rhodf",
       "4.20.9-rhodf",
       "4.21.0-rhodf",
-      "4.21.1-rhodf"
+      "4.21.1-rhodf",
+      "4.21.2-rhodf"
     ],
     "minVersion": "4.20.0-rhodf",
-    "maxVersion": "4.21.1-rhodf",
+    "maxVersion": "4.21.2-rhodf",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -6111,7 +6180,8 @@
       ],
       "stable-4.21": [
         "4.21.0-rhodf",
-        "4.21.1-rhodf"
+        "4.21.1-rhodf",
+        "4.21.2-rhodf"
       ]
     },
     "channelVersionRanges": {
@@ -6121,7 +6191,7 @@
       },
       "stable-4.21": {
         "minVersion": "4.21.0-rhodf",
-        "maxVersion": "4.21.1-rhodf"
+        "maxVersion": "4.21.2-rhodf"
       }
     },
     "availableVersions": [
@@ -6136,10 +6206,11 @@
       "4.20.8-rhodf",
       "4.20.9-rhodf",
       "4.21.0-rhodf",
-      "4.21.1-rhodf"
+      "4.21.1-rhodf",
+      "4.21.2-rhodf"
     ],
     "minVersion": "4.20.0-rhodf",
-    "maxVersion": "4.21.1-rhodf",
+    "maxVersion": "4.21.2-rhodf",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -6166,7 +6237,8 @@
       ],
       "stable-4.21": [
         "4.21.0-rhodf",
-        "4.21.1-rhodf"
+        "4.21.1-rhodf",
+        "4.21.2-rhodf"
       ]
     },
     "channelVersionRanges": {
@@ -6176,7 +6248,7 @@
       },
       "stable-4.21": {
         "minVersion": "4.21.0-rhodf",
-        "maxVersion": "4.21.1-rhodf"
+        "maxVersion": "4.21.2-rhodf"
       }
     },
     "availableVersions": [
@@ -6191,10 +6263,11 @@
       "4.20.8-rhodf",
       "4.20.9-rhodf",
       "4.21.0-rhodf",
-      "4.21.1-rhodf"
+      "4.21.1-rhodf",
+      "4.21.2-rhodf"
     ],
     "minVersion": "4.20.0-rhodf",
-    "maxVersion": "4.21.1-rhodf",
+    "maxVersion": "4.21.2-rhodf",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -6221,7 +6294,8 @@
       ],
       "stable-4.21": [
         "4.21.0-rhodf",
-        "4.21.1-rhodf"
+        "4.21.1-rhodf",
+        "4.21.2-rhodf"
       ]
     },
     "channelVersionRanges": {
@@ -6231,7 +6305,7 @@
       },
       "stable-4.21": {
         "minVersion": "4.21.0-rhodf",
-        "maxVersion": "4.21.1-rhodf"
+        "maxVersion": "4.21.2-rhodf"
       }
     },
     "availableVersions": [
@@ -6246,10 +6320,11 @@
       "4.20.8-rhodf",
       "4.20.9-rhodf",
       "4.21.0-rhodf",
-      "4.21.1-rhodf"
+      "4.21.1-rhodf",
+      "4.21.2-rhodf"
     ],
     "minVersion": "4.20.0-rhodf",
-    "maxVersion": "4.21.1-rhodf",
+    "maxVersion": "4.21.2-rhodf",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -6276,7 +6351,8 @@
       ],
       "stable-4.21": [
         "4.21.0-rhodf",
-        "4.21.1-rhodf"
+        "4.21.1-rhodf",
+        "4.21.2-rhodf"
       ]
     },
     "channelVersionRanges": {
@@ -6286,7 +6362,7 @@
       },
       "stable-4.21": {
         "minVersion": "4.21.0-rhodf",
-        "maxVersion": "4.21.1-rhodf"
+        "maxVersion": "4.21.2-rhodf"
       }
     },
     "availableVersions": [
@@ -6301,10 +6377,11 @@
       "4.20.8-rhodf",
       "4.20.9-rhodf",
       "4.21.0-rhodf",
-      "4.21.1-rhodf"
+      "4.21.1-rhodf",
+      "4.21.2-rhodf"
     ],
     "minVersion": "4.20.0-rhodf",
-    "maxVersion": "4.21.1-rhodf",
+    "maxVersion": "4.21.2-rhodf",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -6331,7 +6408,8 @@
       ],
       "stable-4.21": [
         "4.21.0-rhodf",
-        "4.21.1-rhodf"
+        "4.21.1-rhodf",
+        "4.21.2-rhodf"
       ]
     },
     "channelVersionRanges": {
@@ -6341,7 +6419,7 @@
       },
       "stable-4.21": {
         "minVersion": "4.21.0-rhodf",
-        "maxVersion": "4.21.1-rhodf"
+        "maxVersion": "4.21.2-rhodf"
       }
     },
     "availableVersions": [
@@ -6356,10 +6434,45 @@
       "4.20.8-rhodf",
       "4.20.9-rhodf",
       "4.21.0-rhodf",
-      "4.21.1-rhodf"
+      "4.21.1-rhodf",
+      "4.21.2-rhodf"
     ],
     "minVersion": "4.20.0-rhodf",
-    "maxVersion": "4.21.1-rhodf",
+    "maxVersion": "4.21.2-rhodf",
+    "catalog": "redhat-operator-index",
+    "ocpVersion": "v4.21",
+    "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
+  },
+  {
+    "name": "openperouter-operator",
+    "defaultChannel": "alpha",
+    "channels": [
+      "4.21",
+      "alpha"
+    ],
+    "channelVersions": {
+      "4.21": [
+        "4.21.0"
+      ],
+      "alpha": [
+        "4.21.0"
+      ]
+    },
+    "channelVersionRanges": {
+      "4.21": {
+        "minVersion": "4.21.0",
+        "maxVersion": "4.21.0"
+      },
+      "alpha": {
+        "minVersion": "4.21.0",
+        "maxVersion": "4.21.0"
+      }
+    },
+    "availableVersions": [
+      "4.21.0"
+    ],
+    "minVersion": "4.21.0",
+    "maxVersion": "4.21.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -7435,13 +7548,14 @@
         "4.21.0-202603092144",
         "4.21.0-202603181245",
         "4.21.0-202603251225",
-        "4.21.0-202603300221"
+        "4.21.0-202603300221",
+        "4.21.0-202604061320"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601130153",
-        "maxVersion": "4.21.0-202603300221"
+        "maxVersion": "4.21.0-202604061320"
       }
     },
     "availableVersions": [
@@ -7453,27 +7567,44 @@
       "4.21.0-202603092144",
       "4.21.0-202603181245",
       "4.21.0-202603251225",
-      "4.21.0-202603300221"
+      "4.21.0-202603300221",
+      "4.21.0-202604061320"
     ],
     "minVersion": "4.21.0-202601130153",
-    "maxVersion": "4.21.0-202603300221",
+    "maxVersion": "4.21.0-202604061320",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
   },
   {
     "name": "policy-controller-operator",
-    "defaultChannel": "tech-preview",
+    "defaultChannel": "stable",
     "channels": [
+      "stable",
+      "stable-v1.0",
       "tech-preview"
     ],
     "channelVersions": {
+      "stable": [
+        "1.0.0"
+      ],
+      "stable-v1.0": [
+        "1.0.0"
+      ],
       "tech-preview": [
         "0.0.1-techpreview",
         "0.0.2-techpreview"
       ]
     },
     "channelVersionRanges": {
+      "stable": {
+        "minVersion": "1.0.0",
+        "maxVersion": "1.0.0"
+      },
+      "stable-v1.0": {
+        "minVersion": "1.0.0",
+        "maxVersion": "1.0.0"
+      },
       "tech-preview": {
         "minVersion": "0.0.1-techpreview",
         "maxVersion": "0.0.2-techpreview"
@@ -7481,10 +7612,11 @@
     },
     "availableVersions": [
       "0.0.1-techpreview",
-      "0.0.2-techpreview"
+      "0.0.2-techpreview",
+      "1.0.0"
     ],
     "minVersion": "0.0.1-techpreview",
-    "maxVersion": "0.0.2-techpreview",
+    "maxVersion": "1.0.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -7540,13 +7672,14 @@
         "4.21.0-202603092144",
         "4.21.0-202603181245",
         "4.21.0-202603242057",
-        "4.21.0-202604011849"
+        "4.21.0-202604011849",
+        "4.21.0-202604061320"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601121715",
-        "maxVersion": "4.21.0-202604011849"
+        "maxVersion": "4.21.0-202604061320"
       }
     },
     "availableVersions": [
@@ -7559,10 +7692,11 @@
       "4.21.0-202603092144",
       "4.21.0-202603181245",
       "4.21.0-202603242057",
-      "4.21.0-202604011849"
+      "4.21.0-202604011849",
+      "4.21.0-202604061320"
     ],
     "minVersion": "4.21.0-202601121715",
-    "maxVersion": "4.21.0-202604011849",
+    "maxVersion": "4.21.0-202604061320",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -8387,7 +8521,8 @@
       ],
       "stable-4.21": [
         "4.21.0-rhodf",
-        "4.21.1-rhodf"
+        "4.21.1-rhodf",
+        "4.21.2-rhodf"
       ]
     },
     "channelVersionRanges": {
@@ -8397,7 +8532,7 @@
       },
       "stable-4.21": {
         "minVersion": "4.21.0-rhodf",
-        "maxVersion": "4.21.1-rhodf"
+        "maxVersion": "4.21.2-rhodf"
       }
     },
     "availableVersions": [
@@ -8412,10 +8547,11 @@
       "4.20.8-rhodf",
       "4.20.9-rhodf",
       "4.21.0-rhodf",
-      "4.21.1-rhodf"
+      "4.21.1-rhodf",
+      "4.21.2-rhodf"
     ],
     "minVersion": "4.20.0-rhodf",
-    "maxVersion": "4.21.1-rhodf",
+    "maxVersion": "4.21.2-rhodf",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -8745,7 +8881,8 @@
         "1.2.0+0.1754338551.p",
         "1.2.0+0.1754874242.p",
         "1.2.1",
-        "1.3.0"
+        "1.3.0",
+        "1.3.1"
       ],
       "stable-v1": [
         "1.0.0",
@@ -8766,7 +8903,8 @@
         "1.2.0+0.1754338551.p",
         "1.2.0+0.1754874242.p",
         "1.2.1",
-        "1.3.0"
+        "1.3.0",
+        "1.3.1"
       ],
       "stable-v1.0": [
         "1.0.0",
@@ -8778,11 +8916,11 @@
     "channelVersionRanges": {
       "latest": {
         "minVersion": "1.0.0",
-        "maxVersion": "1.3.0"
+        "maxVersion": "1.3.1"
       },
       "stable-v1": {
         "minVersion": "1.0.0",
-        "maxVersion": "1.3.0"
+        "maxVersion": "1.3.1"
       },
       "stable-v1.0": {
         "minVersion": "1.0.0",
@@ -8808,10 +8946,11 @@
       "1.2.0+0.1754338551.p",
       "1.2.0+0.1754874242.p",
       "1.2.1",
-      "1.3.0"
+      "1.3.0",
+      "1.3.1"
     ],
     "minVersion": "1.0.0",
-    "maxVersion": "1.3.0",
+    "maxVersion": "1.3.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -10671,7 +10810,8 @@
       "stable-2.25",
       "stable-2.8",
       "stable-3.3",
-      "stable-3.x"
+      "stable-3.x",
+      "support-required-upgrade"
     ],
     "channelVersions": {
       "alpha": [
@@ -11219,11 +11359,16 @@
       ],
       "stable-3.3": [
         "3.3.0",
-        "3.3.1"
+        "3.3.1",
+        "3.3.2"
       ],
       "stable-3.x": [
         "3.3.0",
-        "3.3.1"
+        "3.3.1",
+        "3.3.2"
+      ],
+      "support-required-upgrade": [
+        "3.3.2"
       ]
     },
     "channelVersionRanges": {
@@ -11293,11 +11438,15 @@
       },
       "stable-3.3": {
         "minVersion": "3.3.0",
-        "maxVersion": "3.3.1"
+        "maxVersion": "3.3.2"
       },
       "stable-3.x": {
         "minVersion": "3.3.0",
-        "maxVersion": "3.3.1"
+        "maxVersion": "3.3.2"
+      },
+      "support-required-upgrade": {
+        "minVersion": "3.3.2",
+        "maxVersion": "3.3.2"
       }
     },
     "availableVersions": [
@@ -11365,6 +11514,7 @@
       "3.2.0",
       "3.3.0",
       "3.3.1",
+      "3.3.2",
       "3.4.0-ea.1"
     ],
     "minVersion": "1.20.1-8",
@@ -11627,40 +11777,50 @@
     "defaultChannel": "stable",
     "channels": [
       "stable",
-      "stable-v1.3"
+      "stable-v1.3",
+      "stable-v1.4"
     ],
     "channelVersions": {
       "stable": [
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.3.3"
+        "1.3.3",
+        "1.4.0"
       ],
       "stable-v1.3": [
         "1.3.0",
         "1.3.1",
         "1.3.2",
         "1.3.3"
+      ],
+      "stable-v1.4": [
+        "1.4.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.3.0",
-        "maxVersion": "1.3.3"
+        "maxVersion": "1.4.0"
       },
       "stable-v1.3": {
         "minVersion": "1.3.0",
         "maxVersion": "1.3.3"
+      },
+      "stable-v1.4": {
+        "minVersion": "1.4.0",
+        "maxVersion": "1.4.0"
       }
     },
     "availableVersions": [
       "1.3.0",
       "1.3.1",
       "1.3.2",
-      "1.3.3"
+      "1.3.3",
+      "1.4.0"
     ],
     "minVersion": "1.3.0",
-    "maxVersion": "1.3.3",
+    "maxVersion": "1.4.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -11719,7 +11879,8 @@
       ],
       "stable-4.21": [
         "4.21.0-rhodf",
-        "4.21.1-rhodf"
+        "4.21.1-rhodf",
+        "4.21.2-rhodf"
       ]
     },
     "channelVersionRanges": {
@@ -11729,7 +11890,7 @@
       },
       "stable-4.21": {
         "minVersion": "4.21.0-rhodf",
-        "maxVersion": "4.21.1-rhodf"
+        "maxVersion": "4.21.2-rhodf"
       }
     },
     "availableVersions": [
@@ -11744,10 +11905,11 @@
       "4.20.8-rhodf",
       "4.20.9-rhodf",
       "4.21.0-rhodf",
-      "4.21.1-rhodf"
+      "4.21.1-rhodf",
+      "4.21.2-rhodf"
     ],
     "minVersion": "4.20.0-rhodf",
-    "maxVersion": "4.21.1-rhodf",
+    "maxVersion": "4.21.2-rhodf",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -11925,13 +12087,14 @@
         "4.21.0-202603092144",
         "4.21.0-202603181245",
         "4.21.0-202603241611",
-        "4.21.0-202603300623"
+        "4.21.0-202603300623",
+        "4.21.0-202604060715"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601121715",
-        "maxVersion": "4.21.0-202603300623"
+        "maxVersion": "4.21.0-202604060715"
       }
     },
     "availableVersions": [
@@ -11943,10 +12106,11 @@
       "4.21.0-202603092144",
       "4.21.0-202603181245",
       "4.21.0-202603241611",
-      "4.21.0-202603300623"
+      "4.21.0-202603300623",
+      "4.21.0-202604060715"
     ],
     "minVersion": "4.21.0-202601121715",
-    "maxVersion": "4.21.0-202603300623",
+    "maxVersion": "4.21.0-202604060715",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -12934,13 +13098,14 @@
         "4.21.0-202603092144",
         "4.21.0-202603181245",
         "4.21.0-202603241611",
-        "4.21.0-202603300623"
+        "4.21.0-202603300623",
+        "4.21.0-202604061320"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601121715",
-        "maxVersion": "4.21.0-202603300623"
+        "maxVersion": "4.21.0-202604061320"
       }
     },
     "availableVersions": [
@@ -12952,10 +13117,11 @@
       "4.21.0-202603092144",
       "4.21.0-202603181245",
       "4.21.0-202603241611",
-      "4.21.0-202603300623"
+      "4.21.0-202603300623",
+      "4.21.0-202604061320"
     ],
     "minVersion": "4.21.0-202601121715",
-    "maxVersion": "4.21.0-202603300623",
+    "maxVersion": "4.21.0-202604061320",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -12976,13 +13142,14 @@
         "4.21.0-202603092144",
         "4.21.0-202603181245",
         "4.21.0-202603250027",
-        "4.21.0-202604011521"
+        "4.21.0-202604011521",
+        "4.21.0-202604071949"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601130153",
-        "maxVersion": "4.21.0-202604011521"
+        "maxVersion": "4.21.0-202604071949"
       }
     },
     "availableVersions": [
@@ -12994,10 +13161,11 @@
       "4.21.0-202603092144",
       "4.21.0-202603181245",
       "4.21.0-202603250027",
-      "4.21.0-202604011521"
+      "4.21.0-202604011521",
+      "4.21.0-202604071949"
     ],
     "minVersion": "4.21.0-202601130153",
-    "maxVersion": "4.21.0-202604011521",
+    "maxVersion": "4.21.0-202604071949",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -13037,7 +13205,8 @@
     ],
     "channelVersions": {
       "stable-0.22": [
-        "0.22.0"
+        "0.22.0",
+        "0.22.1"
       ],
       "stable-0.23": [
         "0.23.1"
@@ -13046,7 +13215,7 @@
     "channelVersionRanges": {
       "stable-0.22": {
         "minVersion": "0.22.0",
-        "maxVersion": "0.22.0"
+        "maxVersion": "0.22.1"
       },
       "stable-0.23": {
         "minVersion": "0.23.1",
@@ -13055,6 +13224,7 @@
     },
     "availableVersions": [
       "0.22.0",
+      "0.22.1",
       "0.23.1"
     ],
     "minVersion": "0.22.0",
@@ -13073,22 +13243,24 @@
       "tech-preview": [
         "4.20.0",
         "4.21.0-202603241154",
-        "4.21.0-202603300623"
+        "4.21.0-202603300623",
+        "4.21.0-202604060715"
       ]
     },
     "channelVersionRanges": {
       "tech-preview": {
         "minVersion": "4.20.0",
-        "maxVersion": "4.21.0-202603300623"
+        "maxVersion": "4.21.0-202604060715"
       }
     },
     "availableVersions": [
       "4.20.0",
       "4.21.0-202603241154",
-      "4.21.0-202603300623"
+      "4.21.0-202603300623",
+      "4.21.0-202604060715"
     ],
     "minVersion": "4.20.0",
-    "maxVersion": "4.21.0-202603300623",
+    "maxVersion": "4.21.0-202604060715",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -13238,6 +13410,42 @@
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
   },
   {
+    "name": "trustee-operator",
+    "defaultChannel": "stable",
+    "channels": [
+      "stable"
+    ],
+    "channelVersions": {
+      "stable": [
+        "0.3.0",
+        "0.4.0",
+        "0.4.1",
+        "0.4.2",
+        "1.0.0",
+        "1.1.0"
+      ]
+    },
+    "channelVersionRanges": {
+      "stable": {
+        "minVersion": "0.3.0",
+        "maxVersion": "1.1.0"
+      }
+    },
+    "availableVersions": [
+      "0.3.0",
+      "0.4.0",
+      "0.4.1",
+      "0.4.2",
+      "1.0.0",
+      "1.1.0"
+    ],
+    "minVersion": "0.3.0",
+    "maxVersion": "1.1.0",
+    "catalog": "redhat-operator-index",
+    "ocpVersion": "v4.21",
+    "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
+  },
+  {
     "name": "vertical-pod-autoscaler",
     "defaultChannel": "stable",
     "channels": [
@@ -13253,13 +13461,14 @@
         "4.21.0-202603092144",
         "4.21.0-202603181245",
         "4.21.0-202603242057",
-        "4.21.0-202603300221"
+        "4.21.0-202603300221",
+        "4.21.0-202604060715"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601121715",
-        "maxVersion": "4.21.0-202603300221"
+        "maxVersion": "4.21.0-202604060715"
       }
     },
     "availableVersions": [
@@ -13271,10 +13480,11 @@
       "4.21.0-202603092144",
       "4.21.0-202603181245",
       "4.21.0-202603242057",
-      "4.21.0-202603300221"
+      "4.21.0-202603300221",
+      "4.21.0-202604060715"
     ],
     "minVersion": "4.21.0-202601121715",
-    "maxVersion": "4.21.0-202603300221",
+    "maxVersion": "4.21.0-202604060715",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"


### PR DESCRIPTION
Update operator catalog data across all versions (v4.16-v4.21) for redhat, certified, and community operator indexes.

Made-with: Cursor