### PR TITLE
fix: set NODE_ENV in Dockerfile + refresh catalog metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,8 @@ RUN set -eux; \
 
 FROM node:22-slim AS production
 
+ENV NODE_ENV=production
+
 ARG BUILD_DATE=""
 ARG VCS_REF=""
 ARG VERSION=1.0

--- a/catalog-data/catalog-index.json
+++ b/catalog-data/catalog-index.json
@@ -89,7 +89,7 @@
       "catalog_type": "redhat-operator-index",
       "ocp_version": "v4.20",
       "catalog_url": "registry.redhat.io/redhat/redhat-operator-index:v4.20",
-      "operator_count": 149
+      "operator_count": 150
     },
     {
       "catalog_type": "certified-operator-index",
@@ -107,7 +107,7 @@
       "catalog_type": "redhat-operator-index",
       "ocp_version": "v4.21",
       "catalog_url": "registry.redhat.io/redhat/redhat-operator-index:v4.21",
-      "operator_count": 143
+      "operator_count": 144
     },
     {
       "catalog_type": "certified-operator-index",
@@ -119,7 +119,7 @@
       "catalog_type": "community-operator-index",
       "ocp_version": "v4.21",
       "catalog_url": "registry.redhat.io/redhat/community-operator-index:v4.21",
-      "operator_count": 270
+      "operator_count": 271
     }
   ]
 }

--- a/catalog-data/certified-operator-index/v4.16/operators.json
+++ b/catalog-data/certified-operator-index/v4.16/operators.json
@@ -1320,7 +1320,8 @@
         "1.16.17-cee.1",
         "1.16.19-cee.1",
         "1.16.20-cee.1",
-        "1.16.21-cee.1"
+        "1.16.21-cee.1",
+        "1.16.22-cee.1"
       ],
       "1.17": [
         "0.0.1",
@@ -1333,7 +1334,8 @@
         "1.17.10-cee.2",
         "1.17.12-cee.1",
         "1.17.13-cee.1",
-        "1.17.14-cee.1"
+        "1.17.14-cee.1",
+        "1.17.15-cee.1"
       ],
       "1.18": [
         "1.18.4-cee.1",
@@ -1341,21 +1343,22 @@
         "1.18.6-cee.2",
         "1.18.7-cee.1",
         "1.18.8-cee.1",
-        "1.18.8-cee.2"
+        "1.18.8-cee.2",
+        "1.18.9-cee.1"
       ]
     },
     "channelVersionRanges": {
       "1.16": {
         "minVersion": "1.16.17-cee.1",
-        "maxVersion": "1.16.21-cee.1"
+        "maxVersion": "1.16.22-cee.1"
       },
       "1.17": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.17.14-cee.1"
+        "maxVersion": "1.17.15-cee.1"
       },
       "1.18": {
         "minVersion": "1.18.4-cee.1",
-        "maxVersion": "1.18.8-cee.2"
+        "maxVersion": "1.18.9-cee.1"
       }
     },
     "availableVersions": [
@@ -1364,6 +1367,7 @@
       "1.16.19-cee.1",
       "1.16.20-cee.1",
       "1.16.21-cee.1",
+      "1.16.22-cee.1",
       "1.17.4-cee.1",
       "1.17.5-cee.1",
       "1.17.7-cee.1",
@@ -1374,15 +1378,17 @@
       "1.17.12-cee.1",
       "1.17.13-cee.1",
       "1.17.14-cee.1",
+      "1.17.15-cee.1",
       "1.18.4-cee.1",
       "1.18.6-cee.1",
       "1.18.6-cee.2",
       "1.18.7-cee.1",
       "1.18.8-cee.1",
-      "1.18.8-cee.2"
+      "1.18.8-cee.2",
+      "1.18.9-cee.1"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.18.8-cee.2",
+    "maxVersion": "1.18.9-cee.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"
@@ -2153,7 +2159,8 @@
         "6.2.2"
       ],
       "v6.4": [
-        "6.4.0"
+        "6.4.0",
+        "6.4.2"
       ]
     },
     "channelVersionRanges": {
@@ -2167,16 +2174,17 @@
       },
       "v6.4": {
         "minVersion": "6.4.0",
-        "maxVersion": "6.4.0"
+        "maxVersion": "6.4.2"
       }
     },
     "availableVersions": [
       "6.1.3",
       "6.2.2",
-      "6.4.0"
+      "6.4.0",
+      "6.4.2"
     ],
     "minVersion": "6.1.3",
-    "maxVersion": "6.4.0",
+    "maxVersion": "6.4.2",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"
@@ -2561,7 +2569,8 @@
       "stable",
       "stable-v24.1",
       "stable-v24.3",
-      "stable-v25.1"
+      "stable-v25.1",
+      "stable-v26.1"
     ],
     "channelVersions": {
       "beta": [
@@ -2601,7 +2610,12 @@
         "25.1.6",
         "25.1.8",
         "25.1.9",
+        "25.1.10",
         "25.1.10-1"
+      ],
+      "stable-v26.1": [
+        "26.1.0",
+        "26.1.1"
       ]
     },
     "channelVersionRanges": {
@@ -2624,6 +2638,10 @@
       "stable-v25.1": {
         "minVersion": "25.1.0",
         "maxVersion": "25.1.10-1"
+      },
+      "stable-v26.1": {
+        "minVersion": "26.1.0",
+        "maxVersion": "26.1.1"
       }
     },
     "availableVersions": [
@@ -2653,11 +2671,13 @@
       "25.1.6",
       "25.1.8",
       "25.1.9",
+      "25.1.10",
       "25.1.10-1",
-      "26.1.0"
+      "26.1.0",
+      "26.1.1"
     ],
     "minVersion": "24.1.10",
-    "maxVersion": "26.1.0",
+    "maxVersion": "26.1.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"
@@ -3158,20 +3178,22 @@
     ],
     "channelVersions": {
       "stable": [
-        "8.1.2"
+        "8.1.2",
+        "8.1.3"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "8.1.2",
-        "maxVersion": "8.1.2"
+        "maxVersion": "8.1.3"
       }
     },
     "availableVersions": [
-      "8.1.2"
+      "8.1.2",
+      "8.1.3"
     ],
     "minVersion": "8.1.2",
-    "maxVersion": "8.1.2",
+    "maxVersion": "8.1.3",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"
@@ -3240,33 +3262,36 @@
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ],
       "unstable": [
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.9.2",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       },
       "unstable": {
         "minVersion": "2.9.2",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       }
     },
     "availableVersions": [
       "2.9.2",
       "2.10.0",
       "2.10.1",
-      "2.11.0"
+      "2.11.0",
+      "2.11.1"
     ],
     "minVersion": "2.9.2",
-    "maxVersion": "2.11.0",
+    "maxVersion": "2.11.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"
@@ -3288,13 +3313,14 @@
         "1.46.0",
         "1.47.0",
         "1.47.1",
-        "1.48.0"
+        "1.48.0",
+        "1.48.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.42.0",
-        "maxVersion": "1.48.0"
+        "maxVersion": "1.48.1"
       }
     },
     "availableVersions": [
@@ -3307,10 +3333,11 @@
       "1.46.0",
       "1.47.0",
       "1.47.1",
-      "1.48.0"
+      "1.48.0",
+      "1.48.1"
     ],
     "minVersion": "1.42.0",
-    "maxVersion": "1.48.0",
+    "maxVersion": "1.48.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"
@@ -3364,7 +3391,8 @@
         "25.3.4",
         "25.10.0",
         "25.10.1",
-        "26.3.0"
+        "26.3.0",
+        "26.3.1"
       ],
       "v1.10": [
         "1.10.0",
@@ -3552,13 +3580,14 @@
         "25.3.4"
       ],
       "v26.3": [
-        "26.3.0"
+        "26.3.0",
+        "26.3.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.10.0",
-        "maxVersion": "26.3.0"
+        "maxVersion": "26.3.1"
       },
       "v1.10": {
         "minVersion": "1.10.0",
@@ -3606,7 +3635,7 @@
       },
       "v26.3": {
         "minVersion": "26.3.0",
-        "maxVersion": "26.3.0"
+        "maxVersion": "26.3.1"
       }
     },
     "availableVersions": [
@@ -3639,10 +3668,11 @@
       "25.3.4",
       "25.10.0",
       "25.10.1",
-      "26.3.0"
+      "26.3.0",
+      "26.3.1"
     ],
     "minVersion": "1.10.0",
-    "maxVersion": "26.3.0",
+    "maxVersion": "26.3.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"
@@ -6490,7 +6520,7 @@
     ],
     "channelVersions": {
       "beta": [
-        "8.19.40-beta.1"
+        "8.19.50-beta.1"
       ],
       "stable": [
         "8.19.40"
@@ -6498,8 +6528,8 @@
     },
     "channelVersionRanges": {
       "beta": {
-        "minVersion": "8.19.40-beta.1",
-        "maxVersion": "8.19.40-beta.1"
+        "minVersion": "8.19.50-beta.1",
+        "maxVersion": "8.19.50-beta.1"
       },
       "stable": {
         "minVersion": "8.19.40",
@@ -6508,10 +6538,10 @@
     },
     "availableVersions": [
       "8.19.40",
-      "8.19.40-beta.1"
+      "8.19.50-beta.1"
     ],
     "minVersion": "8.19.40",
-    "maxVersion": "8.19.40-beta.1",
+    "maxVersion": "8.19.50-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"
@@ -6700,7 +6730,7 @@
     ],
     "channelVersions": {
       "alpha": [
-        "8.19.40-beta.1"
+        "8.19.50-beta.1"
       ],
       "stable": [
         "8.19.40"
@@ -6708,8 +6738,8 @@
     },
     "channelVersionRanges": {
       "alpha": {
-        "minVersion": "8.19.40-beta.1",
-        "maxVersion": "8.19.40-beta.1"
+        "minVersion": "8.19.50-beta.1",
+        "maxVersion": "8.19.50-beta.1"
       },
       "stable": {
         "minVersion": "8.19.40",
@@ -6718,10 +6748,10 @@
     },
     "availableVersions": [
       "8.19.40",
-      "8.19.40-beta.1"
+      "8.19.50-beta.1"
     ],
     "minVersion": "8.19.40",
-    "maxVersion": "8.19.40-beta.1",
+    "maxVersion": "8.19.50-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"
@@ -8426,7 +8456,7 @@
     ],
     "channelVersions": {
       "beta": [
-        "8.19.40-beta.1"
+        "8.19.50-beta.1"
       ],
       "stable": [
         "8.19.40"
@@ -8434,8 +8464,8 @@
     },
     "channelVersionRanges": {
       "beta": {
-        "minVersion": "8.19.40-beta.1",
-        "maxVersion": "8.19.40-beta.1"
+        "minVersion": "8.19.50-beta.1",
+        "maxVersion": "8.19.50-beta.1"
       },
       "stable": {
         "minVersion": "8.19.40",
@@ -8444,10 +8474,10 @@
     },
     "availableVersions": [
       "8.19.40",
-      "8.19.40-beta.1"
+      "8.19.50-beta.1"
     ],
     "minVersion": "8.19.40",
-    "maxVersion": "8.19.40-beta.1",
+    "maxVersion": "8.19.50-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"
@@ -9374,13 +9404,14 @@
   },
   {
     "name": "scaleops-operator",
-    "defaultChannel": "stable-v1.29",
+    "defaultChannel": "stable-v1.30",
     "channels": [
       "stable-v1",
       "stable-v1.26",
       "stable-v1.27",
       "stable-v1.28",
-      "stable-v1.29"
+      "stable-v1.29",
+      "stable-v1.30"
     ],
     "channelVersions": {
       "stable-v1": [
@@ -9433,7 +9464,8 @@
         "1.29.7",
         "1.29.8",
         "1.29.10",
-        "1.29.11"
+        "1.29.11",
+        "1.30.0"
       ],
       "stable-v1.26": [
         "1.26.8",
@@ -9492,12 +9524,15 @@
         "1.29.8",
         "1.29.10",
         "1.29.11"
+      ],
+      "stable-v1.30": [
+        "1.30.0"
       ]
     },
     "channelVersionRanges": {
       "stable-v1": {
         "minVersion": "1.26.8",
-        "maxVersion": "1.29.11"
+        "maxVersion": "1.30.0"
       },
       "stable-v1.26": {
         "minVersion": "1.26.8",
@@ -9514,6 +9549,10 @@
       "stable-v1.29": {
         "minVersion": "1.29.3",
         "maxVersion": "1.29.11"
+      },
+      "stable-v1.30": {
+        "minVersion": "1.30.0",
+        "maxVersion": "1.30.0"
       }
     },
     "availableVersions": [
@@ -9566,10 +9605,11 @@
       "1.29.7",
       "1.29.8",
       "1.29.10",
-      "1.29.11"
+      "1.29.11",
+      "1.30.0"
     ],
     "minVersion": "1.26.8",
-    "maxVersion": "1.29.11",
+    "maxVersion": "1.30.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"
@@ -10765,20 +10805,24 @@
     ],
     "channelVersions": {
       "alpha": [
-        "4.21.0-0"
+        "4.21.0-0",
+        "4.27.1-0",
+        "4.27.1-1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "4.21.0-0",
-        "maxVersion": "4.21.0-0"
+        "maxVersion": "4.27.1-1"
       }
     },
     "availableVersions": [
-      "4.21.0-0"
+      "4.21.0-0",
+      "4.27.1-0",
+      "4.27.1-1"
     ],
     "minVersion": "4.21.0-0",
-    "maxVersion": "4.21.0-0",
+    "maxVersion": "4.27.1-1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.16"
@@ -10881,7 +10925,7 @@
   },
   {
     "name": "tawon-operator",
-    "defaultChannel": "candidate-v2",
+    "defaultChannel": "fast-v2",
     "channels": [
       "alpha",
       "candidate-v2",
@@ -10907,7 +10951,8 @@
         "2.39.32",
         "2.39.34",
         "2.39.35",
-        "2.39.37"
+        "2.39.37",
+        "2.40.0"
       ]
     },
     "channelVersionRanges": {
@@ -10921,7 +10966,7 @@
       },
       "fast-v2": {
         "minVersion": "2.39.27",
-        "maxVersion": "2.39.37"
+        "maxVersion": "2.40.0"
       }
     },
     "availableVersions": [
@@ -10938,6 +10983,7 @@
       "2.39.36-rc1",
       "2.39.36-rc2",
       "2.39.37",
+      "2.40.0",
       "2.40.0-rc19",
       "2.40.0-rc20"
     ],

--- a/catalog-data/certified-operator-index/v4.17/operators.json
+++ b/catalog-data/certified-operator-index/v4.17/operators.json
@@ -1316,7 +1316,8 @@
         "1.16.17-cee.1",
         "1.16.19-cee.1",
         "1.16.20-cee.1",
-        "1.16.21-cee.1"
+        "1.16.21-cee.1",
+        "1.16.22-cee.1"
       ],
       "1.17": [
         "0.0.1",
@@ -1329,7 +1330,8 @@
         "1.17.10-cee.2",
         "1.17.12-cee.1",
         "1.17.13-cee.1",
-        "1.17.14-cee.1"
+        "1.17.14-cee.1",
+        "1.17.15-cee.1"
       ],
       "1.18": [
         "1.18.4-cee.1",
@@ -1337,21 +1339,22 @@
         "1.18.6-cee.2",
         "1.18.7-cee.1",
         "1.18.8-cee.1",
-        "1.18.8-cee.2"
+        "1.18.8-cee.2",
+        "1.18.9-cee.1"
       ]
     },
     "channelVersionRanges": {
       "1.16": {
         "minVersion": "1.16.17-cee.1",
-        "maxVersion": "1.16.21-cee.1"
+        "maxVersion": "1.16.22-cee.1"
       },
       "1.17": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.17.14-cee.1"
+        "maxVersion": "1.17.15-cee.1"
       },
       "1.18": {
         "minVersion": "1.18.4-cee.1",
-        "maxVersion": "1.18.8-cee.2"
+        "maxVersion": "1.18.9-cee.1"
       }
     },
     "availableVersions": [
@@ -1360,6 +1363,7 @@
       "1.16.19-cee.1",
       "1.16.20-cee.1",
       "1.16.21-cee.1",
+      "1.16.22-cee.1",
       "1.17.4-cee.1",
       "1.17.5-cee.1",
       "1.17.7-cee.1",
@@ -1370,15 +1374,17 @@
       "1.17.12-cee.1",
       "1.17.13-cee.1",
       "1.17.14-cee.1",
+      "1.17.15-cee.1",
       "1.18.4-cee.1",
       "1.18.6-cee.1",
       "1.18.6-cee.2",
       "1.18.7-cee.1",
       "1.18.8-cee.1",
-      "1.18.8-cee.2"
+      "1.18.8-cee.2",
+      "1.18.9-cee.1"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.18.8-cee.2",
+    "maxVersion": "1.18.9-cee.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -2140,7 +2146,8 @@
         "6.2.2"
       ],
       "v6.4": [
-        "6.4.0"
+        "6.4.0",
+        "6.4.2"
       ]
     },
     "channelVersionRanges": {
@@ -2154,16 +2161,17 @@
       },
       "v6.4": {
         "minVersion": "6.4.0",
-        "maxVersion": "6.4.0"
+        "maxVersion": "6.4.2"
       }
     },
     "availableVersions": [
       "6.1.3",
       "6.2.2",
-      "6.4.0"
+      "6.4.0",
+      "6.4.2"
     ],
     "minVersion": "6.1.3",
-    "maxVersion": "6.4.0",
+    "maxVersion": "6.4.2",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -2556,7 +2564,8 @@
       "stable",
       "stable-v24.1",
       "stable-v24.3",
-      "stable-v25.1"
+      "stable-v25.1",
+      "stable-v26.1"
     ],
     "channelVersions": {
       "beta": [
@@ -2596,7 +2605,12 @@
         "25.1.6",
         "25.1.8",
         "25.1.9",
+        "25.1.10",
         "25.1.10-1"
+      ],
+      "stable-v26.1": [
+        "26.1.0",
+        "26.1.1"
       ]
     },
     "channelVersionRanges": {
@@ -2619,6 +2633,10 @@
       "stable-v25.1": {
         "minVersion": "25.1.0",
         "maxVersion": "25.1.10-1"
+      },
+      "stable-v26.1": {
+        "minVersion": "26.1.0",
+        "maxVersion": "26.1.1"
       }
     },
     "availableVersions": [
@@ -2648,11 +2666,13 @@
       "25.1.6",
       "25.1.8",
       "25.1.9",
+      "25.1.10",
       "25.1.10-1",
-      "26.1.0"
+      "26.1.0",
+      "26.1.1"
     ],
     "minVersion": "24.1.10",
-    "maxVersion": "26.1.0",
+    "maxVersion": "26.1.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -2822,7 +2842,8 @@
         "2025.12.0",
         "2026.1.0",
         "2026.2.0",
-        "2026.3.0"
+        "2026.3.0",
+        "2026.4.1"
       ],
       "lts-v1.3": [
         "1.3.2",
@@ -2854,7 +2875,7 @@
       },
       "innovation": {
         "minVersion": "2025.11.0",
-        "maxVersion": "2026.3.0"
+        "maxVersion": "2026.4.1"
       },
       "lts-v1.3": {
         "minVersion": "1.3.2",
@@ -2882,10 +2903,11 @@
       "2025.12.0",
       "2026.1.0",
       "2026.2.0",
-      "2026.3.0"
+      "2026.3.0",
+      "2026.4.1"
     ],
     "minVersion": "1.2.0",
-    "maxVersion": "2026.3.0",
+    "maxVersion": "2026.4.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -3251,20 +3273,22 @@
     ],
     "channelVersions": {
       "stable": [
-        "8.1.2"
+        "8.1.2",
+        "8.1.3"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "8.1.2",
-        "maxVersion": "8.1.2"
+        "maxVersion": "8.1.3"
       }
     },
     "availableVersions": [
-      "8.1.2"
+      "8.1.2",
+      "8.1.3"
     ],
     "minVersion": "8.1.2",
-    "maxVersion": "8.1.2",
+    "maxVersion": "8.1.3",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -3307,33 +3331,36 @@
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ],
       "unstable": [
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.9.2",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       },
       "unstable": {
         "minVersion": "2.9.2",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       }
     },
     "availableVersions": [
       "2.9.2",
       "2.10.0",
       "2.10.1",
-      "2.11.0"
+      "2.11.0",
+      "2.11.1"
     ],
     "minVersion": "2.9.2",
-    "maxVersion": "2.11.0",
+    "maxVersion": "2.11.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -3355,13 +3382,14 @@
         "1.46.0",
         "1.47.0",
         "1.47.1",
-        "1.48.0"
+        "1.48.0",
+        "1.48.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.42.0",
-        "maxVersion": "1.48.0"
+        "maxVersion": "1.48.1"
       }
     },
     "availableVersions": [
@@ -3374,10 +3402,11 @@
       "1.46.0",
       "1.47.0",
       "1.47.1",
-      "1.48.0"
+      "1.48.0",
+      "1.48.1"
     ],
     "minVersion": "1.42.0",
-    "maxVersion": "1.48.0",
+    "maxVersion": "1.48.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -3431,7 +3460,8 @@
         "25.3.4",
         "25.10.0",
         "25.10.1",
-        "26.3.0"
+        "26.3.0",
+        "26.3.1"
       ],
       "v1.10": [
         "1.10.0",
@@ -3619,13 +3649,14 @@
         "25.3.4"
       ],
       "v26.3": [
-        "26.3.0"
+        "26.3.0",
+        "26.3.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.10.0",
-        "maxVersion": "26.3.0"
+        "maxVersion": "26.3.1"
       },
       "v1.10": {
         "minVersion": "1.10.0",
@@ -3673,7 +3704,7 @@
       },
       "v26.3": {
         "minVersion": "26.3.0",
-        "maxVersion": "26.3.0"
+        "maxVersion": "26.3.1"
       }
     },
     "availableVersions": [
@@ -3706,10 +3737,11 @@
       "25.3.4",
       "25.10.0",
       "25.10.1",
-      "26.3.0"
+      "26.3.0",
+      "26.3.1"
     ],
     "minVersion": "1.10.0",
-    "maxVersion": "26.3.0",
+    "maxVersion": "26.3.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -6577,7 +6609,7 @@
     ],
     "channelVersions": {
       "beta": [
-        "8.19.40-beta.1"
+        "8.19.50-beta.1"
       ],
       "stable": [
         "8.19.40"
@@ -6585,8 +6617,8 @@
     },
     "channelVersionRanges": {
       "beta": {
-        "minVersion": "8.19.40-beta.1",
-        "maxVersion": "8.19.40-beta.1"
+        "minVersion": "8.19.50-beta.1",
+        "maxVersion": "8.19.50-beta.1"
       },
       "stable": {
         "minVersion": "8.19.40",
@@ -6595,10 +6627,10 @@
     },
     "availableVersions": [
       "8.19.40",
-      "8.19.40-beta.1"
+      "8.19.50-beta.1"
     ],
     "minVersion": "8.19.40",
-    "maxVersion": "8.19.40-beta.1",
+    "maxVersion": "8.19.50-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -6813,7 +6845,7 @@
     ],
     "channelVersions": {
       "alpha": [
-        "8.19.40-beta.1"
+        "8.19.50-beta.1"
       ],
       "stable": [
         "8.19.40"
@@ -6821,8 +6853,8 @@
     },
     "channelVersionRanges": {
       "alpha": {
-        "minVersion": "8.19.40-beta.1",
-        "maxVersion": "8.19.40-beta.1"
+        "minVersion": "8.19.50-beta.1",
+        "maxVersion": "8.19.50-beta.1"
       },
       "stable": {
         "minVersion": "8.19.40",
@@ -6831,10 +6863,10 @@
     },
     "availableVersions": [
       "8.19.40",
-      "8.19.40-beta.1"
+      "8.19.50-beta.1"
     ],
     "minVersion": "8.19.40",
-    "maxVersion": "8.19.40-beta.1",
+    "maxVersion": "8.19.50-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -8487,7 +8519,7 @@
     ],
     "channelVersions": {
       "beta": [
-        "8.19.40-beta.1"
+        "8.19.50-beta.1"
       ],
       "stable": [
         "8.19.40"
@@ -8495,8 +8527,8 @@
     },
     "channelVersionRanges": {
       "beta": {
-        "minVersion": "8.19.40-beta.1",
-        "maxVersion": "8.19.40-beta.1"
+        "minVersion": "8.19.50-beta.1",
+        "maxVersion": "8.19.50-beta.1"
       },
       "stable": {
         "minVersion": "8.19.40",
@@ -8505,10 +8537,10 @@
     },
     "availableVersions": [
       "8.19.40",
-      "8.19.40-beta.1"
+      "8.19.50-beta.1"
     ],
     "minVersion": "8.19.40",
-    "maxVersion": "8.19.40-beta.1",
+    "maxVersion": "8.19.50-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -9517,13 +9549,14 @@
   },
   {
     "name": "scaleops-operator",
-    "defaultChannel": "stable-v1.29",
+    "defaultChannel": "stable-v1.30",
     "channels": [
       "stable-v1",
       "stable-v1.26",
       "stable-v1.27",
       "stable-v1.28",
-      "stable-v1.29"
+      "stable-v1.29",
+      "stable-v1.30"
     ],
     "channelVersions": {
       "stable-v1": [
@@ -9576,7 +9609,8 @@
         "1.29.7",
         "1.29.8",
         "1.29.10",
-        "1.29.11"
+        "1.29.11",
+        "1.30.0"
       ],
       "stable-v1.26": [
         "1.26.8",
@@ -9635,12 +9669,15 @@
         "1.29.8",
         "1.29.10",
         "1.29.11"
+      ],
+      "stable-v1.30": [
+        "1.30.0"
       ]
     },
     "channelVersionRanges": {
       "stable-v1": {
         "minVersion": "1.26.8",
-        "maxVersion": "1.29.11"
+        "maxVersion": "1.30.0"
       },
       "stable-v1.26": {
         "minVersion": "1.26.8",
@@ -9657,6 +9694,10 @@
       "stable-v1.29": {
         "minVersion": "1.29.3",
         "maxVersion": "1.29.11"
+      },
+      "stable-v1.30": {
+        "minVersion": "1.30.0",
+        "maxVersion": "1.30.0"
       }
     },
     "availableVersions": [
@@ -9709,10 +9750,11 @@
       "1.29.7",
       "1.29.8",
       "1.29.10",
-      "1.29.11"
+      "1.29.11",
+      "1.30.0"
     ],
     "minVersion": "1.26.8",
-    "maxVersion": "1.29.11",
+    "maxVersion": "1.30.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"
@@ -10773,20 +10815,24 @@
     ],
     "channelVersions": {
       "alpha": [
-        "4.21.0-0"
+        "4.21.0-0",
+        "4.27.1-0",
+        "4.27.1-1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "4.21.0-0",
-        "maxVersion": "4.21.0-0"
+        "maxVersion": "4.27.1-1"
       }
     },
     "availableVersions": [
-      "4.21.0-0"
+      "4.21.0-0",
+      "4.27.1-0",
+      "4.27.1-1"
     ],
     "minVersion": "4.21.0-0",
-    "maxVersion": "4.21.0-0",
+    "maxVersion": "4.27.1-1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.17"

--- a/catalog-data/certified-operator-index/v4.18/operators.json
+++ b/catalog-data/certified-operator-index/v4.18/operators.json
@@ -1290,7 +1290,8 @@
         "1.16.17-cee.1",
         "1.16.19-cee.1",
         "1.16.20-cee.1",
-        "1.16.21-cee.1"
+        "1.16.21-cee.1",
+        "1.16.22-cee.1"
       ],
       "1.17": [
         "0.0.1",
@@ -1303,7 +1304,8 @@
         "1.17.10-cee.2",
         "1.17.12-cee.1",
         "1.17.13-cee.1",
-        "1.17.14-cee.1"
+        "1.17.14-cee.1",
+        "1.17.15-cee.1"
       ],
       "1.18": [
         "1.18.4-cee.1",
@@ -1311,21 +1313,22 @@
         "1.18.6-cee.2",
         "1.18.7-cee.1",
         "1.18.8-cee.1",
-        "1.18.8-cee.2"
+        "1.18.8-cee.2",
+        "1.18.9-cee.1"
       ]
     },
     "channelVersionRanges": {
       "1.16": {
         "minVersion": "1.16.17-cee.1",
-        "maxVersion": "1.16.21-cee.1"
+        "maxVersion": "1.16.22-cee.1"
       },
       "1.17": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.17.14-cee.1"
+        "maxVersion": "1.17.15-cee.1"
       },
       "1.18": {
         "minVersion": "1.18.4-cee.1",
-        "maxVersion": "1.18.8-cee.2"
+        "maxVersion": "1.18.9-cee.1"
       }
     },
     "availableVersions": [
@@ -1334,6 +1337,7 @@
       "1.16.19-cee.1",
       "1.16.20-cee.1",
       "1.16.21-cee.1",
+      "1.16.22-cee.1",
       "1.17.4-cee.1",
       "1.17.5-cee.1",
       "1.17.7-cee.1",
@@ -1344,15 +1348,17 @@
       "1.17.12-cee.1",
       "1.17.13-cee.1",
       "1.17.14-cee.1",
+      "1.17.15-cee.1",
       "1.18.4-cee.1",
       "1.18.6-cee.1",
       "1.18.6-cee.2",
       "1.18.7-cee.1",
       "1.18.8-cee.1",
-      "1.18.8-cee.2"
+      "1.18.8-cee.2",
+      "1.18.9-cee.1"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.18.8-cee.2",
+    "maxVersion": "1.18.9-cee.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -2103,7 +2109,8 @@
         "6.2.2"
       ],
       "v6.4": [
-        "6.4.0"
+        "6.4.0",
+        "6.4.2"
       ]
     },
     "channelVersionRanges": {
@@ -2117,16 +2124,17 @@
       },
       "v6.4": {
         "minVersion": "6.4.0",
-        "maxVersion": "6.4.0"
+        "maxVersion": "6.4.2"
       }
     },
     "availableVersions": [
       "6.1.3",
       "6.2.2",
-      "6.4.0"
+      "6.4.0",
+      "6.4.2"
     ],
     "minVersion": "6.1.3",
-    "maxVersion": "6.4.0",
+    "maxVersion": "6.4.2",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -2493,7 +2501,8 @@
       "stable",
       "stable-v24.1",
       "stable-v24.3",
-      "stable-v25.1"
+      "stable-v25.1",
+      "stable-v26.1"
     ],
     "channelVersions": {
       "beta": [
@@ -2533,7 +2542,12 @@
         "25.1.6",
         "25.1.8",
         "25.1.9",
+        "25.1.10",
         "25.1.10-1"
+      ],
+      "stable-v26.1": [
+        "26.1.0",
+        "26.1.1"
       ]
     },
     "channelVersionRanges": {
@@ -2556,6 +2570,10 @@
       "stable-v25.1": {
         "minVersion": "25.1.0",
         "maxVersion": "25.1.10-1"
+      },
+      "stable-v26.1": {
+        "minVersion": "26.1.0",
+        "maxVersion": "26.1.1"
       }
     },
     "availableVersions": [
@@ -2585,11 +2603,13 @@
       "25.1.6",
       "25.1.8",
       "25.1.9",
+      "25.1.10",
       "25.1.10-1",
-      "26.1.0"
+      "26.1.0",
+      "26.1.1"
     ],
     "minVersion": "24.1.10",
-    "maxVersion": "26.1.0",
+    "maxVersion": "26.1.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -2759,7 +2779,8 @@
         "2025.12.0",
         "2026.1.0",
         "2026.2.0",
-        "2026.3.0"
+        "2026.3.0",
+        "2026.4.1"
       ],
       "lts-v1.3": [
         "1.3.2",
@@ -2791,7 +2812,7 @@
       },
       "innovation": {
         "minVersion": "2025.11.0",
-        "maxVersion": "2026.3.0"
+        "maxVersion": "2026.4.1"
       },
       "lts-v1.3": {
         "minVersion": "1.3.2",
@@ -2819,10 +2840,11 @@
       "2025.12.0",
       "2026.1.0",
       "2026.2.0",
-      "2026.3.0"
+      "2026.3.0",
+      "2026.4.1"
     ],
     "minVersion": "1.2.0",
-    "maxVersion": "2026.3.0",
+    "maxVersion": "2026.4.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -3188,20 +3210,22 @@
     ],
     "channelVersions": {
       "stable": [
-        "8.1.2"
+        "8.1.2",
+        "8.1.3"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "8.1.2",
-        "maxVersion": "8.1.2"
+        "maxVersion": "8.1.3"
       }
     },
     "availableVersions": [
-      "8.1.2"
+      "8.1.2",
+      "8.1.3"
     ],
     "minVersion": "8.1.2",
-    "maxVersion": "8.1.2",
+    "maxVersion": "8.1.3",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -3244,33 +3268,36 @@
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ],
       "unstable": [
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.9.2",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       },
       "unstable": {
         "minVersion": "2.9.2",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       }
     },
     "availableVersions": [
       "2.9.2",
       "2.10.0",
       "2.10.1",
-      "2.11.0"
+      "2.11.0",
+      "2.11.1"
     ],
     "minVersion": "2.9.2",
-    "maxVersion": "2.11.0",
+    "maxVersion": "2.11.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -3292,13 +3319,14 @@
         "1.46.0",
         "1.47.0",
         "1.47.1",
-        "1.48.0"
+        "1.48.0",
+        "1.48.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.42.0",
-        "maxVersion": "1.48.0"
+        "maxVersion": "1.48.1"
       }
     },
     "availableVersions": [
@@ -3311,10 +3339,11 @@
       "1.46.0",
       "1.47.0",
       "1.47.1",
-      "1.48.0"
+      "1.48.0",
+      "1.48.1"
     ],
     "minVersion": "1.42.0",
-    "maxVersion": "1.48.0",
+    "maxVersion": "1.48.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -3368,7 +3397,8 @@
         "25.3.4",
         "25.10.0",
         "25.10.1",
-        "26.3.0"
+        "26.3.0",
+        "26.3.1"
       ],
       "v1.10": [
         "1.10.0",
@@ -3556,13 +3586,14 @@
         "25.3.4"
       ],
       "v26.3": [
-        "26.3.0"
+        "26.3.0",
+        "26.3.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.10.0",
-        "maxVersion": "26.3.0"
+        "maxVersion": "26.3.1"
       },
       "v1.10": {
         "minVersion": "1.10.0",
@@ -3610,7 +3641,7 @@
       },
       "v26.3": {
         "minVersion": "26.3.0",
-        "maxVersion": "26.3.0"
+        "maxVersion": "26.3.1"
       }
     },
     "availableVersions": [
@@ -3643,10 +3674,11 @@
       "25.3.4",
       "25.10.0",
       "25.10.1",
-      "26.3.0"
+      "26.3.0",
+      "26.3.1"
     ],
     "minVersion": "1.10.0",
-    "maxVersion": "26.3.0",
+    "maxVersion": "26.3.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -6490,7 +6522,7 @@
     ],
     "channelVersions": {
       "beta": [
-        "8.19.40-beta.1"
+        "8.19.50-beta.1"
       ],
       "stable": [
         "8.19.40"
@@ -6498,8 +6530,8 @@
     },
     "channelVersionRanges": {
       "beta": {
-        "minVersion": "8.19.40-beta.1",
-        "maxVersion": "8.19.40-beta.1"
+        "minVersion": "8.19.50-beta.1",
+        "maxVersion": "8.19.50-beta.1"
       },
       "stable": {
         "minVersion": "8.19.40",
@@ -6508,10 +6540,10 @@
     },
     "availableVersions": [
       "8.19.40",
-      "8.19.40-beta.1"
+      "8.19.50-beta.1"
     ],
     "minVersion": "8.19.40",
-    "maxVersion": "8.19.40-beta.1",
+    "maxVersion": "8.19.50-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -6726,7 +6758,7 @@
     ],
     "channelVersions": {
       "alpha": [
-        "8.19.40-beta.1"
+        "8.19.50-beta.1"
       ],
       "stable": [
         "8.19.40"
@@ -6734,8 +6766,8 @@
     },
     "channelVersionRanges": {
       "alpha": {
-        "minVersion": "8.19.40-beta.1",
-        "maxVersion": "8.19.40-beta.1"
+        "minVersion": "8.19.50-beta.1",
+        "maxVersion": "8.19.50-beta.1"
       },
       "stable": {
         "minVersion": "8.19.40",
@@ -6744,10 +6776,10 @@
     },
     "availableVersions": [
       "8.19.40",
-      "8.19.40-beta.1"
+      "8.19.50-beta.1"
     ],
     "minVersion": "8.19.40",
-    "maxVersion": "8.19.40-beta.1",
+    "maxVersion": "8.19.50-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -8394,7 +8426,7 @@
     ],
     "channelVersions": {
       "beta": [
-        "8.19.40-beta.1"
+        "8.19.50-beta.1"
       ],
       "stable": [
         "8.19.40"
@@ -8402,8 +8434,8 @@
     },
     "channelVersionRanges": {
       "beta": {
-        "minVersion": "8.19.40-beta.1",
-        "maxVersion": "8.19.40-beta.1"
+        "minVersion": "8.19.50-beta.1",
+        "maxVersion": "8.19.50-beta.1"
       },
       "stable": {
         "minVersion": "8.19.40",
@@ -8412,10 +8444,10 @@
     },
     "availableVersions": [
       "8.19.40",
-      "8.19.40-beta.1"
+      "8.19.50-beta.1"
     ],
     "minVersion": "8.19.40",
-    "maxVersion": "8.19.40-beta.1",
+    "maxVersion": "8.19.50-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -9424,13 +9456,14 @@
   },
   {
     "name": "scaleops-operator",
-    "defaultChannel": "stable-v1.29",
+    "defaultChannel": "stable-v1.30",
     "channels": [
       "stable-v1",
       "stable-v1.26",
       "stable-v1.27",
       "stable-v1.28",
-      "stable-v1.29"
+      "stable-v1.29",
+      "stable-v1.30"
     ],
     "channelVersions": {
       "stable-v1": [
@@ -9483,7 +9516,8 @@
         "1.29.7",
         "1.29.8",
         "1.29.10",
-        "1.29.11"
+        "1.29.11",
+        "1.30.0"
       ],
       "stable-v1.26": [
         "1.26.8",
@@ -9542,12 +9576,15 @@
         "1.29.8",
         "1.29.10",
         "1.29.11"
+      ],
+      "stable-v1.30": [
+        "1.30.0"
       ]
     },
     "channelVersionRanges": {
       "stable-v1": {
         "minVersion": "1.26.8",
-        "maxVersion": "1.29.11"
+        "maxVersion": "1.30.0"
       },
       "stable-v1.26": {
         "minVersion": "1.26.8",
@@ -9564,6 +9601,10 @@
       "stable-v1.29": {
         "minVersion": "1.29.3",
         "maxVersion": "1.29.11"
+      },
+      "stable-v1.30": {
+        "minVersion": "1.30.0",
+        "maxVersion": "1.30.0"
       }
     },
     "availableVersions": [
@@ -9616,10 +9657,11 @@
       "1.29.7",
       "1.29.8",
       "1.29.10",
-      "1.29.11"
+      "1.29.11",
+      "1.30.0"
     ],
     "minVersion": "1.26.8",
-    "maxVersion": "1.29.11",
+    "maxVersion": "1.30.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"
@@ -10952,20 +10994,24 @@
     ],
     "channelVersions": {
       "alpha": [
-        "4.21.0-0"
+        "4.21.0-0",
+        "4.27.1-0",
+        "4.27.1-1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "4.21.0-0",
-        "maxVersion": "4.21.0-0"
+        "maxVersion": "4.27.1-1"
       }
     },
     "availableVersions": [
-      "4.21.0-0"
+      "4.21.0-0",
+      "4.27.1-0",
+      "4.27.1-1"
     ],
     "minVersion": "4.21.0-0",
-    "maxVersion": "4.21.0-0",
+    "maxVersion": "4.27.1-1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.18"

--- a/catalog-data/certified-operator-index/v4.19/operators.json
+++ b/catalog-data/certified-operator-index/v4.19/operators.json
@@ -980,7 +980,8 @@
         "1.16.17-cee.1",
         "1.16.19-cee.1",
         "1.16.20-cee.1",
-        "1.16.21-cee.1"
+        "1.16.21-cee.1",
+        "1.16.22-cee.1"
       ],
       "1.17": [
         "0.0.1",
@@ -993,7 +994,8 @@
         "1.17.10-cee.2",
         "1.17.12-cee.1",
         "1.17.13-cee.1",
-        "1.17.14-cee.1"
+        "1.17.14-cee.1",
+        "1.17.15-cee.1"
       ],
       "1.18": [
         "1.18.4-cee.1",
@@ -1001,21 +1003,22 @@
         "1.18.6-cee.2",
         "1.18.7-cee.1",
         "1.18.8-cee.1",
-        "1.18.8-cee.2"
+        "1.18.8-cee.2",
+        "1.18.9-cee.1"
       ]
     },
     "channelVersionRanges": {
       "1.16": {
         "minVersion": "1.16.17-cee.1",
-        "maxVersion": "1.16.21-cee.1"
+        "maxVersion": "1.16.22-cee.1"
       },
       "1.17": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.17.14-cee.1"
+        "maxVersion": "1.17.15-cee.1"
       },
       "1.18": {
         "minVersion": "1.18.4-cee.1",
-        "maxVersion": "1.18.8-cee.2"
+        "maxVersion": "1.18.9-cee.1"
       }
     },
     "availableVersions": [
@@ -1024,6 +1027,7 @@
       "1.16.19-cee.1",
       "1.16.20-cee.1",
       "1.16.21-cee.1",
+      "1.16.22-cee.1",
       "1.17.4-cee.1",
       "1.17.5-cee.1",
       "1.17.7-cee.1",
@@ -1034,15 +1038,17 @@
       "1.17.12-cee.1",
       "1.17.13-cee.1",
       "1.17.14-cee.1",
+      "1.17.15-cee.1",
       "1.18.4-cee.1",
       "1.18.6-cee.1",
       "1.18.6-cee.2",
       "1.18.7-cee.1",
       "1.18.8-cee.1",
-      "1.18.8-cee.2"
+      "1.18.8-cee.2",
+      "1.18.9-cee.1"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.18.8-cee.2",
+    "maxVersion": "1.18.9-cee.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -2020,7 +2026,8 @@
       "stable",
       "stable-v24.1",
       "stable-v24.3",
-      "stable-v25.1"
+      "stable-v25.1",
+      "stable-v26.1"
     ],
     "channelVersions": {
       "beta": [
@@ -2039,7 +2046,11 @@
         "24.3.6"
       ],
       "stable-v25.1": [
+        "25.1.10",
         "25.1.10-1"
+      ],
+      "stable-v26.1": [
+        "26.1.1"
       ]
     },
     "channelVersionRanges": {
@@ -2060,8 +2071,12 @@
         "maxVersion": "24.3.6"
       },
       "stable-v25.1": {
-        "minVersion": "25.1.10-1",
+        "minVersion": "25.1.10",
         "maxVersion": "25.1.10-1"
+      },
+      "stable-v26.1": {
+        "minVersion": "26.1.1",
+        "maxVersion": "26.1.1"
       }
     },
     "availableVersions": [
@@ -2071,10 +2086,12 @@
       "24.3.5",
       "24.3.6",
       "25.1.0-beta.6",
-      "25.1.10-1"
+      "25.1.10",
+      "25.1.10-1",
+      "26.1.1"
     ],
     "minVersion": "24.1.10",
-    "maxVersion": "25.1.10-1",
+    "maxVersion": "26.1.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -2243,7 +2260,8 @@
         "2025.12.0",
         "2026.1.0",
         "2026.2.0",
-        "2026.3.0"
+        "2026.3.0",
+        "2026.4.1"
       ],
       "lts-v1.3": [
         "1.3.2",
@@ -2274,7 +2292,7 @@
       },
       "innovation": {
         "minVersion": "2025.11.0",
-        "maxVersion": "2026.3.0"
+        "maxVersion": "2026.4.1"
       },
       "lts-v1.3": {
         "minVersion": "1.3.2",
@@ -2301,10 +2319,11 @@
       "2025.12.0",
       "2026.1.0",
       "2026.2.0",
-      "2026.3.0"
+      "2026.3.0",
+      "2026.4.1"
     ],
     "minVersion": "1.2.1",
-    "maxVersion": "2026.3.0",
+    "maxVersion": "2026.4.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -2566,20 +2585,22 @@
     ],
     "channelVersions": {
       "stable": [
-        "8.1.2"
+        "8.1.2",
+        "8.1.3"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "8.1.2",
-        "maxVersion": "8.1.2"
+        "maxVersion": "8.1.3"
       }
     },
     "availableVersions": [
-      "8.1.2"
+      "8.1.2",
+      "8.1.3"
     ],
     "minVersion": "8.1.2",
-    "maxVersion": "8.1.2",
+    "maxVersion": "8.1.3",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -2622,33 +2643,36 @@
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ],
       "unstable": [
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.9.2",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       },
       "unstable": {
         "minVersion": "2.9.2",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       }
     },
     "availableVersions": [
       "2.9.2",
       "2.10.0",
       "2.10.1",
-      "2.11.0"
+      "2.11.0",
+      "2.11.1"
     ],
     "minVersion": "2.9.2",
-    "maxVersion": "2.11.0",
+    "maxVersion": "2.11.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -2670,13 +2694,14 @@
         "1.46.0",
         "1.47.0",
         "1.47.1",
-        "1.48.0"
+        "1.48.0",
+        "1.48.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.42.0",
-        "maxVersion": "1.48.0"
+        "maxVersion": "1.48.1"
       }
     },
     "availableVersions": [
@@ -2689,10 +2714,11 @@
       "1.46.0",
       "1.47.0",
       "1.47.1",
-      "1.48.0"
+      "1.48.0",
+      "1.48.1"
     ],
     "minVersion": "1.42.0",
-    "maxVersion": "1.48.0",
+    "maxVersion": "1.48.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -2746,7 +2772,8 @@
         "25.3.4",
         "25.10.0",
         "25.10.1",
-        "26.3.0"
+        "26.3.0",
+        "26.3.1"
       ],
       "v1.10": [
         "1.10.0",
@@ -2934,13 +2961,14 @@
         "25.3.4"
       ],
       "v26.3": [
-        "26.3.0"
+        "26.3.0",
+        "26.3.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.10.0",
-        "maxVersion": "26.3.0"
+        "maxVersion": "26.3.1"
       },
       "v1.10": {
         "minVersion": "1.10.0",
@@ -2988,7 +3016,7 @@
       },
       "v26.3": {
         "minVersion": "26.3.0",
-        "maxVersion": "26.3.0"
+        "maxVersion": "26.3.1"
       }
     },
     "availableVersions": [
@@ -3021,10 +3049,11 @@
       "25.3.4",
       "25.10.0",
       "25.10.1",
-      "26.3.0"
+      "26.3.0",
+      "26.3.1"
     ],
     "minVersion": "1.10.0",
-    "maxVersion": "26.3.0",
+    "maxVersion": "26.3.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -4613,7 +4642,7 @@
     ],
     "channelVersions": {
       "beta": [
-        "8.19.40-beta.1"
+        "8.19.50-beta.1"
       ],
       "stable": [
         "8.19.40"
@@ -4621,8 +4650,8 @@
     },
     "channelVersionRanges": {
       "beta": {
-        "minVersion": "8.19.40-beta.1",
-        "maxVersion": "8.19.40-beta.1"
+        "minVersion": "8.19.50-beta.1",
+        "maxVersion": "8.19.50-beta.1"
       },
       "stable": {
         "minVersion": "8.19.40",
@@ -4631,10 +4660,10 @@
     },
     "availableVersions": [
       "8.19.40",
-      "8.19.40-beta.1"
+      "8.19.50-beta.1"
     ],
     "minVersion": "8.19.40",
-    "maxVersion": "8.19.40-beta.1",
+    "maxVersion": "8.19.50-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -4797,7 +4826,7 @@
     ],
     "channelVersions": {
       "alpha": [
-        "8.19.40-beta.1"
+        "8.19.50-beta.1"
       ],
       "stable": [
         "8.19.40"
@@ -4805,8 +4834,8 @@
     },
     "channelVersionRanges": {
       "alpha": {
-        "minVersion": "8.19.40-beta.1",
-        "maxVersion": "8.19.40-beta.1"
+        "minVersion": "8.19.50-beta.1",
+        "maxVersion": "8.19.50-beta.1"
       },
       "stable": {
         "minVersion": "8.19.40",
@@ -4815,10 +4844,10 @@
     },
     "availableVersions": [
       "8.19.40",
-      "8.19.40-beta.1"
+      "8.19.50-beta.1"
     ],
     "minVersion": "8.19.40",
-    "maxVersion": "8.19.40-beta.1",
+    "maxVersion": "8.19.50-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -6227,7 +6256,7 @@
     ],
     "channelVersions": {
       "beta": [
-        "8.19.40-beta.1"
+        "8.19.50-beta.1"
       ],
       "stable": [
         "8.19.40"
@@ -6235,8 +6264,8 @@
     },
     "channelVersionRanges": {
       "beta": {
-        "minVersion": "8.19.40-beta.1",
-        "maxVersion": "8.19.40-beta.1"
+        "minVersion": "8.19.50-beta.1",
+        "maxVersion": "8.19.50-beta.1"
       },
       "stable": {
         "minVersion": "8.19.40",
@@ -6245,10 +6274,10 @@
     },
     "availableVersions": [
       "8.19.40",
-      "8.19.40-beta.1"
+      "8.19.50-beta.1"
     ],
     "minVersion": "8.19.40",
-    "maxVersion": "8.19.40-beta.1",
+    "maxVersion": "8.19.50-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -6884,13 +6913,14 @@
   },
   {
     "name": "scaleops-operator",
-    "defaultChannel": "stable-v1.29",
+    "defaultChannel": "stable-v1.30",
     "channels": [
       "stable-v1",
       "stable-v1.26",
       "stable-v1.27",
       "stable-v1.28",
-      "stable-v1.29"
+      "stable-v1.29",
+      "stable-v1.30"
     ],
     "channelVersions": {
       "stable-v1": [
@@ -6943,7 +6973,8 @@
         "1.29.7",
         "1.29.8",
         "1.29.10",
-        "1.29.11"
+        "1.29.11",
+        "1.30.0"
       ],
       "stable-v1.26": [
         "1.26.8",
@@ -7002,12 +7033,15 @@
         "1.29.8",
         "1.29.10",
         "1.29.11"
+      ],
+      "stable-v1.30": [
+        "1.30.0"
       ]
     },
     "channelVersionRanges": {
       "stable-v1": {
         "minVersion": "1.26.8",
-        "maxVersion": "1.29.11"
+        "maxVersion": "1.30.0"
       },
       "stable-v1.26": {
         "minVersion": "1.26.8",
@@ -7024,6 +7058,10 @@
       "stable-v1.29": {
         "minVersion": "1.29.3",
         "maxVersion": "1.29.11"
+      },
+      "stable-v1.30": {
+        "minVersion": "1.30.0",
+        "maxVersion": "1.30.0"
       }
     },
     "availableVersions": [
@@ -7076,10 +7114,11 @@
       "1.29.7",
       "1.29.8",
       "1.29.10",
-      "1.29.11"
+      "1.29.11",
+      "1.30.0"
     ],
     "minVersion": "1.26.8",
-    "maxVersion": "1.29.11",
+    "maxVersion": "1.30.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"
@@ -8381,20 +8420,24 @@
     ],
     "channelVersions": {
       "alpha": [
-        "4.21.0-0"
+        "4.21.0-0",
+        "4.27.1-0",
+        "4.27.1-1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "4.21.0-0",
-        "maxVersion": "4.21.0-0"
+        "maxVersion": "4.27.1-1"
       }
     },
     "availableVersions": [
-      "4.21.0-0"
+      "4.21.0-0",
+      "4.27.1-0",
+      "4.27.1-1"
     ],
     "minVersion": "4.21.0-0",
-    "maxVersion": "4.21.0-0",
+    "maxVersion": "4.27.1-1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.19"

--- a/catalog-data/certified-operator-index/v4.20/operators.json
+++ b/catalog-data/certified-operator-index/v4.20/operators.json
@@ -910,7 +910,8 @@
         "1.16.17-cee.1",
         "1.16.19-cee.1",
         "1.16.20-cee.1",
-        "1.16.21-cee.1"
+        "1.16.21-cee.1",
+        "1.16.22-cee.1"
       ],
       "1.17": [
         "0.0.1",
@@ -923,7 +924,8 @@
         "1.17.10-cee.2",
         "1.17.12-cee.1",
         "1.17.13-cee.1",
-        "1.17.14-cee.1"
+        "1.17.14-cee.1",
+        "1.17.15-cee.1"
       ],
       "1.18": [
         "1.18.4-cee.1",
@@ -931,21 +933,22 @@
         "1.18.6-cee.2",
         "1.18.7-cee.1",
         "1.18.8-cee.1",
-        "1.18.8-cee.2"
+        "1.18.8-cee.2",
+        "1.18.9-cee.1"
       ]
     },
     "channelVersionRanges": {
       "1.16": {
         "minVersion": "1.16.17-cee.1",
-        "maxVersion": "1.16.21-cee.1"
+        "maxVersion": "1.16.22-cee.1"
       },
       "1.17": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.17.14-cee.1"
+        "maxVersion": "1.17.15-cee.1"
       },
       "1.18": {
         "minVersion": "1.18.4-cee.1",
-        "maxVersion": "1.18.8-cee.2"
+        "maxVersion": "1.18.9-cee.1"
       }
     },
     "availableVersions": [
@@ -954,6 +957,7 @@
       "1.16.19-cee.1",
       "1.16.20-cee.1",
       "1.16.21-cee.1",
+      "1.16.22-cee.1",
       "1.17.4-cee.1",
       "1.17.5-cee.1",
       "1.17.7-cee.1",
@@ -964,15 +968,17 @@
       "1.17.12-cee.1",
       "1.17.13-cee.1",
       "1.17.14-cee.1",
+      "1.17.15-cee.1",
       "1.18.4-cee.1",
       "1.18.6-cee.1",
       "1.18.6-cee.2",
       "1.18.7-cee.1",
       "1.18.8-cee.1",
-      "1.18.8-cee.2"
+      "1.18.8-cee.2",
+      "1.18.9-cee.1"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.18.8-cee.2",
+    "maxVersion": "1.18.9-cee.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -1833,7 +1839,8 @@
       "stable",
       "stable-v24.1",
       "stable-v24.3",
-      "stable-v25.1"
+      "stable-v25.1",
+      "stable-v26.1"
     ],
     "channelVersions": {
       "beta": [
@@ -1852,7 +1859,11 @@
         "24.3.6"
       ],
       "stable-v25.1": [
+        "25.1.10",
         "25.1.10-1"
+      ],
+      "stable-v26.1": [
+        "26.1.1"
       ]
     },
     "channelVersionRanges": {
@@ -1873,8 +1884,12 @@
         "maxVersion": "24.3.6"
       },
       "stable-v25.1": {
-        "minVersion": "25.1.10-1",
+        "minVersion": "25.1.10",
         "maxVersion": "25.1.10-1"
+      },
+      "stable-v26.1": {
+        "minVersion": "26.1.1",
+        "maxVersion": "26.1.1"
       }
     },
     "availableVersions": [
@@ -1884,10 +1899,12 @@
       "24.3.5",
       "24.3.6",
       "25.1.0-beta.6",
-      "25.1.10-1"
+      "25.1.10",
+      "25.1.10-1",
+      "26.1.1"
     ],
     "minVersion": "24.1.10",
-    "maxVersion": "25.1.10-1",
+    "maxVersion": "26.1.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -2048,7 +2065,8 @@
       "innovation": [
         "2026.1.0",
         "2026.2.0",
-        "2026.3.0"
+        "2026.3.0",
+        "2026.4.1"
       ],
       "lts-v1.3": [
         "1.3.3",
@@ -2072,7 +2090,7 @@
       },
       "innovation": {
         "minVersion": "2026.1.0",
-        "maxVersion": "2026.3.0"
+        "maxVersion": "2026.4.1"
       },
       "lts-v1.3": {
         "minVersion": "1.3.3",
@@ -2091,10 +2109,11 @@
       "1.3.7",
       "2026.1.0",
       "2026.2.0",
-      "2026.3.0"
+      "2026.3.0",
+      "2026.4.1"
     ],
     "minVersion": "1.3.3",
-    "maxVersion": "2026.3.0",
+    "maxVersion": "2026.4.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -2358,33 +2377,36 @@
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ],
       "unstable": [
         "2.9.2",
         "2.10.0",
         "2.10.1",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.9.2",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       },
       "unstable": {
         "minVersion": "2.9.2",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       }
     },
     "availableVersions": [
       "2.9.2",
       "2.10.0",
       "2.10.1",
-      "2.11.0"
+      "2.11.0",
+      "2.11.1"
     ],
     "minVersion": "2.9.2",
-    "maxVersion": "2.11.0",
+    "maxVersion": "2.11.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -2405,13 +2427,14 @@
         "1.46.0",
         "1.47.0",
         "1.47.1",
-        "1.48.0"
+        "1.48.0",
+        "1.48.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.43.0",
-        "maxVersion": "1.48.0"
+        "maxVersion": "1.48.1"
       }
     },
     "availableVersions": [
@@ -2423,10 +2446,11 @@
       "1.46.0",
       "1.47.0",
       "1.47.1",
-      "1.48.0"
+      "1.48.0",
+      "1.48.1"
     ],
     "minVersion": "1.43.0",
-    "maxVersion": "1.48.0",
+    "maxVersion": "1.48.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -2480,7 +2504,8 @@
         "25.3.4",
         "25.10.0",
         "25.10.1",
-        "26.3.0"
+        "26.3.0",
+        "26.3.1"
       ],
       "v1.10": [
         "1.10.0",
@@ -2668,13 +2693,14 @@
         "25.3.4"
       ],
       "v26.3": [
-        "26.3.0"
+        "26.3.0",
+        "26.3.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.10.0",
-        "maxVersion": "26.3.0"
+        "maxVersion": "26.3.1"
       },
       "v1.10": {
         "minVersion": "1.10.0",
@@ -2722,7 +2748,7 @@
       },
       "v26.3": {
         "minVersion": "26.3.0",
-        "maxVersion": "26.3.0"
+        "maxVersion": "26.3.1"
       }
     },
     "availableVersions": [
@@ -2755,10 +2781,11 @@
       "25.3.4",
       "25.10.0",
       "25.10.1",
-      "26.3.0"
+      "26.3.0",
+      "26.3.1"
     ],
     "minVersion": "1.10.0",
-    "maxVersion": "26.3.0",
+    "maxVersion": "26.3.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -4211,7 +4238,7 @@
     ],
     "channelVersions": {
       "beta": [
-        "8.19.40-beta.1"
+        "8.19.50-beta.1"
       ],
       "stable": [
         "8.19.40"
@@ -4219,8 +4246,8 @@
     },
     "channelVersionRanges": {
       "beta": {
-        "minVersion": "8.19.40-beta.1",
-        "maxVersion": "8.19.40-beta.1"
+        "minVersion": "8.19.50-beta.1",
+        "maxVersion": "8.19.50-beta.1"
       },
       "stable": {
         "minVersion": "8.19.40",
@@ -4229,10 +4256,10 @@
     },
     "availableVersions": [
       "8.19.40",
-      "8.19.40-beta.1"
+      "8.19.50-beta.1"
     ],
     "minVersion": "8.19.40",
-    "maxVersion": "8.19.40-beta.1",
+    "maxVersion": "8.19.50-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -4370,7 +4397,7 @@
     ],
     "channelVersions": {
       "alpha": [
-        "8.19.40-beta.1"
+        "8.19.50-beta.1"
       ],
       "stable": [
         "8.19.40"
@@ -4378,8 +4405,8 @@
     },
     "channelVersionRanges": {
       "alpha": {
-        "minVersion": "8.19.40-beta.1",
-        "maxVersion": "8.19.40-beta.1"
+        "minVersion": "8.19.50-beta.1",
+        "maxVersion": "8.19.50-beta.1"
       },
       "stable": {
         "minVersion": "8.19.40",
@@ -4388,10 +4415,10 @@
     },
     "availableVersions": [
       "8.19.40",
-      "8.19.40-beta.1"
+      "8.19.50-beta.1"
     ],
     "minVersion": "8.19.40",
-    "maxVersion": "8.19.40-beta.1",
+    "maxVersion": "8.19.50-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -5786,7 +5813,7 @@
     ],
     "channelVersions": {
       "beta": [
-        "8.19.40-beta.1"
+        "8.19.50-beta.1"
       ],
       "stable": [
         "8.19.40"
@@ -5794,8 +5821,8 @@
     },
     "channelVersionRanges": {
       "beta": {
-        "minVersion": "8.19.40-beta.1",
-        "maxVersion": "8.19.40-beta.1"
+        "minVersion": "8.19.50-beta.1",
+        "maxVersion": "8.19.50-beta.1"
       },
       "stable": {
         "minVersion": "8.19.40",
@@ -5804,10 +5831,10 @@
     },
     "availableVersions": [
       "8.19.40",
-      "8.19.40-beta.1"
+      "8.19.50-beta.1"
     ],
     "minVersion": "8.19.40",
-    "maxVersion": "8.19.40-beta.1",
+    "maxVersion": "8.19.50-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -6208,13 +6235,14 @@
   },
   {
     "name": "scaleops-operator",
-    "defaultChannel": "stable-v1.29",
+    "defaultChannel": "stable-v1.30",
     "channels": [
       "stable-v1",
       "stable-v1.26",
       "stable-v1.27",
       "stable-v1.28",
-      "stable-v1.29"
+      "stable-v1.29",
+      "stable-v1.30"
     ],
     "channelVersions": {
       "stable-v1": [
@@ -6267,7 +6295,8 @@
         "1.29.7",
         "1.29.8",
         "1.29.10",
-        "1.29.11"
+        "1.29.11",
+        "1.30.0"
       ],
       "stable-v1.26": [
         "1.26.8",
@@ -6326,12 +6355,15 @@
         "1.29.8",
         "1.29.10",
         "1.29.11"
+      ],
+      "stable-v1.30": [
+        "1.30.0"
       ]
     },
     "channelVersionRanges": {
       "stable-v1": {
         "minVersion": "1.26.8",
-        "maxVersion": "1.29.11"
+        "maxVersion": "1.30.0"
       },
       "stable-v1.26": {
         "minVersion": "1.26.8",
@@ -6348,6 +6380,10 @@
       "stable-v1.29": {
         "minVersion": "1.29.3",
         "maxVersion": "1.29.11"
+      },
+      "stable-v1.30": {
+        "minVersion": "1.30.0",
+        "maxVersion": "1.30.0"
       }
     },
     "availableVersions": [
@@ -6400,10 +6436,11 @@
       "1.29.7",
       "1.29.8",
       "1.29.10",
-      "1.29.11"
+      "1.29.11",
+      "1.30.0"
     ],
     "minVersion": "1.26.8",
-    "maxVersion": "1.29.11",
+    "maxVersion": "1.30.0",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"
@@ -7372,20 +7409,24 @@
     ],
     "channelVersions": {
       "alpha": [
-        "4.21.0-0"
+        "4.21.0-0",
+        "4.27.1-0",
+        "4.27.1-1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "4.21.0-0",
-        "maxVersion": "4.21.0-0"
+        "maxVersion": "4.27.1-1"
       }
     },
     "availableVersions": [
-      "4.21.0-0"
+      "4.21.0-0",
+      "4.27.1-0",
+      "4.27.1-1"
     ],
     "minVersion": "4.21.0-0",
-    "maxVersion": "4.21.0-0",
+    "maxVersion": "4.27.1-1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.20"

--- a/catalog-data/certified-operator-index/v4.21/operators.json
+++ b/catalog-data/certified-operator-index/v4.21/operators.json
@@ -1600,7 +1600,8 @@
       "stable",
       "stable-v24.1",
       "stable-v24.3",
-      "stable-v25.1"
+      "stable-v25.1",
+      "stable-v26.1"
     ],
     "channelVersions": {
       "beta": [
@@ -1619,7 +1620,11 @@
         "24.3.6"
       ],
       "stable-v25.1": [
+        "25.1.10",
         "25.1.10-1"
+      ],
+      "stable-v26.1": [
+        "26.1.1"
       ]
     },
     "channelVersionRanges": {
@@ -1640,8 +1645,12 @@
         "maxVersion": "24.3.6"
       },
       "stable-v25.1": {
-        "minVersion": "25.1.10-1",
+        "minVersion": "25.1.10",
         "maxVersion": "25.1.10-1"
+      },
+      "stable-v26.1": {
+        "minVersion": "26.1.1",
+        "maxVersion": "26.1.1"
       }
     },
     "availableVersions": [
@@ -1651,10 +1660,12 @@
       "24.3.5",
       "24.3.6",
       "25.1.0-beta.6",
-      "25.1.10-1"
+      "25.1.10",
+      "25.1.10-1",
+      "26.1.1"
     ],
     "minVersion": "24.1.10",
-    "maxVersion": "25.1.10-1",
+    "maxVersion": "26.1.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.21"
@@ -1803,20 +1814,22 @@
     ],
     "channelVersions": {
       "innovation": [
-        "2026.3.0"
+        "2026.3.0",
+        "2026.4.1"
       ]
     },
     "channelVersionRanges": {
       "innovation": {
         "minVersion": "2026.3.0",
-        "maxVersion": "2026.3.0"
+        "maxVersion": "2026.4.1"
       }
     },
     "availableVersions": [
-      "2026.3.0"
+      "2026.3.0",
+      "2026.4.1"
     ],
     "minVersion": "2026.3.0",
-    "maxVersion": "2026.3.0",
+    "maxVersion": "2026.4.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.21"
@@ -2079,31 +2092,34 @@
       "stable": [
         "2.10.0",
         "2.10.1",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ],
       "unstable": [
         "2.10.0",
         "2.10.1",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.10.0",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       },
       "unstable": {
         "minVersion": "2.10.0",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       }
     },
     "availableVersions": [
       "2.10.0",
       "2.10.1",
-      "2.11.0"
+      "2.11.0",
+      "2.11.1"
     ],
     "minVersion": "2.10.0",
-    "maxVersion": "2.11.0",
+    "maxVersion": "2.11.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.21"
@@ -2157,7 +2173,8 @@
         "25.3.4",
         "25.10.0",
         "25.10.1",
-        "26.3.0"
+        "26.3.0",
+        "26.3.1"
       ],
       "v1.10": [
         "1.10.0",
@@ -2345,13 +2362,14 @@
         "25.3.4"
       ],
       "v26.3": [
-        "26.3.0"
+        "26.3.0",
+        "26.3.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.10.0",
-        "maxVersion": "26.3.0"
+        "maxVersion": "26.3.1"
       },
       "v1.10": {
         "minVersion": "1.10.0",
@@ -2399,7 +2417,7 @@
       },
       "v26.3": {
         "minVersion": "26.3.0",
-        "maxVersion": "26.3.0"
+        "maxVersion": "26.3.1"
       }
     },
     "availableVersions": [
@@ -2432,10 +2450,11 @@
       "25.3.4",
       "25.10.0",
       "25.10.1",
-      "26.3.0"
+      "26.3.0",
+      "26.3.1"
     ],
     "minVersion": "1.10.0",
-    "maxVersion": "26.3.0",
+    "maxVersion": "26.3.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.21"
@@ -3594,7 +3613,7 @@
     ],
     "channelVersions": {
       "beta": [
-        "8.19.40-beta.1"
+        "8.19.50-beta.1"
       ],
       "stable": [
         "8.19.40"
@@ -3602,8 +3621,8 @@
     },
     "channelVersionRanges": {
       "beta": {
-        "minVersion": "8.19.40-beta.1",
-        "maxVersion": "8.19.40-beta.1"
+        "minVersion": "8.19.50-beta.1",
+        "maxVersion": "8.19.50-beta.1"
       },
       "stable": {
         "minVersion": "8.19.40",
@@ -3612,10 +3631,10 @@
     },
     "availableVersions": [
       "8.19.40",
-      "8.19.40-beta.1"
+      "8.19.50-beta.1"
     ],
     "minVersion": "8.19.40",
-    "maxVersion": "8.19.40-beta.1",
+    "maxVersion": "8.19.50-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.21"
@@ -3753,7 +3772,7 @@
     ],
     "channelVersions": {
       "alpha": [
-        "8.19.40-beta.1"
+        "8.19.50-beta.1"
       ],
       "stable": [
         "8.19.40"
@@ -3761,8 +3780,8 @@
     },
     "channelVersionRanges": {
       "alpha": {
-        "minVersion": "8.19.40-beta.1",
-        "maxVersion": "8.19.40-beta.1"
+        "minVersion": "8.19.50-beta.1",
+        "maxVersion": "8.19.50-beta.1"
       },
       "stable": {
         "minVersion": "8.19.40",
@@ -3771,10 +3790,10 @@
     },
     "availableVersions": [
       "8.19.40",
-      "8.19.40-beta.1"
+      "8.19.50-beta.1"
     ],
     "minVersion": "8.19.40",
-    "maxVersion": "8.19.40-beta.1",
+    "maxVersion": "8.19.50-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.21"
@@ -4991,7 +5010,7 @@
     ],
     "channelVersions": {
       "beta": [
-        "8.19.40-beta.1"
+        "8.19.50-beta.1"
       ],
       "stable": [
         "8.19.40"
@@ -4999,8 +5018,8 @@
     },
     "channelVersionRanges": {
       "beta": {
-        "minVersion": "8.19.40-beta.1",
-        "maxVersion": "8.19.40-beta.1"
+        "minVersion": "8.19.50-beta.1",
+        "maxVersion": "8.19.50-beta.1"
       },
       "stable": {
         "minVersion": "8.19.40",
@@ -5009,10 +5028,10 @@
     },
     "availableVersions": [
       "8.19.40",
-      "8.19.40-beta.1"
+      "8.19.50-beta.1"
     ],
     "minVersion": "8.19.40",
-    "maxVersion": "8.19.40-beta.1",
+    "maxVersion": "8.19.50-beta.1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.21"
@@ -6050,20 +6069,24 @@
     ],
     "channelVersions": {
       "alpha": [
-        "4.21.0-0"
+        "4.21.0-0",
+        "4.27.1-0",
+        "4.27.1-1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "4.21.0-0",
-        "maxVersion": "4.21.0-0"
+        "maxVersion": "4.27.1-1"
       }
     },
     "availableVersions": [
-      "4.21.0-0"
+      "4.21.0-0",
+      "4.27.1-0",
+      "4.27.1-1"
     ],
     "minVersion": "4.21.0-0",
-    "maxVersion": "4.21.0-0",
+    "maxVersion": "4.27.1-1",
     "catalog": "certified-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/certified-operator-index:v4.21"

--- a/catalog-data/community-operator-index/v4.16/operators.json
+++ b/catalog-data/community-operator-index/v4.16/operators.json
@@ -253,13 +253,14 @@
         "1.3.2",
         "1.4.0",
         "1.4.1",
-        "1.4.2"
+        "1.4.2",
+        "1.4.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.4.2"
+        "maxVersion": "1.4.3"
       }
     },
     "availableVersions": [
@@ -282,10 +283,11 @@
       "1.3.2",
       "1.4.0",
       "1.4.1",
-      "1.4.2"
+      "1.4.2",
+      "1.4.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.4.2",
+    "maxVersion": "1.4.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -454,13 +456,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.2.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -508,10 +511,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.2.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -543,13 +547,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -572,10 +577,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -593,13 +599,14 @@
         "1.0.1",
         "1.1.0",
         "1.1.1",
-        "1.1.2"
+        "1.1.2",
+        "1.1.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "1.1.2"
+        "maxVersion": "1.1.3"
       }
     },
     "availableVersions": [
@@ -608,10 +615,11 @@
       "1.0.1",
       "1.1.0",
       "1.1.1",
-      "1.1.2"
+      "1.1.2",
+      "1.1.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "1.1.2",
+    "maxVersion": "1.1.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -735,13 +743,14 @@
         "1.2.2",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.3.3"
       }
     },
     "availableVersions": [
@@ -778,10 +787,11 @@
       "1.2.2",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.3.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -824,13 +834,14 @@
         "1.1.1",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -864,10 +875,11 @@
       "1.1.1",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.1.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -984,13 +996,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1018,10 +1031,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -1041,13 +1055,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.11",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1058,10 +1073,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.11",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -1135,13 +1151,14 @@
         "1.2.1",
         "1.2.2",
         "1.3.0",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.6",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -1168,10 +1185,11 @@
       "1.2.1",
       "1.2.2",
       "1.3.0",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.6",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -1247,13 +1265,14 @@
         "1.6.1",
         "1.7.0",
         "1.7.1",
-        "1.7.2"
+        "1.7.2",
+        "1.7.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.8",
-        "maxVersion": "1.7.2"
+        "maxVersion": "1.7.3"
       }
     },
     "availableVersions": [
@@ -1320,10 +1339,11 @@
       "1.6.1",
       "1.7.0",
       "1.7.1",
-      "1.7.2"
+      "1.7.2",
+      "1.7.3"
     ],
     "minVersion": "0.0.8",
-    "maxVersion": "1.7.2",
+    "maxVersion": "1.7.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -1691,13 +1711,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.12",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1708,10 +1729,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.12",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -1744,13 +1766,14 @@
         "1.1.1",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.5",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1774,10 +1797,11 @@
       "1.1.1",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.5",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -1817,13 +1841,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.4",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1854,10 +1879,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.4",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -1948,13 +1974,14 @@
         "1.11.2",
         "1.11.3",
         "1.11.4",
-        "1.12.0"
+        "1.12.0",
+        "1.12.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.12.0"
+        "maxVersion": "1.12.2"
       }
     },
     "availableVersions": [
@@ -2036,10 +2063,11 @@
       "1.11.2",
       "1.11.3",
       "1.11.4",
-      "1.12.0"
+      "1.12.0",
+      "1.12.2"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.12.0",
+    "maxVersion": "1.12.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -2103,13 +2131,14 @@
         "1.3.1",
         "1.3.2",
         "1.3.3",
-        "1.3.4"
+        "1.3.4",
+        "1.3.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.8",
-        "maxVersion": "1.3.4"
+        "maxVersion": "1.3.5"
       }
     },
     "availableVersions": [
@@ -2164,10 +2193,11 @@
       "1.3.1",
       "1.3.2",
       "1.3.3",
-      "1.3.4"
+      "1.3.4",
+      "1.3.5"
     ],
     "minVersion": "0.0.8",
-    "maxVersion": "1.3.4",
+    "maxVersion": "1.3.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -2210,13 +2240,14 @@
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.3.3"
+        "1.3.3",
+        "1.3.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.3.3"
+        "maxVersion": "1.3.5"
       }
     },
     "availableVersions": [
@@ -2250,10 +2281,11 @@
       "1.3.0",
       "1.3.1",
       "1.3.2",
-      "1.3.3"
+      "1.3.3",
+      "1.3.5"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.3.3",
+    "maxVersion": "1.3.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -2301,13 +2333,14 @@
         "1.2.0",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.3.3"
       }
     },
     "availableVersions": [
@@ -2346,10 +2379,11 @@
       "1.2.0",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.3.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -2395,13 +2429,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -2438,10 +2473,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -2457,23 +2493,25 @@
         "0.1.0",
         "0.2.0",
         "0.2.1",
-        "0.2.2"
+        "0.2.2",
+        "0.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.2.2"
+        "maxVersion": "0.2.3"
       }
     },
     "availableVersions": [
       "0.1.0",
       "0.2.0",
       "0.2.1",
-      "0.2.2"
+      "0.2.2",
+      "0.2.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.2.2",
+    "maxVersion": "0.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -2492,13 +2530,14 @@
         "0.2.2",
         "0.3.0",
         "0.3.1",
-        "0.3.2"
+        "0.3.2",
+        "0.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.3.2"
+        "maxVersion": "0.3.3"
       }
     },
     "availableVersions": [
@@ -2508,10 +2547,11 @@
       "0.2.2",
       "0.3.0",
       "0.3.1",
-      "0.3.2"
+      "0.3.2",
+      "0.3.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.3.2",
+    "maxVersion": "0.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -2715,13 +2755,14 @@
         "1.3.2",
         "1.4.0",
         "1.4.1",
-        "1.5.0"
+        "1.5.0",
+        "1.5.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.5.0"
+        "maxVersion": "1.5.1"
       }
     },
     "availableVersions": [
@@ -2762,10 +2803,11 @@
       "1.3.2",
       "1.4.0",
       "1.4.1",
-      "1.5.0"
+      "1.5.0",
+      "1.5.1"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.5.0",
+    "maxVersion": "1.5.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -2811,13 +2853,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -2854,10 +2897,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -3018,13 +3062,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -3082,10 +3127,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -3158,13 +3204,14 @@
         "1.9.2",
         "1.10.0",
         "1.10.1",
-        "1.10.2"
+        "1.10.2",
+        "1.12.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.10.2"
+        "maxVersion": "1.12.2"
       }
     },
     "availableVersions": [
@@ -3228,10 +3275,11 @@
       "1.9.2",
       "1.10.0",
       "1.10.1",
-      "1.10.2"
+      "1.10.2",
+      "1.12.2"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.10.2",
+    "maxVersion": "1.12.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -3274,13 +3322,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -3314,10 +3363,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -3526,13 +3576,14 @@
         "0.2.2",
         "0.3.0",
         "0.3.1",
-        "0.3.2"
+        "0.3.2",
+        "0.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.3.2"
+        "maxVersion": "0.3.3"
       }
     },
     "availableVersions": [
@@ -3544,10 +3595,11 @@
       "0.2.2",
       "0.3.0",
       "0.3.1",
-      "0.3.2"
+      "0.3.2",
+      "0.3.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.3.2",
+    "maxVersion": "0.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -3597,13 +3649,15 @@
         "1.2.0",
         "1.2.1",
         "1.2.2",
-        "1.2.3"
+        "1.2.3",
+        "1.2.4",
+        "1.2.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.4",
-        "maxVersion": "1.2.3"
+        "maxVersion": "1.2.5"
       }
     },
     "availableVersions": [
@@ -3644,10 +3698,12 @@
       "1.2.0",
       "1.2.1",
       "1.2.2",
-      "1.2.3"
+      "1.2.3",
+      "1.2.4",
+      "1.2.5"
     ],
     "minVersion": "0.0.4",
-    "maxVersion": "1.2.3",
+    "maxVersion": "1.2.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -3681,13 +3737,14 @@
         "1.2.0",
         "1.2.1",
         "1.2.2",
-        "1.2.3"
+        "1.2.3",
+        "1.2.4"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.6",
-        "maxVersion": "1.2.3"
+        "maxVersion": "1.2.4"
       }
     },
     "availableVersions": [
@@ -3712,10 +3769,11 @@
       "1.2.0",
       "1.2.1",
       "1.2.2",
-      "1.2.3"
+      "1.2.3",
+      "1.2.4"
     ],
     "minVersion": "0.0.6",
-    "maxVersion": "1.2.3",
+    "maxVersion": "1.2.4",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -3755,13 +3813,14 @@
         "1.1.3",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -3792,10 +3851,11 @@
       "1.1.3",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -3843,13 +3903,14 @@
         "1.3.2",
         "1.4.0",
         "1.4.1",
-        "1.4.2"
+        "1.4.2",
+        "1.4.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.4.2"
+        "maxVersion": "1.4.3"
       }
     },
     "availableVersions": [
@@ -3888,10 +3949,11 @@
       "1.3.2",
       "1.4.0",
       "1.4.1",
-      "1.4.2"
+      "1.4.2",
+      "1.4.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.4.2",
+    "maxVersion": "1.4.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -3905,21 +3967,23 @@
     "channelVersions": {
       "alpha": [
         "0.1.0",
-        "0.1.1"
+        "0.1.1",
+        "0.2.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.1.1"
+        "maxVersion": "0.2.1"
       }
     },
     "availableVersions": [
       "0.1.0",
-      "0.1.1"
+      "0.1.1",
+      "0.2.1"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.1.1",
+    "maxVersion": "0.2.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -4174,13 +4238,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4204,10 +4269,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -4250,13 +4316,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.2",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -4290,10 +4357,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.2",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -4329,13 +4397,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4362,10 +4431,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -4442,13 +4512,15 @@
         "1.2.2",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.3.3",
+        "1.3.4"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.7",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.3.4"
       }
     },
     "availableVersions": [
@@ -4516,10 +4588,12 @@
       "1.2.2",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.3.3",
+      "1.3.4"
     ],
     "minVersion": "0.0.7",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.3.4",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -4538,13 +4612,14 @@
         "1.1.1",
         "1.1.2",
         "1.2.0",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.10",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4554,10 +4629,11 @@
       "1.1.1",
       "1.1.2",
       "1.2.0",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.10",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -4612,13 +4688,14 @@
         "1.7.0",
         "1.7.1",
         "1.7.2",
-        "1.7.3"
+        "1.7.3",
+        "1.7.4"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.3.1",
-        "maxVersion": "1.7.3"
+        "maxVersion": "1.7.4"
       }
     },
     "availableVersions": [
@@ -4664,10 +4741,11 @@
       "1.7.0",
       "1.7.1",
       "1.7.2",
-      "1.7.3"
+      "1.7.3",
+      "1.7.4"
     ],
     "minVersion": "0.3.1",
-    "maxVersion": "1.7.3",
+    "maxVersion": "1.7.4",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -4706,13 +4784,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4742,10 +4821,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -4777,13 +4857,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4806,10 +4887,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -4872,13 +4954,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.5",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4932,10 +5015,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.5",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -4992,13 +5076,14 @@
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.4.0"
+        "1.4.0",
+        "1.4.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.4",
-        "maxVersion": "1.4.0"
+        "maxVersion": "1.4.1"
       }
     },
     "availableVersions": [
@@ -5046,10 +5131,11 @@
       "1.3.0",
       "1.3.1",
       "1.3.2",
-      "1.4.0"
+      "1.4.0",
+      "1.4.1"
     ],
     "minVersion": "0.0.4",
-    "maxVersion": "1.4.0",
+    "maxVersion": "1.4.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -5103,13 +5189,14 @@
         "1.3.0",
         "1.3.1",
         "1.4.0",
-        "1.4.2"
+        "1.4.2",
+        "1.4.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.4.2"
+        "maxVersion": "1.4.3"
       }
     },
     "availableVersions": [
@@ -5154,10 +5241,11 @@
       "1.3.0",
       "1.3.1",
       "1.4.0",
-      "1.4.2"
+      "1.4.2",
+      "1.4.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.4.2",
+    "maxVersion": "1.4.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -5189,13 +5277,14 @@
         "1.2.0",
         "1.2.1",
         "1.3.0",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -5218,10 +5307,11 @@
       "1.2.0",
       "1.2.1",
       "1.3.0",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -5255,13 +5345,14 @@
         "1.2.1",
         "1.2.2",
         "1.3.0",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -5286,10 +5377,11 @@
       "1.2.1",
       "1.2.2",
       "1.3.0",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -5327,7 +5419,8 @@
         "4.1.1",
         "4.1.2",
         "4.2.0",
-        "4.3.0"
+        "4.3.0",
+        "4.4.0"
       ]
     },
     "channelVersionRanges": {
@@ -5337,7 +5430,7 @@
       },
       "stable": {
         "minVersion": "3.0.0",
-        "maxVersion": "4.3.0"
+        "maxVersion": "4.4.0"
       }
     },
     "availableVersions": [
@@ -5363,10 +5456,11 @@
       "4.1.1",
       "4.1.2",
       "4.2.0",
-      "4.3.0"
+      "4.3.0",
+      "4.4.0"
     ],
     "minVersion": "2.1.0",
-    "maxVersion": "4.3.0",
+    "maxVersion": "4.4.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -9834,13 +9928,14 @@
         "0.45.0",
         "0.45.1",
         "0.46.0",
-        "0.47.0"
+        "0.47.0",
+        "0.48.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.18.0",
-        "maxVersion": "0.47.0"
+        "maxVersion": "0.48.0"
       }
     },
     "availableVersions": [
@@ -9872,10 +9967,11 @@
       "0.45.0",
       "0.45.1",
       "0.46.0",
-      "0.47.0"
+      "0.47.0",
+      "0.48.0"
     ],
     "minVersion": "0.18.0",
-    "maxVersion": "0.47.0",
+    "maxVersion": "0.48.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -10045,7 +10141,8 @@
         "2.10.0",
         "2.10.1",
         "2.10.2",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ],
       "unstable": [
         "1.3.0",
@@ -10114,17 +10211,18 @@
         "2.10.0",
         "2.10.1",
         "2.10.2",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.3.0",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       },
       "unstable": {
         "minVersion": "1.3.0",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       }
     },
     "availableVersions": [
@@ -10194,10 +10292,11 @@
       "2.10.0",
       "2.10.1",
       "2.10.2",
-      "2.11.0"
+      "2.11.0",
+      "2.11.1"
     ],
     "minVersion": "1.3.0",
-    "maxVersion": "2.11.0",
+    "maxVersion": "2.11.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -10219,13 +10318,14 @@
         "1.46.0",
         "1.47.0",
         "1.47.1",
-        "1.48.0"
+        "1.48.0",
+        "1.48.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.42.0",
-        "maxVersion": "1.48.0"
+        "maxVersion": "1.48.1"
       }
     },
     "availableVersions": [
@@ -10238,10 +10338,11 @@
       "1.46.0",
       "1.47.0",
       "1.47.1",
-      "1.48.0"
+      "1.48.0",
+      "1.48.1"
     ],
     "minVersion": "1.42.0",
-    "maxVersion": "1.48.0",
+    "maxVersion": "1.48.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -10657,7 +10758,8 @@
         "1.2.5135-afd4101",
         "1.2.5143-a5d0850",
         "1.2.5151-a6aa930",
-        "1.2.5177-a325b87"
+        "1.2.5177-a325b87",
+        "1.2.5181-aa1db74"
       ],
       "mce-2.0": [
         "2.5.3489-6dec9c3",
@@ -10701,7 +10803,7 @@
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.2.4355-e5f809f",
-        "maxVersion": "1.2.5177-a325b87"
+        "maxVersion": "1.2.5181-aa1db74"
       },
       "mce-2.0": {
         "minVersion": "2.5.3489-6dec9c3",
@@ -10797,6 +10899,7 @@
       "1.2.5143-a5d0850",
       "1.2.5151-a6aa930",
       "1.2.5177-a325b87",
+      "1.2.5181-aa1db74",
       "2.3.3039-60b8a9a",
       "2.4.3180-7299056",
       "2.4.3189-026033b",
@@ -12653,21 +12756,23 @@
     "channelVersions": {
       "alpha": [
         "0.0.3",
-        "0.0.4"
+        "0.0.4",
+        "0.0.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "0.0.4"
+        "maxVersion": "0.0.5"
       }
     },
     "availableVersions": [
       "0.0.3",
-      "0.0.4"
+      "0.0.4",
+      "0.0.5"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "0.0.4",
+    "maxVersion": "0.0.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -15044,13 +15149,14 @@
         "0.143.0",
         "0.144.0",
         "0.145.0",
-        "0.148.0"
+        "0.148.0",
+        "0.149.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.105.0",
-        "maxVersion": "0.148.0"
+        "maxVersion": "0.149.0"
       }
     },
     "availableVersions": [
@@ -15091,10 +15197,11 @@
       "0.143.0",
       "0.144.0",
       "0.145.0",
-      "0.148.0"
+      "0.148.0",
+      "0.149.0"
     ],
     "minVersion": "0.105.0",
-    "maxVersion": "0.148.0",
+    "maxVersion": "0.149.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"
@@ -16583,11 +16690,6 @@
     ],
     "channelVersions": {
       "1.29-nightly": [
-        "1.29.0-nightly-2026-04-04",
-        "1.29.0-nightly-2026-04-05",
-        "1.29.0-nightly-2026-04-06",
-        "1.29.0-nightly-2026-04-07",
-        "1.29.0-nightly-2026-04-08",
         "1.29.0-nightly-2026-04-09"
       ],
       "1.30-nightly": [
@@ -16599,7 +16701,10 @@
         "1.30.0-nightly-2026-04-15",
         "1.30.0-nightly-2026-04-16",
         "1.30.0-nightly-2026-04-17",
-        "1.30.0-nightly-2026-04-18"
+        "1.30.0-nightly-2026-04-18",
+        "1.30.0-nightly-2026-04-19",
+        "1.30.0-nightly-2026-04-20",
+        "1.30.0-nightly-2026-04-21"
       ],
       "candidates": [
         "0.1.0",
@@ -16657,12 +16762,12 @@
     },
     "channelVersionRanges": {
       "1.29-nightly": {
-        "minVersion": "1.29.0-nightly-2026-04-04",
+        "minVersion": "1.29.0-nightly-2026-04-09",
         "maxVersion": "1.29.0-nightly-2026-04-09"
       },
       "1.30-nightly": {
         "minVersion": "1.30.0-nightly-2026-04-10",
-        "maxVersion": "1.30.0-nightly-2026-04-18"
+        "maxVersion": "1.30.0-nightly-2026-04-21"
       },
       "candidates": {
         "minVersion": "0.1.0",
@@ -16717,11 +16822,6 @@
       "1.28.2",
       "1.28.3",
       "1.29.0",
-      "1.29.0-nightly-2026-04-04",
-      "1.29.0-nightly-2026-04-05",
-      "1.29.0-nightly-2026-04-06",
-      "1.29.0-nightly-2026-04-07",
-      "1.29.0-nightly-2026-04-08",
       "1.29.0-nightly-2026-04-09",
       "1.29.1",
       "1.30.0-nightly-2026-04-10",
@@ -16732,10 +16832,13 @@
       "1.30.0-nightly-2026-04-15",
       "1.30.0-nightly-2026-04-16",
       "1.30.0-nightly-2026-04-17",
-      "1.30.0-nightly-2026-04-18"
+      "1.30.0-nightly-2026-04-18",
+      "1.30.0-nightly-2026-04-19",
+      "1.30.0-nightly-2026-04-20",
+      "1.30.0-nightly-2026-04-21"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "1.30.0-nightly-2026-04-18",
+    "maxVersion": "1.30.0-nightly-2026-04-21",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.16"

--- a/catalog-data/community-operator-index/v4.17/operators.json
+++ b/catalog-data/community-operator-index/v4.17/operators.json
@@ -253,13 +253,14 @@
         "1.3.2",
         "1.4.0",
         "1.4.1",
-        "1.4.2"
+        "1.4.2",
+        "1.4.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.4.2"
+        "maxVersion": "1.4.3"
       }
     },
     "availableVersions": [
@@ -282,10 +283,11 @@
       "1.3.2",
       "1.4.0",
       "1.4.1",
-      "1.4.2"
+      "1.4.2",
+      "1.4.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.4.2",
+    "maxVersion": "1.4.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -454,13 +456,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.2.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -508,10 +511,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.2.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -543,13 +547,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -572,10 +577,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -593,13 +599,14 @@
         "1.0.1",
         "1.1.0",
         "1.1.1",
-        "1.1.2"
+        "1.1.2",
+        "1.1.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "1.1.2"
+        "maxVersion": "1.1.3"
       }
     },
     "availableVersions": [
@@ -608,10 +615,11 @@
       "1.0.1",
       "1.1.0",
       "1.1.1",
-      "1.1.2"
+      "1.1.2",
+      "1.1.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "1.1.2",
+    "maxVersion": "1.1.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -735,13 +743,14 @@
         "1.2.2",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.3.3"
       }
     },
     "availableVersions": [
@@ -778,10 +787,11 @@
       "1.2.2",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.3.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -824,13 +834,14 @@
         "1.1.1",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -864,10 +875,11 @@
       "1.1.1",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.1.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -984,13 +996,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1018,10 +1031,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -1041,13 +1055,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.11",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1058,10 +1073,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.11",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -1134,13 +1150,14 @@
         "1.2.1",
         "1.2.2",
         "1.3.0",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.6",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -1166,10 +1183,11 @@
       "1.2.1",
       "1.2.2",
       "1.3.0",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.6",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -1245,13 +1263,14 @@
         "1.6.1",
         "1.7.0",
         "1.7.1",
-        "1.7.2"
+        "1.7.2",
+        "1.7.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.8",
-        "maxVersion": "1.7.2"
+        "maxVersion": "1.7.3"
       }
     },
     "availableVersions": [
@@ -1318,10 +1337,11 @@
       "1.6.1",
       "1.7.0",
       "1.7.1",
-      "1.7.2"
+      "1.7.2",
+      "1.7.3"
     ],
     "minVersion": "0.0.8",
-    "maxVersion": "1.7.2",
+    "maxVersion": "1.7.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -1689,13 +1709,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.12",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1706,10 +1727,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.12",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -1742,13 +1764,14 @@
         "1.1.1",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.5",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1772,10 +1795,11 @@
       "1.1.1",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.5",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -1815,13 +1839,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.4",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1852,10 +1877,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.4",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -1946,13 +1972,14 @@
         "1.11.2",
         "1.11.3",
         "1.11.4",
-        "1.12.0"
+        "1.12.0",
+        "1.12.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.12.0"
+        "maxVersion": "1.12.2"
       }
     },
     "availableVersions": [
@@ -2034,10 +2061,11 @@
       "1.11.2",
       "1.11.3",
       "1.11.4",
-      "1.12.0"
+      "1.12.0",
+      "1.12.2"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.12.0",
+    "maxVersion": "1.12.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -2101,13 +2129,14 @@
         "1.3.1",
         "1.3.2",
         "1.3.3",
-        "1.3.4"
+        "1.3.4",
+        "1.3.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.8",
-        "maxVersion": "1.3.4"
+        "maxVersion": "1.3.5"
       }
     },
     "availableVersions": [
@@ -2162,10 +2191,11 @@
       "1.3.1",
       "1.3.2",
       "1.3.3",
-      "1.3.4"
+      "1.3.4",
+      "1.3.5"
     ],
     "minVersion": "0.0.8",
-    "maxVersion": "1.3.4",
+    "maxVersion": "1.3.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -2208,13 +2238,14 @@
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.3.3"
+        "1.3.3",
+        "1.3.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.3.3"
+        "maxVersion": "1.3.5"
       }
     },
     "availableVersions": [
@@ -2248,10 +2279,11 @@
       "1.3.0",
       "1.3.1",
       "1.3.2",
-      "1.3.3"
+      "1.3.3",
+      "1.3.5"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.3.3",
+    "maxVersion": "1.3.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -2299,13 +2331,14 @@
         "1.2.0",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.3.3"
       }
     },
     "availableVersions": [
@@ -2344,10 +2377,11 @@
       "1.2.0",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.3.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -2393,13 +2427,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -2436,10 +2471,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -2454,22 +2490,24 @@
       "alpha": [
         "0.1.0",
         "0.2.0",
-        "0.2.2"
+        "0.2.2",
+        "0.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.2.2"
+        "maxVersion": "0.2.3"
       }
     },
     "availableVersions": [
       "0.1.0",
       "0.2.0",
-      "0.2.2"
+      "0.2.2",
+      "0.2.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.2.2",
+    "maxVersion": "0.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -2488,13 +2526,14 @@
         "0.2.2",
         "0.3.0",
         "0.3.1",
-        "0.3.2"
+        "0.3.2",
+        "0.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.3.2"
+        "maxVersion": "0.3.3"
       }
     },
     "availableVersions": [
@@ -2504,10 +2543,11 @@
       "0.2.2",
       "0.3.0",
       "0.3.1",
-      "0.3.2"
+      "0.3.2",
+      "0.3.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.3.2",
+    "maxVersion": "0.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -2711,13 +2751,14 @@
         "1.3.2",
         "1.4.0",
         "1.4.1",
-        "1.5.0"
+        "1.5.0",
+        "1.5.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.5.0"
+        "maxVersion": "1.5.1"
       }
     },
     "availableVersions": [
@@ -2758,10 +2799,11 @@
       "1.3.2",
       "1.4.0",
       "1.4.1",
-      "1.5.0"
+      "1.5.0",
+      "1.5.1"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.5.0",
+    "maxVersion": "1.5.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -2807,13 +2849,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -2850,10 +2893,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -3014,13 +3058,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -3078,10 +3123,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -3154,13 +3200,14 @@
         "1.9.2",
         "1.10.0",
         "1.10.1",
-        "1.10.2"
+        "1.10.2",
+        "1.12.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.10.2"
+        "maxVersion": "1.12.2"
       }
     },
     "availableVersions": [
@@ -3224,10 +3271,11 @@
       "1.9.2",
       "1.10.0",
       "1.10.1",
-      "1.10.2"
+      "1.10.2",
+      "1.12.2"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.10.2",
+    "maxVersion": "1.12.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -3270,13 +3318,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -3310,10 +3359,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -3522,13 +3572,14 @@
         "0.2.2",
         "0.3.0",
         "0.3.1",
-        "0.3.2"
+        "0.3.2",
+        "0.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.3.2"
+        "maxVersion": "0.3.3"
       }
     },
     "availableVersions": [
@@ -3540,10 +3591,11 @@
       "0.2.2",
       "0.3.0",
       "0.3.1",
-      "0.3.2"
+      "0.3.2",
+      "0.3.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.3.2",
+    "maxVersion": "0.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -3593,13 +3645,15 @@
         "1.2.0",
         "1.2.1",
         "1.2.2",
-        "1.2.3"
+        "1.2.3",
+        "1.2.4",
+        "1.2.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.4",
-        "maxVersion": "1.2.3"
+        "maxVersion": "1.2.5"
       }
     },
     "availableVersions": [
@@ -3640,10 +3694,12 @@
       "1.2.0",
       "1.2.1",
       "1.2.2",
-      "1.2.3"
+      "1.2.3",
+      "1.2.4",
+      "1.2.5"
     ],
     "minVersion": "0.0.4",
-    "maxVersion": "1.2.3",
+    "maxVersion": "1.2.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -3677,13 +3733,14 @@
         "1.2.0",
         "1.2.1",
         "1.2.2",
-        "1.2.3"
+        "1.2.3",
+        "1.2.4"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.6",
-        "maxVersion": "1.2.3"
+        "maxVersion": "1.2.4"
       }
     },
     "availableVersions": [
@@ -3708,10 +3765,11 @@
       "1.2.0",
       "1.2.1",
       "1.2.2",
-      "1.2.3"
+      "1.2.3",
+      "1.2.4"
     ],
     "minVersion": "0.0.6",
-    "maxVersion": "1.2.3",
+    "maxVersion": "1.2.4",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -3751,13 +3809,14 @@
         "1.1.3",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -3788,10 +3847,11 @@
       "1.1.3",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -3839,13 +3899,14 @@
         "1.3.2",
         "1.4.0",
         "1.4.1",
-        "1.4.2"
+        "1.4.2",
+        "1.4.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.4.2"
+        "maxVersion": "1.4.3"
       }
     },
     "availableVersions": [
@@ -3884,10 +3945,11 @@
       "1.3.2",
       "1.4.0",
       "1.4.1",
-      "1.4.2"
+      "1.4.2",
+      "1.4.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.4.2",
+    "maxVersion": "1.4.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -3901,21 +3963,23 @@
     "channelVersions": {
       "alpha": [
         "0.1.0",
-        "0.1.1"
+        "0.1.1",
+        "0.2.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.1.1"
+        "maxVersion": "0.2.1"
       }
     },
     "availableVersions": [
       "0.1.0",
-      "0.1.1"
+      "0.1.1",
+      "0.2.1"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.1.1",
+    "maxVersion": "0.2.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -4170,13 +4234,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4200,10 +4265,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -4246,13 +4312,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.2",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -4286,10 +4353,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.2",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -4324,13 +4392,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4356,10 +4425,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -4436,13 +4506,15 @@
         "1.2.2",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.3.3",
+        "1.3.4"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.7",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.3.4"
       }
     },
     "availableVersions": [
@@ -4510,10 +4582,12 @@
       "1.2.2",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.3.3",
+      "1.3.4"
     ],
     "minVersion": "0.0.7",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.3.4",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -4532,13 +4606,14 @@
         "1.1.1",
         "1.1.2",
         "1.2.0",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.10",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4548,10 +4623,11 @@
       "1.1.1",
       "1.1.2",
       "1.2.0",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.10",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -4606,13 +4682,14 @@
         "1.7.0",
         "1.7.1",
         "1.7.2",
-        "1.7.3"
+        "1.7.3",
+        "1.7.4"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.3.1",
-        "maxVersion": "1.7.3"
+        "maxVersion": "1.7.4"
       }
     },
     "availableVersions": [
@@ -4658,10 +4735,11 @@
       "1.7.0",
       "1.7.1",
       "1.7.2",
-      "1.7.3"
+      "1.7.3",
+      "1.7.4"
     ],
     "minVersion": "0.3.1",
-    "maxVersion": "1.7.3",
+    "maxVersion": "1.7.4",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -4700,13 +4778,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4736,10 +4815,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -4771,13 +4851,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4800,10 +4881,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -4866,13 +4948,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.5",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4926,10 +5009,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.5",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -4986,13 +5070,14 @@
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.4.0"
+        "1.4.0",
+        "1.4.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.4",
-        "maxVersion": "1.4.0"
+        "maxVersion": "1.4.1"
       }
     },
     "availableVersions": [
@@ -5040,10 +5125,11 @@
       "1.3.0",
       "1.3.1",
       "1.3.2",
-      "1.4.0"
+      "1.4.0",
+      "1.4.1"
     ],
     "minVersion": "0.0.4",
-    "maxVersion": "1.4.0",
+    "maxVersion": "1.4.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -5097,13 +5183,14 @@
         "1.3.0",
         "1.3.1",
         "1.4.0",
-        "1.4.2"
+        "1.4.2",
+        "1.4.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.4.2"
+        "maxVersion": "1.4.3"
       }
     },
     "availableVersions": [
@@ -5148,10 +5235,11 @@
       "1.3.0",
       "1.3.1",
       "1.4.0",
-      "1.4.2"
+      "1.4.2",
+      "1.4.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.4.2",
+    "maxVersion": "1.4.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -5183,13 +5271,14 @@
         "1.2.0",
         "1.2.1",
         "1.3.0",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -5212,10 +5301,11 @@
       "1.2.0",
       "1.2.1",
       "1.3.0",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -5249,13 +5339,14 @@
         "1.2.1",
         "1.2.2",
         "1.3.0",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -5280,10 +5371,11 @@
       "1.2.1",
       "1.2.2",
       "1.3.0",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -5321,7 +5413,8 @@
         "4.1.1",
         "4.1.2",
         "4.2.0",
-        "4.3.0"
+        "4.3.0",
+        "4.4.0"
       ]
     },
     "channelVersionRanges": {
@@ -5331,7 +5424,7 @@
       },
       "stable": {
         "minVersion": "3.0.0",
-        "maxVersion": "4.3.0"
+        "maxVersion": "4.4.0"
       }
     },
     "availableVersions": [
@@ -5357,10 +5450,11 @@
       "4.1.1",
       "4.1.2",
       "4.2.0",
-      "4.3.0"
+      "4.3.0",
+      "4.4.0"
     ],
     "minVersion": "2.1.0",
-    "maxVersion": "4.3.0",
+    "maxVersion": "4.4.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -9877,13 +9971,14 @@
         "0.45.0",
         "0.45.1",
         "0.46.0",
-        "0.47.0"
+        "0.47.0",
+        "0.48.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.18.0",
-        "maxVersion": "0.47.0"
+        "maxVersion": "0.48.0"
       }
     },
     "availableVersions": [
@@ -9915,10 +10010,11 @@
       "0.45.0",
       "0.45.1",
       "0.46.0",
-      "0.47.0"
+      "0.47.0",
+      "0.48.0"
     ],
     "minVersion": "0.18.0",
-    "maxVersion": "0.47.0",
+    "maxVersion": "0.48.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -10080,7 +10176,8 @@
         "2.10.0",
         "2.10.1",
         "2.10.2",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ],
       "unstable": [
         "1.6.0",
@@ -10141,17 +10238,18 @@
         "2.10.0",
         "2.10.1",
         "2.10.2",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.6.0",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       },
       "unstable": {
         "minVersion": "1.6.0",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       }
     },
     "availableVersions": [
@@ -10213,10 +10311,11 @@
       "2.10.0",
       "2.10.1",
       "2.10.2",
-      "2.11.0"
+      "2.11.0",
+      "2.11.1"
     ],
     "minVersion": "1.6.0",
-    "maxVersion": "2.11.0",
+    "maxVersion": "2.11.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -10238,13 +10337,14 @@
         "1.46.0",
         "1.47.0",
         "1.47.1",
-        "1.48.0"
+        "1.48.0",
+        "1.48.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.42.0",
-        "maxVersion": "1.48.0"
+        "maxVersion": "1.48.1"
       }
     },
     "availableVersions": [
@@ -10257,10 +10357,11 @@
       "1.46.0",
       "1.47.0",
       "1.47.1",
-      "1.48.0"
+      "1.48.0",
+      "1.48.1"
     ],
     "minVersion": "1.42.0",
-    "maxVersion": "1.48.0",
+    "maxVersion": "1.48.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -10672,7 +10773,8 @@
         "1.2.5135-afd4101",
         "1.2.5143-a5d0850",
         "1.2.5151-a6aa930",
-        "1.2.5177-a325b87"
+        "1.2.5177-a325b87",
+        "1.2.5181-aa1db74"
       ],
       "mce-2.0": [
         "2.5.3489-6dec9c3",
@@ -10716,7 +10818,7 @@
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.2.4355-e5f809f",
-        "maxVersion": "1.2.5177-a325b87"
+        "maxVersion": "1.2.5181-aa1db74"
       },
       "mce-2.0": {
         "minVersion": "2.5.3489-6dec9c3",
@@ -10812,6 +10914,7 @@
       "1.2.5143-a5d0850",
       "1.2.5151-a6aa930",
       "1.2.5177-a325b87",
+      "1.2.5181-aa1db74",
       "2.3.3039-60b8a9a",
       "2.4.3180-7299056",
       "2.4.3189-026033b",
@@ -12664,21 +12767,23 @@
     "channelVersions": {
       "alpha": [
         "0.0.3",
-        "0.0.4"
+        "0.0.4",
+        "0.0.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "0.0.4"
+        "maxVersion": "0.0.5"
       }
     },
     "availableVersions": [
       "0.0.3",
-      "0.0.4"
+      "0.0.4",
+      "0.0.5"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "0.0.4",
+    "maxVersion": "0.0.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -15052,13 +15157,14 @@
         "0.143.0",
         "0.144.0",
         "0.145.0",
-        "0.148.0"
+        "0.148.0",
+        "0.149.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.105.0",
-        "maxVersion": "0.148.0"
+        "maxVersion": "0.149.0"
       }
     },
     "availableVersions": [
@@ -15099,10 +15205,11 @@
       "0.143.0",
       "0.144.0",
       "0.145.0",
-      "0.148.0"
+      "0.148.0",
+      "0.149.0"
     ],
     "minVersion": "0.105.0",
-    "maxVersion": "0.148.0",
+    "maxVersion": "0.149.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"
@@ -16694,11 +16801,6 @@
     ],
     "channelVersions": {
       "1.29-nightly": [
-        "1.29.0-nightly-2026-04-04",
-        "1.29.0-nightly-2026-04-05",
-        "1.29.0-nightly-2026-04-06",
-        "1.29.0-nightly-2026-04-07",
-        "1.29.0-nightly-2026-04-08",
         "1.29.0-nightly-2026-04-09"
       ],
       "1.30-nightly": [
@@ -16710,7 +16812,10 @@
         "1.30.0-nightly-2026-04-15",
         "1.30.0-nightly-2026-04-16",
         "1.30.0-nightly-2026-04-17",
-        "1.30.0-nightly-2026-04-18"
+        "1.30.0-nightly-2026-04-18",
+        "1.30.0-nightly-2026-04-19",
+        "1.30.0-nightly-2026-04-20",
+        "1.30.0-nightly-2026-04-21"
       ],
       "candidates": [
         "0.1.0",
@@ -16768,12 +16873,12 @@
     },
     "channelVersionRanges": {
       "1.29-nightly": {
-        "minVersion": "1.29.0-nightly-2026-04-04",
+        "minVersion": "1.29.0-nightly-2026-04-09",
         "maxVersion": "1.29.0-nightly-2026-04-09"
       },
       "1.30-nightly": {
         "minVersion": "1.30.0-nightly-2026-04-10",
-        "maxVersion": "1.30.0-nightly-2026-04-18"
+        "maxVersion": "1.30.0-nightly-2026-04-21"
       },
       "candidates": {
         "minVersion": "0.1.0",
@@ -16828,11 +16933,6 @@
       "1.28.2",
       "1.28.3",
       "1.29.0",
-      "1.29.0-nightly-2026-04-04",
-      "1.29.0-nightly-2026-04-05",
-      "1.29.0-nightly-2026-04-06",
-      "1.29.0-nightly-2026-04-07",
-      "1.29.0-nightly-2026-04-08",
       "1.29.0-nightly-2026-04-09",
       "1.29.1",
       "1.30.0-nightly-2026-04-10",
@@ -16843,10 +16943,13 @@
       "1.30.0-nightly-2026-04-15",
       "1.30.0-nightly-2026-04-16",
       "1.30.0-nightly-2026-04-17",
-      "1.30.0-nightly-2026-04-18"
+      "1.30.0-nightly-2026-04-18",
+      "1.30.0-nightly-2026-04-19",
+      "1.30.0-nightly-2026-04-20",
+      "1.30.0-nightly-2026-04-21"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "1.30.0-nightly-2026-04-18",
+    "maxVersion": "1.30.0-nightly-2026-04-21",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.17"

--- a/catalog-data/community-operator-index/v4.18/operators.json
+++ b/catalog-data/community-operator-index/v4.18/operators.json
@@ -253,13 +253,14 @@
         "1.3.2",
         "1.4.0",
         "1.4.1",
-        "1.4.2"
+        "1.4.2",
+        "1.4.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.4.2"
+        "maxVersion": "1.4.3"
       }
     },
     "availableVersions": [
@@ -282,10 +283,11 @@
       "1.3.2",
       "1.4.0",
       "1.4.1",
-      "1.4.2"
+      "1.4.2",
+      "1.4.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.4.2",
+    "maxVersion": "1.4.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -454,13 +456,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.2.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -508,10 +511,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.2.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -543,13 +547,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -572,10 +577,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -593,13 +599,14 @@
         "1.0.1",
         "1.1.0",
         "1.1.1",
-        "1.1.2"
+        "1.1.2",
+        "1.1.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "1.1.2"
+        "maxVersion": "1.1.3"
       }
     },
     "availableVersions": [
@@ -608,10 +615,11 @@
       "1.0.1",
       "1.1.0",
       "1.1.1",
-      "1.1.2"
+      "1.1.2",
+      "1.1.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "1.1.2",
+    "maxVersion": "1.1.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -735,13 +743,14 @@
         "1.2.2",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.3.3"
       }
     },
     "availableVersions": [
@@ -778,10 +787,11 @@
       "1.2.2",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.3.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -824,13 +834,14 @@
         "1.1.1",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -864,10 +875,11 @@
       "1.1.1",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.1.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -984,13 +996,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1018,10 +1031,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -1041,13 +1055,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.11",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1058,10 +1073,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.11",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -1134,13 +1150,14 @@
         "1.2.1",
         "1.2.2",
         "1.3.0",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.6",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -1166,10 +1183,11 @@
       "1.2.1",
       "1.2.2",
       "1.3.0",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.6",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -1245,13 +1263,14 @@
         "1.6.1",
         "1.7.0",
         "1.7.1",
-        "1.7.2"
+        "1.7.2",
+        "1.7.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.8",
-        "maxVersion": "1.7.2"
+        "maxVersion": "1.7.3"
       }
     },
     "availableVersions": [
@@ -1318,10 +1337,11 @@
       "1.6.1",
       "1.7.0",
       "1.7.1",
-      "1.7.2"
+      "1.7.2",
+      "1.7.3"
     ],
     "minVersion": "0.0.8",
-    "maxVersion": "1.7.2",
+    "maxVersion": "1.7.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -1689,13 +1709,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.12",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1706,10 +1727,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.12",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -1742,13 +1764,14 @@
         "1.1.1",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.5",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1772,10 +1795,11 @@
       "1.1.1",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.5",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -1815,13 +1839,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.4",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1852,10 +1877,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.4",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -1946,13 +1972,14 @@
         "1.11.2",
         "1.11.3",
         "1.11.4",
-        "1.12.0"
+        "1.12.0",
+        "1.12.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.12.0"
+        "maxVersion": "1.12.2"
       }
     },
     "availableVersions": [
@@ -2034,10 +2061,11 @@
       "1.11.2",
       "1.11.3",
       "1.11.4",
-      "1.12.0"
+      "1.12.0",
+      "1.12.2"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.12.0",
+    "maxVersion": "1.12.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -2101,13 +2129,14 @@
         "1.3.1",
         "1.3.2",
         "1.3.3",
-        "1.3.4"
+        "1.3.4",
+        "1.3.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.8",
-        "maxVersion": "1.3.4"
+        "maxVersion": "1.3.5"
       }
     },
     "availableVersions": [
@@ -2162,10 +2191,11 @@
       "1.3.1",
       "1.3.2",
       "1.3.3",
-      "1.3.4"
+      "1.3.4",
+      "1.3.5"
     ],
     "minVersion": "0.0.8",
-    "maxVersion": "1.3.4",
+    "maxVersion": "1.3.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -2208,13 +2238,14 @@
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.3.3"
+        "1.3.3",
+        "1.3.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.3.3"
+        "maxVersion": "1.3.5"
       }
     },
     "availableVersions": [
@@ -2248,10 +2279,11 @@
       "1.3.0",
       "1.3.1",
       "1.3.2",
-      "1.3.3"
+      "1.3.3",
+      "1.3.5"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.3.3",
+    "maxVersion": "1.3.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -2299,13 +2331,14 @@
         "1.2.0",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.3.3"
       }
     },
     "availableVersions": [
@@ -2344,10 +2377,11 @@
       "1.2.0",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.3.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -2393,13 +2427,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -2436,10 +2471,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -2454,22 +2490,24 @@
       "alpha": [
         "0.1.0",
         "0.2.0",
-        "0.2.2"
+        "0.2.2",
+        "0.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.2.2"
+        "maxVersion": "0.2.3"
       }
     },
     "availableVersions": [
       "0.1.0",
       "0.2.0",
-      "0.2.2"
+      "0.2.2",
+      "0.2.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.2.2",
+    "maxVersion": "0.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -2488,13 +2526,14 @@
         "0.2.2",
         "0.3.0",
         "0.3.1",
-        "0.3.2"
+        "0.3.2",
+        "0.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.3.2"
+        "maxVersion": "0.3.3"
       }
     },
     "availableVersions": [
@@ -2504,10 +2543,11 @@
       "0.2.2",
       "0.3.0",
       "0.3.1",
-      "0.3.2"
+      "0.3.2",
+      "0.3.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.3.2",
+    "maxVersion": "0.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -2711,13 +2751,14 @@
         "1.3.2",
         "1.4.0",
         "1.4.1",
-        "1.5.0"
+        "1.5.0",
+        "1.5.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.5.0"
+        "maxVersion": "1.5.1"
       }
     },
     "availableVersions": [
@@ -2758,10 +2799,11 @@
       "1.3.2",
       "1.4.0",
       "1.4.1",
-      "1.5.0"
+      "1.5.0",
+      "1.5.1"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.5.0",
+    "maxVersion": "1.5.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -2807,13 +2849,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -2850,10 +2893,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -3014,13 +3058,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -3078,10 +3123,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -3154,13 +3200,14 @@
         "1.9.2",
         "1.10.0",
         "1.10.1",
-        "1.10.2"
+        "1.10.2",
+        "1.12.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.10.2"
+        "maxVersion": "1.12.2"
       }
     },
     "availableVersions": [
@@ -3224,10 +3271,11 @@
       "1.9.2",
       "1.10.0",
       "1.10.1",
-      "1.10.2"
+      "1.10.2",
+      "1.12.2"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.10.2",
+    "maxVersion": "1.12.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -3270,13 +3318,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -3310,10 +3359,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -3522,13 +3572,14 @@
         "0.2.2",
         "0.3.0",
         "0.3.1",
-        "0.3.2"
+        "0.3.2",
+        "0.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.3.2"
+        "maxVersion": "0.3.3"
       }
     },
     "availableVersions": [
@@ -3540,10 +3591,11 @@
       "0.2.2",
       "0.3.0",
       "0.3.1",
-      "0.3.2"
+      "0.3.2",
+      "0.3.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.3.2",
+    "maxVersion": "0.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -3593,13 +3645,15 @@
         "1.2.0",
         "1.2.1",
         "1.2.2",
-        "1.2.3"
+        "1.2.3",
+        "1.2.4",
+        "1.2.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.4",
-        "maxVersion": "1.2.3"
+        "maxVersion": "1.2.5"
       }
     },
     "availableVersions": [
@@ -3640,10 +3694,12 @@
       "1.2.0",
       "1.2.1",
       "1.2.2",
-      "1.2.3"
+      "1.2.3",
+      "1.2.4",
+      "1.2.5"
     ],
     "minVersion": "0.0.4",
-    "maxVersion": "1.2.3",
+    "maxVersion": "1.2.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -3677,13 +3733,14 @@
         "1.2.0",
         "1.2.1",
         "1.2.2",
-        "1.2.3"
+        "1.2.3",
+        "1.2.4"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.6",
-        "maxVersion": "1.2.3"
+        "maxVersion": "1.2.4"
       }
     },
     "availableVersions": [
@@ -3708,10 +3765,11 @@
       "1.2.0",
       "1.2.1",
       "1.2.2",
-      "1.2.3"
+      "1.2.3",
+      "1.2.4"
     ],
     "minVersion": "0.0.6",
-    "maxVersion": "1.2.3",
+    "maxVersion": "1.2.4",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -3751,13 +3809,14 @@
         "1.1.3",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -3788,10 +3847,11 @@
       "1.1.3",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -3839,13 +3899,14 @@
         "1.3.2",
         "1.4.0",
         "1.4.1",
-        "1.4.2"
+        "1.4.2",
+        "1.4.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.4.2"
+        "maxVersion": "1.4.3"
       }
     },
     "availableVersions": [
@@ -3884,10 +3945,11 @@
       "1.3.2",
       "1.4.0",
       "1.4.1",
-      "1.4.2"
+      "1.4.2",
+      "1.4.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.4.2",
+    "maxVersion": "1.4.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -3901,21 +3963,23 @@
     "channelVersions": {
       "alpha": [
         "0.1.0",
-        "0.1.1"
+        "0.1.1",
+        "0.2.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.1.1"
+        "maxVersion": "0.2.1"
       }
     },
     "availableVersions": [
       "0.1.0",
-      "0.1.1"
+      "0.1.1",
+      "0.2.1"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.1.1",
+    "maxVersion": "0.2.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -4170,13 +4234,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4200,10 +4265,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -4246,13 +4312,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.2",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -4286,10 +4353,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.2",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -4324,13 +4392,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4356,10 +4425,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -4436,13 +4506,15 @@
         "1.2.2",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.3.3",
+        "1.3.4"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.7",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.3.4"
       }
     },
     "availableVersions": [
@@ -4510,10 +4582,12 @@
       "1.2.2",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.3.3",
+      "1.3.4"
     ],
     "minVersion": "0.0.7",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.3.4",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -4532,13 +4606,14 @@
         "1.1.1",
         "1.1.2",
         "1.2.0",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.10",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4548,10 +4623,11 @@
       "1.1.1",
       "1.1.2",
       "1.2.0",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.10",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -4606,13 +4682,14 @@
         "1.7.0",
         "1.7.1",
         "1.7.2",
-        "1.7.3"
+        "1.7.3",
+        "1.7.4"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.3.1",
-        "maxVersion": "1.7.3"
+        "maxVersion": "1.7.4"
       }
     },
     "availableVersions": [
@@ -4658,10 +4735,11 @@
       "1.7.0",
       "1.7.1",
       "1.7.2",
-      "1.7.3"
+      "1.7.3",
+      "1.7.4"
     ],
     "minVersion": "0.3.1",
-    "maxVersion": "1.7.3",
+    "maxVersion": "1.7.4",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -4700,13 +4778,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4736,10 +4815,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -4771,13 +4851,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4800,10 +4881,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -4866,13 +4948,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.5",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4926,10 +5009,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.5",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -4986,13 +5070,14 @@
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.4.0"
+        "1.4.0",
+        "1.4.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.4",
-        "maxVersion": "1.4.0"
+        "maxVersion": "1.4.1"
       }
     },
     "availableVersions": [
@@ -5040,10 +5125,11 @@
       "1.3.0",
       "1.3.1",
       "1.3.2",
-      "1.4.0"
+      "1.4.0",
+      "1.4.1"
     ],
     "minVersion": "0.0.4",
-    "maxVersion": "1.4.0",
+    "maxVersion": "1.4.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -5097,13 +5183,14 @@
         "1.3.0",
         "1.3.1",
         "1.4.0",
-        "1.4.2"
+        "1.4.2",
+        "1.4.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.4.2"
+        "maxVersion": "1.4.3"
       }
     },
     "availableVersions": [
@@ -5148,10 +5235,11 @@
       "1.3.0",
       "1.3.1",
       "1.4.0",
-      "1.4.2"
+      "1.4.2",
+      "1.4.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.4.2",
+    "maxVersion": "1.4.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -5183,13 +5271,14 @@
         "1.2.0",
         "1.2.1",
         "1.3.0",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -5212,10 +5301,11 @@
       "1.2.0",
       "1.2.1",
       "1.3.0",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -5249,13 +5339,14 @@
         "1.2.1",
         "1.2.2",
         "1.3.0",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -5280,10 +5371,11 @@
       "1.2.1",
       "1.2.2",
       "1.3.0",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -5321,7 +5413,8 @@
         "4.1.1",
         "4.1.2",
         "4.2.0",
-        "4.3.0"
+        "4.3.0",
+        "4.4.0"
       ]
     },
     "channelVersionRanges": {
@@ -5331,7 +5424,7 @@
       },
       "stable": {
         "minVersion": "3.0.0",
-        "maxVersion": "4.3.0"
+        "maxVersion": "4.4.0"
       }
     },
     "availableVersions": [
@@ -5357,10 +5450,11 @@
       "4.1.1",
       "4.1.2",
       "4.2.0",
-      "4.3.0"
+      "4.3.0",
+      "4.4.0"
     ],
     "minVersion": "2.1.0",
-    "maxVersion": "4.3.0",
+    "maxVersion": "4.4.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -9891,13 +9985,14 @@
         "0.45.0",
         "0.45.1",
         "0.46.0",
-        "0.47.0"
+        "0.47.0",
+        "0.48.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.18.0",
-        "maxVersion": "0.47.0"
+        "maxVersion": "0.48.0"
       }
     },
     "availableVersions": [
@@ -9929,10 +10024,11 @@
       "0.45.0",
       "0.45.1",
       "0.46.0",
-      "0.47.0"
+      "0.47.0",
+      "0.48.0"
     ],
     "minVersion": "0.18.0",
-    "maxVersion": "0.47.0",
+    "maxVersion": "0.48.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -10072,7 +10168,8 @@
         "2.10.0",
         "2.10.1",
         "2.10.2",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ],
       "unstable": [
         "2.0.0",
@@ -10111,17 +10208,18 @@
         "2.10.0",
         "2.10.1",
         "2.10.2",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.0.0",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       },
       "unstable": {
         "minVersion": "2.0.0",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       }
     },
     "availableVersions": [
@@ -10161,10 +10259,11 @@
       "2.10.0",
       "2.10.1",
       "2.10.2",
-      "2.11.0"
+      "2.11.0",
+      "2.11.1"
     ],
     "minVersion": "2.0.0",
-    "maxVersion": "2.11.0",
+    "maxVersion": "2.11.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -10186,13 +10285,14 @@
         "1.46.0",
         "1.47.0",
         "1.47.1",
-        "1.48.0"
+        "1.48.0",
+        "1.48.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.42.0",
-        "maxVersion": "1.48.0"
+        "maxVersion": "1.48.1"
       }
     },
     "availableVersions": [
@@ -10205,10 +10305,11 @@
       "1.46.0",
       "1.47.0",
       "1.47.1",
-      "1.48.0"
+      "1.48.0",
+      "1.48.1"
     ],
     "minVersion": "1.42.0",
-    "maxVersion": "1.48.0",
+    "maxVersion": "1.48.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -10618,7 +10719,8 @@
         "1.2.5135-afd4101",
         "1.2.5143-a5d0850",
         "1.2.5151-a6aa930",
-        "1.2.5177-a325b87"
+        "1.2.5177-a325b87",
+        "1.2.5181-aa1db74"
       ],
       "mce-2.0": [
         "2.5.3489-6dec9c3",
@@ -10662,7 +10764,7 @@
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.2.4355-e5f809f",
-        "maxVersion": "1.2.5177-a325b87"
+        "maxVersion": "1.2.5181-aa1db74"
       },
       "mce-2.0": {
         "minVersion": "2.5.3489-6dec9c3",
@@ -10758,6 +10860,7 @@
       "1.2.5143-a5d0850",
       "1.2.5151-a6aa930",
       "1.2.5177-a325b87",
+      "1.2.5181-aa1db74",
       "2.3.3039-60b8a9a",
       "2.4.3180-7299056",
       "2.4.3189-026033b",
@@ -12652,21 +12755,23 @@
     "channelVersions": {
       "alpha": [
         "0.0.3",
-        "0.0.4"
+        "0.0.4",
+        "0.0.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "0.0.4"
+        "maxVersion": "0.0.5"
       }
     },
     "availableVersions": [
       "0.0.3",
-      "0.0.4"
+      "0.0.4",
+      "0.0.5"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "0.0.4",
+    "maxVersion": "0.0.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -15079,13 +15184,14 @@
         "0.143.0",
         "0.144.0",
         "0.145.0",
-        "0.148.0"
+        "0.148.0",
+        "0.149.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.105.0",
-        "maxVersion": "0.148.0"
+        "maxVersion": "0.149.0"
       }
     },
     "availableVersions": [
@@ -15126,10 +15232,11 @@
       "0.143.0",
       "0.144.0",
       "0.145.0",
-      "0.148.0"
+      "0.148.0",
+      "0.149.0"
     ],
     "minVersion": "0.105.0",
-    "maxVersion": "0.148.0",
+    "maxVersion": "0.149.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"
@@ -16711,11 +16818,6 @@
     ],
     "channelVersions": {
       "1.29-nightly": [
-        "1.29.0-nightly-2026-04-04",
-        "1.29.0-nightly-2026-04-05",
-        "1.29.0-nightly-2026-04-06",
-        "1.29.0-nightly-2026-04-07",
-        "1.29.0-nightly-2026-04-08",
         "1.29.0-nightly-2026-04-09"
       ],
       "1.30-nightly": [
@@ -16727,7 +16829,10 @@
         "1.30.0-nightly-2026-04-15",
         "1.30.0-nightly-2026-04-16",
         "1.30.0-nightly-2026-04-17",
-        "1.30.0-nightly-2026-04-18"
+        "1.30.0-nightly-2026-04-18",
+        "1.30.0-nightly-2026-04-19",
+        "1.30.0-nightly-2026-04-20",
+        "1.30.0-nightly-2026-04-21"
       ],
       "candidates": [
         "0.1.0",
@@ -16785,12 +16890,12 @@
     },
     "channelVersionRanges": {
       "1.29-nightly": {
-        "minVersion": "1.29.0-nightly-2026-04-04",
+        "minVersion": "1.29.0-nightly-2026-04-09",
         "maxVersion": "1.29.0-nightly-2026-04-09"
       },
       "1.30-nightly": {
         "minVersion": "1.30.0-nightly-2026-04-10",
-        "maxVersion": "1.30.0-nightly-2026-04-18"
+        "maxVersion": "1.30.0-nightly-2026-04-21"
       },
       "candidates": {
         "minVersion": "0.1.0",
@@ -16845,11 +16950,6 @@
       "1.28.2",
       "1.28.3",
       "1.29.0",
-      "1.29.0-nightly-2026-04-04",
-      "1.29.0-nightly-2026-04-05",
-      "1.29.0-nightly-2026-04-06",
-      "1.29.0-nightly-2026-04-07",
-      "1.29.0-nightly-2026-04-08",
       "1.29.0-nightly-2026-04-09",
       "1.29.1",
       "1.30.0-nightly-2026-04-10",
@@ -16860,10 +16960,13 @@
       "1.30.0-nightly-2026-04-15",
       "1.30.0-nightly-2026-04-16",
       "1.30.0-nightly-2026-04-17",
-      "1.30.0-nightly-2026-04-18"
+      "1.30.0-nightly-2026-04-18",
+      "1.30.0-nightly-2026-04-19",
+      "1.30.0-nightly-2026-04-20",
+      "1.30.0-nightly-2026-04-21"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "1.30.0-nightly-2026-04-18",
+    "maxVersion": "1.30.0-nightly-2026-04-21",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.18"

--- a/catalog-data/community-operator-index/v4.19/operators.json
+++ b/catalog-data/community-operator-index/v4.19/operators.json
@@ -253,13 +253,14 @@
         "1.3.2",
         "1.4.0",
         "1.4.1",
-        "1.4.2"
+        "1.4.2",
+        "1.4.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.4.2"
+        "maxVersion": "1.4.3"
       }
     },
     "availableVersions": [
@@ -282,10 +283,11 @@
       "1.3.2",
       "1.4.0",
       "1.4.1",
-      "1.4.2"
+      "1.4.2",
+      "1.4.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.4.2",
+    "maxVersion": "1.4.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -454,13 +456,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.2.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -508,10 +511,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.2.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -543,13 +547,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -572,10 +577,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -593,13 +599,14 @@
         "1.0.1",
         "1.1.0",
         "1.1.1",
-        "1.1.2"
+        "1.1.2",
+        "1.1.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "1.1.2"
+        "maxVersion": "1.1.3"
       }
     },
     "availableVersions": [
@@ -608,10 +615,11 @@
       "1.0.1",
       "1.1.0",
       "1.1.1",
-      "1.1.2"
+      "1.1.2",
+      "1.1.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "1.1.2",
+    "maxVersion": "1.1.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -735,13 +743,14 @@
         "1.2.2",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.3.3"
       }
     },
     "availableVersions": [
@@ -778,10 +787,11 @@
       "1.2.2",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.3.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -824,13 +834,14 @@
         "1.1.1",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -864,10 +875,11 @@
       "1.1.1",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.1.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -984,13 +996,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1018,10 +1031,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -1041,13 +1055,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.11",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1058,10 +1073,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.11",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -1134,13 +1150,14 @@
         "1.2.1",
         "1.2.2",
         "1.3.0",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.6",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -1166,10 +1183,11 @@
       "1.2.1",
       "1.2.2",
       "1.3.0",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.6",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -1245,13 +1263,14 @@
         "1.6.1",
         "1.7.0",
         "1.7.1",
-        "1.7.2"
+        "1.7.2",
+        "1.7.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.8",
-        "maxVersion": "1.7.2"
+        "maxVersion": "1.7.3"
       }
     },
     "availableVersions": [
@@ -1318,10 +1337,11 @@
       "1.6.1",
       "1.7.0",
       "1.7.1",
-      "1.7.2"
+      "1.7.2",
+      "1.7.3"
     ],
     "minVersion": "0.0.8",
-    "maxVersion": "1.7.2",
+    "maxVersion": "1.7.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -1689,13 +1709,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.12",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1706,10 +1727,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.12",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -1732,13 +1754,14 @@
         "1.1.1",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.9",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1752,10 +1775,11 @@
       "1.1.1",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.9",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -1795,13 +1819,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.4",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1832,10 +1857,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.4",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -1926,13 +1952,14 @@
         "1.11.2",
         "1.11.3",
         "1.11.4",
-        "1.12.0"
+        "1.12.0",
+        "1.12.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.12.0"
+        "maxVersion": "1.12.2"
       }
     },
     "availableVersions": [
@@ -2014,10 +2041,11 @@
       "1.11.2",
       "1.11.3",
       "1.11.4",
-      "1.12.0"
+      "1.12.0",
+      "1.12.2"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.12.0",
+    "maxVersion": "1.12.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -2081,13 +2109,14 @@
         "1.3.1",
         "1.3.2",
         "1.3.3",
-        "1.3.4"
+        "1.3.4",
+        "1.3.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.8",
-        "maxVersion": "1.3.4"
+        "maxVersion": "1.3.5"
       }
     },
     "availableVersions": [
@@ -2142,10 +2171,11 @@
       "1.3.1",
       "1.3.2",
       "1.3.3",
-      "1.3.4"
+      "1.3.4",
+      "1.3.5"
     ],
     "minVersion": "0.0.8",
-    "maxVersion": "1.3.4",
+    "maxVersion": "1.3.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -2188,13 +2218,14 @@
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.3.3"
+        "1.3.3",
+        "1.3.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.3.3"
+        "maxVersion": "1.3.5"
       }
     },
     "availableVersions": [
@@ -2228,10 +2259,11 @@
       "1.3.0",
       "1.3.1",
       "1.3.2",
-      "1.3.3"
+      "1.3.3",
+      "1.3.5"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.3.3",
+    "maxVersion": "1.3.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -2279,13 +2311,14 @@
         "1.2.0",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.3.3"
       }
     },
     "availableVersions": [
@@ -2324,10 +2357,11 @@
       "1.2.0",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.3.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -2373,13 +2407,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -2416,10 +2451,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -2434,22 +2470,24 @@
       "alpha": [
         "0.1.0",
         "0.2.0",
-        "0.2.2"
+        "0.2.2",
+        "0.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.2.2"
+        "maxVersion": "0.2.3"
       }
     },
     "availableVersions": [
       "0.1.0",
       "0.2.0",
-      "0.2.2"
+      "0.2.2",
+      "0.2.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.2.2",
+    "maxVersion": "0.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -2468,13 +2506,14 @@
         "0.2.2",
         "0.3.0",
         "0.3.1",
-        "0.3.2"
+        "0.3.2",
+        "0.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.3.2"
+        "maxVersion": "0.3.3"
       }
     },
     "availableVersions": [
@@ -2484,10 +2523,11 @@
       "0.2.2",
       "0.3.0",
       "0.3.1",
-      "0.3.2"
+      "0.3.2",
+      "0.3.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.3.2",
+    "maxVersion": "0.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -2691,13 +2731,14 @@
         "1.3.2",
         "1.4.0",
         "1.4.1",
-        "1.5.0"
+        "1.5.0",
+        "1.5.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.5.0"
+        "maxVersion": "1.5.1"
       }
     },
     "availableVersions": [
@@ -2738,10 +2779,11 @@
       "1.3.2",
       "1.4.0",
       "1.4.1",
-      "1.5.0"
+      "1.5.0",
+      "1.5.1"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.5.0",
+    "maxVersion": "1.5.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -2787,13 +2829,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -2830,10 +2873,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -2994,13 +3038,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -3058,10 +3103,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -3134,13 +3180,14 @@
         "1.9.2",
         "1.10.0",
         "1.10.1",
-        "1.10.2"
+        "1.10.2",
+        "1.12.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.10.2"
+        "maxVersion": "1.12.2"
       }
     },
     "availableVersions": [
@@ -3204,10 +3251,11 @@
       "1.9.2",
       "1.10.0",
       "1.10.1",
-      "1.10.2"
+      "1.10.2",
+      "1.12.2"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.10.2",
+    "maxVersion": "1.12.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -3250,13 +3298,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -3290,10 +3339,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -3502,13 +3552,14 @@
         "0.2.2",
         "0.3.0",
         "0.3.1",
-        "0.3.2"
+        "0.3.2",
+        "0.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.3.2"
+        "maxVersion": "0.3.3"
       }
     },
     "availableVersions": [
@@ -3520,10 +3571,11 @@
       "0.2.2",
       "0.3.0",
       "0.3.1",
-      "0.3.2"
+      "0.3.2",
+      "0.3.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.3.2",
+    "maxVersion": "0.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -3573,13 +3625,15 @@
         "1.2.0",
         "1.2.1",
         "1.2.2",
-        "1.2.3"
+        "1.2.3",
+        "1.2.4",
+        "1.2.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.4",
-        "maxVersion": "1.2.3"
+        "maxVersion": "1.2.5"
       }
     },
     "availableVersions": [
@@ -3620,10 +3674,12 @@
       "1.2.0",
       "1.2.1",
       "1.2.2",
-      "1.2.3"
+      "1.2.3",
+      "1.2.4",
+      "1.2.5"
     ],
     "minVersion": "0.0.4",
-    "maxVersion": "1.2.3",
+    "maxVersion": "1.2.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -3657,13 +3713,14 @@
         "1.2.0",
         "1.2.1",
         "1.2.2",
-        "1.2.3"
+        "1.2.3",
+        "1.2.4"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.6",
-        "maxVersion": "1.2.3"
+        "maxVersion": "1.2.4"
       }
     },
     "availableVersions": [
@@ -3688,10 +3745,11 @@
       "1.2.0",
       "1.2.1",
       "1.2.2",
-      "1.2.3"
+      "1.2.3",
+      "1.2.4"
     ],
     "minVersion": "0.0.6",
-    "maxVersion": "1.2.3",
+    "maxVersion": "1.2.4",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -3731,13 +3789,14 @@
         "1.1.3",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -3768,10 +3827,11 @@
       "1.1.3",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -3819,13 +3879,14 @@
         "1.3.2",
         "1.4.0",
         "1.4.1",
-        "1.4.2"
+        "1.4.2",
+        "1.4.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.4.2"
+        "maxVersion": "1.4.3"
       }
     },
     "availableVersions": [
@@ -3864,10 +3925,11 @@
       "1.3.2",
       "1.4.0",
       "1.4.1",
-      "1.4.2"
+      "1.4.2",
+      "1.4.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.4.2",
+    "maxVersion": "1.4.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -3881,21 +3943,23 @@
     "channelVersions": {
       "alpha": [
         "0.1.0",
-        "0.1.1"
+        "0.1.1",
+        "0.2.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.1.1"
+        "maxVersion": "0.2.1"
       }
     },
     "availableVersions": [
       "0.1.0",
-      "0.1.1"
+      "0.1.1",
+      "0.2.1"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.1.1",
+    "maxVersion": "0.2.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -4150,13 +4214,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4180,10 +4245,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -4226,13 +4292,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.2",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -4266,10 +4333,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.2",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -4304,13 +4372,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4336,10 +4405,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -4416,13 +4486,15 @@
         "1.2.2",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.3.3",
+        "1.3.4"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.7",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.3.4"
       }
     },
     "availableVersions": [
@@ -4490,10 +4562,12 @@
       "1.2.2",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.3.3",
+      "1.3.4"
     ],
     "minVersion": "0.0.7",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.3.4",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -4512,13 +4586,14 @@
         "1.1.1",
         "1.1.2",
         "1.2.0",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.10",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4528,10 +4603,11 @@
       "1.1.1",
       "1.1.2",
       "1.2.0",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.10",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -4586,13 +4662,14 @@
         "1.7.0",
         "1.7.1",
         "1.7.2",
-        "1.7.3"
+        "1.7.3",
+        "1.7.4"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.3.1",
-        "maxVersion": "1.7.3"
+        "maxVersion": "1.7.4"
       }
     },
     "availableVersions": [
@@ -4638,10 +4715,11 @@
       "1.7.0",
       "1.7.1",
       "1.7.2",
-      "1.7.3"
+      "1.7.3",
+      "1.7.4"
     ],
     "minVersion": "0.3.1",
-    "maxVersion": "1.7.3",
+    "maxVersion": "1.7.4",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -4680,13 +4758,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4716,10 +4795,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -4751,13 +4831,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4780,10 +4861,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -4846,13 +4928,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.5",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4906,10 +4989,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.5",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -4966,13 +5050,14 @@
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.4.0"
+        "1.4.0",
+        "1.4.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.4",
-        "maxVersion": "1.4.0"
+        "maxVersion": "1.4.1"
       }
     },
     "availableVersions": [
@@ -5020,10 +5105,11 @@
       "1.3.0",
       "1.3.1",
       "1.3.2",
-      "1.4.0"
+      "1.4.0",
+      "1.4.1"
     ],
     "minVersion": "0.0.4",
-    "maxVersion": "1.4.0",
+    "maxVersion": "1.4.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -5077,13 +5163,14 @@
         "1.3.0",
         "1.3.1",
         "1.4.0",
-        "1.4.2"
+        "1.4.2",
+        "1.4.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.4.2"
+        "maxVersion": "1.4.3"
       }
     },
     "availableVersions": [
@@ -5128,10 +5215,11 @@
       "1.3.0",
       "1.3.1",
       "1.4.0",
-      "1.4.2"
+      "1.4.2",
+      "1.4.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.4.2",
+    "maxVersion": "1.4.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -5163,13 +5251,14 @@
         "1.2.0",
         "1.2.1",
         "1.3.0",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -5192,10 +5281,11 @@
       "1.2.0",
       "1.2.1",
       "1.3.0",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -5229,13 +5319,14 @@
         "1.2.1",
         "1.2.2",
         "1.3.0",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -5260,10 +5351,11 @@
       "1.2.1",
       "1.2.2",
       "1.3.0",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -5301,7 +5393,8 @@
         "4.1.1",
         "4.1.2",
         "4.2.0",
-        "4.3.0"
+        "4.3.0",
+        "4.4.0"
       ]
     },
     "channelVersionRanges": {
@@ -5311,7 +5404,7 @@
       },
       "stable": {
         "minVersion": "3.0.0",
-        "maxVersion": "4.3.0"
+        "maxVersion": "4.4.0"
       }
     },
     "availableVersions": [
@@ -5337,10 +5430,11 @@
       "4.1.1",
       "4.1.2",
       "4.2.0",
-      "4.3.0"
+      "4.3.0",
+      "4.4.0"
     ],
     "minVersion": "2.1.0",
-    "maxVersion": "4.3.0",
+    "maxVersion": "4.4.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -7002,7 +7096,8 @@
         "1.0.0",
         "1.1.1",
         "1.1.2",
-        "1.1.3"
+        "1.1.3",
+        "1.1.4"
       ],
       "Stable": [
         "0.0.1",
@@ -7013,17 +7108,18 @@
         "1.0.0",
         "1.1.1",
         "1.1.2",
-        "1.1.3"
+        "1.1.3",
+        "1.1.4"
       ]
     },
     "channelVersionRanges": {
       "Fast": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.1.3"
+        "maxVersion": "1.1.4"
       },
       "Stable": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.1.3"
+        "maxVersion": "1.1.4"
       }
     },
     "availableVersions": [
@@ -7035,10 +7131,11 @@
       "1.0.0",
       "1.1.1",
       "1.1.2",
-      "1.1.3"
+      "1.1.3",
+      "1.1.4"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.1.3",
+    "maxVersion": "1.1.4",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -9897,13 +9994,14 @@
         "0.45.0",
         "0.45.1",
         "0.46.0",
-        "0.47.0"
+        "0.47.0",
+        "0.48.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.28.0",
-        "maxVersion": "0.47.0"
+        "maxVersion": "0.48.0"
       }
     },
     "availableVersions": [
@@ -9925,10 +10023,11 @@
       "0.45.0",
       "0.45.1",
       "0.46.0",
-      "0.47.0"
+      "0.47.0",
+      "0.48.0"
     ],
     "minVersion": "0.28.0",
-    "maxVersion": "0.47.0",
+    "maxVersion": "0.48.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -10066,7 +10165,8 @@
         "2.10.0",
         "2.10.1",
         "2.10.2",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ],
       "unstable": [
         "2.2.0",
@@ -10099,17 +10199,18 @@
         "2.10.0",
         "2.10.1",
         "2.10.2",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.2.0",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       },
       "unstable": {
         "minVersion": "2.2.0",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       }
     },
     "availableVersions": [
@@ -10143,10 +10244,11 @@
       "2.10.0",
       "2.10.1",
       "2.10.2",
-      "2.11.0"
+      "2.11.0",
+      "2.11.1"
     ],
     "minVersion": "2.2.0",
-    "maxVersion": "2.11.0",
+    "maxVersion": "2.11.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -10168,13 +10270,14 @@
         "1.46.0",
         "1.47.0",
         "1.47.1",
-        "1.48.0"
+        "1.48.0",
+        "1.48.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.42.0",
-        "maxVersion": "1.48.0"
+        "maxVersion": "1.48.1"
       }
     },
     "availableVersions": [
@@ -10187,10 +10290,11 @@
       "1.46.0",
       "1.47.0",
       "1.47.1",
-      "1.48.0"
+      "1.48.0",
+      "1.48.1"
     ],
     "minVersion": "1.42.0",
-    "maxVersion": "1.48.0",
+    "maxVersion": "1.48.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -10600,7 +10704,8 @@
         "1.2.5135-afd4101",
         "1.2.5143-a5d0850",
         "1.2.5151-a6aa930",
-        "1.2.5177-a325b87"
+        "1.2.5177-a325b87",
+        "1.2.5181-aa1db74"
       ],
       "mce-2.0": [
         "2.5.3489-6dec9c3",
@@ -10644,7 +10749,7 @@
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.2.4355-e5f809f",
-        "maxVersion": "1.2.5177-a325b87"
+        "maxVersion": "1.2.5181-aa1db74"
       },
       "mce-2.0": {
         "minVersion": "2.5.3489-6dec9c3",
@@ -10740,6 +10845,7 @@
       "1.2.5143-a5d0850",
       "1.2.5151-a6aa930",
       "1.2.5177-a325b87",
+      "1.2.5181-aa1db74",
       "2.3.3039-60b8a9a",
       "2.4.3180-7299056",
       "2.4.3189-026033b",
@@ -12517,21 +12623,23 @@
     "channelVersions": {
       "alpha": [
         "0.0.3",
-        "0.0.4"
+        "0.0.4",
+        "0.0.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "0.0.4"
+        "maxVersion": "0.0.5"
       }
     },
     "availableVersions": [
       "0.0.3",
-      "0.0.4"
+      "0.0.4",
+      "0.0.5"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "0.0.4",
+    "maxVersion": "0.0.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -14905,13 +15013,14 @@
         "0.143.0",
         "0.144.0",
         "0.145.0",
-        "0.148.0"
+        "0.148.0",
+        "0.149.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.105.0",
-        "maxVersion": "0.148.0"
+        "maxVersion": "0.149.0"
       }
     },
     "availableVersions": [
@@ -14952,10 +15061,11 @@
       "0.143.0",
       "0.144.0",
       "0.145.0",
-      "0.148.0"
+      "0.148.0",
+      "0.149.0"
     ],
     "minVersion": "0.105.0",
-    "maxVersion": "0.148.0",
+    "maxVersion": "0.149.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"
@@ -16520,11 +16630,6 @@
     ],
     "channelVersions": {
       "1.29-nightly": [
-        "1.29.0-nightly-2026-04-04",
-        "1.29.0-nightly-2026-04-05",
-        "1.29.0-nightly-2026-04-06",
-        "1.29.0-nightly-2026-04-07",
-        "1.29.0-nightly-2026-04-08",
         "1.29.0-nightly-2026-04-09"
       ],
       "1.30-nightly": [
@@ -16536,7 +16641,10 @@
         "1.30.0-nightly-2026-04-15",
         "1.30.0-nightly-2026-04-16",
         "1.30.0-nightly-2026-04-17",
-        "1.30.0-nightly-2026-04-18"
+        "1.30.0-nightly-2026-04-18",
+        "1.30.0-nightly-2026-04-19",
+        "1.30.0-nightly-2026-04-20",
+        "1.30.0-nightly-2026-04-21"
       ],
       "candidates": [
         "0.1.0",
@@ -16594,12 +16702,12 @@
     },
     "channelVersionRanges": {
       "1.29-nightly": {
-        "minVersion": "1.29.0-nightly-2026-04-04",
+        "minVersion": "1.29.0-nightly-2026-04-09",
         "maxVersion": "1.29.0-nightly-2026-04-09"
       },
       "1.30-nightly": {
         "minVersion": "1.30.0-nightly-2026-04-10",
-        "maxVersion": "1.30.0-nightly-2026-04-18"
+        "maxVersion": "1.30.0-nightly-2026-04-21"
       },
       "candidates": {
         "minVersion": "0.1.0",
@@ -16654,11 +16762,6 @@
       "1.28.2",
       "1.28.3",
       "1.29.0",
-      "1.29.0-nightly-2026-04-04",
-      "1.29.0-nightly-2026-04-05",
-      "1.29.0-nightly-2026-04-06",
-      "1.29.0-nightly-2026-04-07",
-      "1.29.0-nightly-2026-04-08",
       "1.29.0-nightly-2026-04-09",
       "1.29.1",
       "1.30.0-nightly-2026-04-10",
@@ -16669,10 +16772,13 @@
       "1.30.0-nightly-2026-04-15",
       "1.30.0-nightly-2026-04-16",
       "1.30.0-nightly-2026-04-17",
-      "1.30.0-nightly-2026-04-18"
+      "1.30.0-nightly-2026-04-18",
+      "1.30.0-nightly-2026-04-19",
+      "1.30.0-nightly-2026-04-20",
+      "1.30.0-nightly-2026-04-21"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "1.30.0-nightly-2026-04-18",
+    "maxVersion": "1.30.0-nightly-2026-04-21",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.19"

--- a/catalog-data/community-operator-index/v4.20/operators.json
+++ b/catalog-data/community-operator-index/v4.20/operators.json
@@ -253,13 +253,14 @@
         "1.3.2",
         "1.4.0",
         "1.4.1",
-        "1.4.2"
+        "1.4.2",
+        "1.4.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.4.2"
+        "maxVersion": "1.4.3"
       }
     },
     "availableVersions": [
@@ -282,10 +283,11 @@
       "1.3.2",
       "1.4.0",
       "1.4.1",
-      "1.4.2"
+      "1.4.2",
+      "1.4.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.4.2",
+    "maxVersion": "1.4.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -454,13 +456,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.2.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -508,10 +511,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.2.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -543,13 +547,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -572,10 +577,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -593,13 +599,14 @@
         "1.0.1",
         "1.1.0",
         "1.1.1",
-        "1.1.2"
+        "1.1.2",
+        "1.1.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "1.1.2"
+        "maxVersion": "1.1.3"
       }
     },
     "availableVersions": [
@@ -608,10 +615,11 @@
       "1.0.1",
       "1.1.0",
       "1.1.1",
-      "1.1.2"
+      "1.1.2",
+      "1.1.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "1.1.2",
+    "maxVersion": "1.1.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -735,13 +743,14 @@
         "1.2.2",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.3.3"
       }
     },
     "availableVersions": [
@@ -778,10 +787,11 @@
       "1.2.2",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.3.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -824,13 +834,14 @@
         "1.1.1",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -864,10 +875,11 @@
       "1.1.1",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.1.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -984,13 +996,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1018,10 +1031,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -1041,13 +1055,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.11",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1058,10 +1073,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.11",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -1134,13 +1150,14 @@
         "1.2.1",
         "1.2.2",
         "1.3.0",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.6",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -1166,10 +1183,11 @@
       "1.2.1",
       "1.2.2",
       "1.3.0",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.6",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -1245,13 +1263,14 @@
         "1.6.1",
         "1.7.0",
         "1.7.1",
-        "1.7.2"
+        "1.7.2",
+        "1.7.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.8",
-        "maxVersion": "1.7.2"
+        "maxVersion": "1.7.3"
       }
     },
     "availableVersions": [
@@ -1318,10 +1337,11 @@
       "1.6.1",
       "1.7.0",
       "1.7.1",
-      "1.7.2"
+      "1.7.2",
+      "1.7.3"
     ],
     "minVersion": "0.0.8",
-    "maxVersion": "1.7.2",
+    "maxVersion": "1.7.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -1689,13 +1709,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.12",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1706,10 +1727,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.12",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -1732,13 +1754,14 @@
         "1.1.1",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.9",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1752,10 +1775,11 @@
       "1.1.1",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.9",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -1795,13 +1819,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.4",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1832,10 +1857,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.4",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -1926,13 +1952,14 @@
         "1.11.2",
         "1.11.3",
         "1.11.4",
-        "1.12.0"
+        "1.12.0",
+        "1.12.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.12.0"
+        "maxVersion": "1.12.2"
       }
     },
     "availableVersions": [
@@ -2014,10 +2041,11 @@
       "1.11.2",
       "1.11.3",
       "1.11.4",
-      "1.12.0"
+      "1.12.0",
+      "1.12.2"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.12.0",
+    "maxVersion": "1.12.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -2081,13 +2109,14 @@
         "1.3.1",
         "1.3.2",
         "1.3.3",
-        "1.3.4"
+        "1.3.4",
+        "1.3.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.8",
-        "maxVersion": "1.3.4"
+        "maxVersion": "1.3.5"
       }
     },
     "availableVersions": [
@@ -2142,10 +2171,11 @@
       "1.3.1",
       "1.3.2",
       "1.3.3",
-      "1.3.4"
+      "1.3.4",
+      "1.3.5"
     ],
     "minVersion": "0.0.8",
-    "maxVersion": "1.3.4",
+    "maxVersion": "1.3.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -2188,13 +2218,14 @@
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.3.3"
+        "1.3.3",
+        "1.3.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.3.3"
+        "maxVersion": "1.3.5"
       }
     },
     "availableVersions": [
@@ -2228,10 +2259,11 @@
       "1.3.0",
       "1.3.1",
       "1.3.2",
-      "1.3.3"
+      "1.3.3",
+      "1.3.5"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.3.3",
+    "maxVersion": "1.3.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -2279,13 +2311,14 @@
         "1.2.0",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.3.3"
       }
     },
     "availableVersions": [
@@ -2324,10 +2357,11 @@
       "1.2.0",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.3.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -2373,13 +2407,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -2416,10 +2451,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -2434,22 +2470,24 @@
       "alpha": [
         "0.1.0",
         "0.2.0",
-        "0.2.2"
+        "0.2.2",
+        "0.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.2.2"
+        "maxVersion": "0.2.3"
       }
     },
     "availableVersions": [
       "0.1.0",
       "0.2.0",
-      "0.2.2"
+      "0.2.2",
+      "0.2.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.2.2",
+    "maxVersion": "0.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -2468,13 +2506,14 @@
         "0.2.2",
         "0.3.0",
         "0.3.1",
-        "0.3.2"
+        "0.3.2",
+        "0.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.3.2"
+        "maxVersion": "0.3.3"
       }
     },
     "availableVersions": [
@@ -2484,10 +2523,11 @@
       "0.2.2",
       "0.3.0",
       "0.3.1",
-      "0.3.2"
+      "0.3.2",
+      "0.3.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.3.2",
+    "maxVersion": "0.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -2691,13 +2731,14 @@
         "1.3.2",
         "1.4.0",
         "1.4.1",
-        "1.5.0"
+        "1.5.0",
+        "1.5.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.5.0"
+        "maxVersion": "1.5.1"
       }
     },
     "availableVersions": [
@@ -2738,10 +2779,11 @@
       "1.3.2",
       "1.4.0",
       "1.4.1",
-      "1.5.0"
+      "1.5.0",
+      "1.5.1"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.5.0",
+    "maxVersion": "1.5.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -2787,13 +2829,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -2830,10 +2873,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -2994,13 +3038,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -3058,10 +3103,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -3134,13 +3180,14 @@
         "1.9.2",
         "1.10.0",
         "1.10.1",
-        "1.10.2"
+        "1.10.2",
+        "1.12.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.10.2"
+        "maxVersion": "1.12.2"
       }
     },
     "availableVersions": [
@@ -3204,10 +3251,11 @@
       "1.9.2",
       "1.10.0",
       "1.10.1",
-      "1.10.2"
+      "1.10.2",
+      "1.12.2"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.10.2",
+    "maxVersion": "1.12.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -3250,13 +3298,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -3290,10 +3339,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -3462,13 +3512,14 @@
         "0.2.2",
         "0.3.0",
         "0.3.1",
-        "0.3.2"
+        "0.3.2",
+        "0.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.3.2"
+        "maxVersion": "0.3.3"
       }
     },
     "availableVersions": [
@@ -3480,10 +3531,11 @@
       "0.2.2",
       "0.3.0",
       "0.3.1",
-      "0.3.2"
+      "0.3.2",
+      "0.3.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.3.2",
+    "maxVersion": "0.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -3533,13 +3585,15 @@
         "1.2.0",
         "1.2.1",
         "1.2.2",
-        "1.2.3"
+        "1.2.3",
+        "1.2.4",
+        "1.2.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.4",
-        "maxVersion": "1.2.3"
+        "maxVersion": "1.2.5"
       }
     },
     "availableVersions": [
@@ -3580,10 +3634,12 @@
       "1.2.0",
       "1.2.1",
       "1.2.2",
-      "1.2.3"
+      "1.2.3",
+      "1.2.4",
+      "1.2.5"
     ],
     "minVersion": "0.0.4",
-    "maxVersion": "1.2.3",
+    "maxVersion": "1.2.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -3617,13 +3673,14 @@
         "1.2.0",
         "1.2.1",
         "1.2.2",
-        "1.2.3"
+        "1.2.3",
+        "1.2.4"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.6",
-        "maxVersion": "1.2.3"
+        "maxVersion": "1.2.4"
       }
     },
     "availableVersions": [
@@ -3648,10 +3705,11 @@
       "1.2.0",
       "1.2.1",
       "1.2.2",
-      "1.2.3"
+      "1.2.3",
+      "1.2.4"
     ],
     "minVersion": "0.0.6",
-    "maxVersion": "1.2.3",
+    "maxVersion": "1.2.4",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -3691,13 +3749,14 @@
         "1.1.3",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -3728,10 +3787,11 @@
       "1.1.3",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -3779,13 +3839,14 @@
         "1.3.2",
         "1.4.0",
         "1.4.1",
-        "1.4.2"
+        "1.4.2",
+        "1.4.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.4.2"
+        "maxVersion": "1.4.3"
       }
     },
     "availableVersions": [
@@ -3824,10 +3885,11 @@
       "1.3.2",
       "1.4.0",
       "1.4.1",
-      "1.4.2"
+      "1.4.2",
+      "1.4.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.4.2",
+    "maxVersion": "1.4.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -3841,21 +3903,23 @@
     "channelVersions": {
       "alpha": [
         "0.1.0",
-        "0.1.1"
+        "0.1.1",
+        "0.2.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.1.1"
+        "maxVersion": "0.2.1"
       }
     },
     "availableVersions": [
       "0.1.0",
-      "0.1.1"
+      "0.1.1",
+      "0.2.1"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.1.1",
+    "maxVersion": "0.2.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -4110,13 +4174,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4140,10 +4205,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -4186,13 +4252,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.2",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -4226,10 +4293,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.2",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -4264,13 +4332,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4296,10 +4365,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -4376,13 +4446,15 @@
         "1.2.2",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.3.3",
+        "1.3.4"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.7",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.3.4"
       }
     },
     "availableVersions": [
@@ -4450,10 +4522,12 @@
       "1.2.2",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.3.3",
+      "1.3.4"
     ],
     "minVersion": "0.0.7",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.3.4",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -4472,13 +4546,14 @@
         "1.1.1",
         "1.1.2",
         "1.2.0",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.10",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4488,10 +4563,11 @@
       "1.1.1",
       "1.1.2",
       "1.2.0",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.10",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -4512,13 +4588,14 @@
         "1.7.0",
         "1.7.1",
         "1.7.2",
-        "1.7.3"
+        "1.7.3",
+        "1.7.4"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.4.0",
-        "maxVersion": "1.7.3"
+        "maxVersion": "1.7.4"
       }
     },
     "availableVersions": [
@@ -4530,10 +4607,11 @@
       "1.7.0",
       "1.7.1",
       "1.7.2",
-      "1.7.3"
+      "1.7.3",
+      "1.7.4"
     ],
     "minVersion": "1.4.0",
-    "maxVersion": "1.7.3",
+    "maxVersion": "1.7.4",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -4572,13 +4650,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4608,10 +4687,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -4629,13 +4709,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.1.0",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4644,10 +4725,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.1.0",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -4710,13 +4792,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.5",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4770,10 +4853,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.5",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -4794,13 +4878,14 @@
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.4.0"
+        "1.4.0",
+        "1.4.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.1.16",
-        "maxVersion": "1.4.0"
+        "maxVersion": "1.4.1"
       }
     },
     "availableVersions": [
@@ -4812,10 +4897,11 @@
       "1.3.0",
       "1.3.1",
       "1.3.2",
-      "1.4.0"
+      "1.4.0",
+      "1.4.1"
     ],
     "minVersion": "1.1.16",
-    "maxVersion": "1.4.0",
+    "maxVersion": "1.4.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -4869,13 +4955,14 @@
         "1.3.0",
         "1.3.1",
         "1.4.0",
-        "1.4.2"
+        "1.4.2",
+        "1.4.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.4.2"
+        "maxVersion": "1.4.3"
       }
     },
     "availableVersions": [
@@ -4920,10 +5007,11 @@
       "1.3.0",
       "1.3.1",
       "1.4.0",
-      "1.4.2"
+      "1.4.2",
+      "1.4.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.4.2",
+    "maxVersion": "1.4.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -4955,13 +5043,14 @@
         "1.2.0",
         "1.2.1",
         "1.3.0",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -4984,10 +5073,11 @@
       "1.2.0",
       "1.2.1",
       "1.3.0",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -5021,13 +5111,14 @@
         "1.2.1",
         "1.2.2",
         "1.3.0",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -5052,10 +5143,11 @@
       "1.2.1",
       "1.2.2",
       "1.3.0",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -5093,7 +5185,8 @@
         "4.1.1",
         "4.1.2",
         "4.2.0",
-        "4.3.0"
+        "4.3.0",
+        "4.4.0"
       ]
     },
     "channelVersionRanges": {
@@ -5103,7 +5196,7 @@
       },
       "stable": {
         "minVersion": "3.0.0",
-        "maxVersion": "4.3.0"
+        "maxVersion": "4.4.0"
       }
     },
     "availableVersions": [
@@ -5129,10 +5222,11 @@
       "4.1.1",
       "4.1.2",
       "4.2.0",
-      "4.3.0"
+      "4.3.0",
+      "4.4.0"
     ],
     "minVersion": "2.1.0",
-    "maxVersion": "4.3.0",
+    "maxVersion": "4.4.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -6794,7 +6888,8 @@
         "1.0.0",
         "1.1.1",
         "1.1.2",
-        "1.1.3"
+        "1.1.3",
+        "1.1.4"
       ],
       "Stable": [
         "0.0.1",
@@ -6805,17 +6900,18 @@
         "1.0.0",
         "1.1.1",
         "1.1.2",
-        "1.1.3"
+        "1.1.3",
+        "1.1.4"
       ]
     },
     "channelVersionRanges": {
       "Fast": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.1.3"
+        "maxVersion": "1.1.4"
       },
       "Stable": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.1.3"
+        "maxVersion": "1.1.4"
       }
     },
     "availableVersions": [
@@ -6827,10 +6923,11 @@
       "1.0.0",
       "1.1.1",
       "1.1.2",
-      "1.1.3"
+      "1.1.3",
+      "1.1.4"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.1.3",
+    "maxVersion": "1.1.4",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -9679,13 +9776,14 @@
         "0.45.0",
         "0.45.1",
         "0.46.0",
-        "0.47.0"
+        "0.47.0",
+        "0.48.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.39.0",
-        "maxVersion": "0.47.0"
+        "maxVersion": "0.48.0"
       }
     },
     "availableVersions": [
@@ -9699,10 +9797,11 @@
       "0.45.0",
       "0.45.1",
       "0.46.0",
-      "0.47.0"
+      "0.47.0",
+      "0.48.0"
     ],
     "minVersion": "0.39.0",
-    "maxVersion": "0.47.0",
+    "maxVersion": "0.48.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -9826,7 +9925,8 @@
         "2.10.0",
         "2.10.1",
         "2.10.2",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ],
       "unstable": [
         "2.6.0",
@@ -9845,17 +9945,18 @@
         "2.10.0",
         "2.10.1",
         "2.10.2",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.6.0",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       },
       "unstable": {
         "minVersion": "2.6.0",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       }
     },
     "availableVersions": [
@@ -9875,10 +9976,11 @@
       "2.10.0",
       "2.10.1",
       "2.10.2",
-      "2.11.0"
+      "2.11.0",
+      "2.11.1"
     ],
     "minVersion": "2.6.0",
-    "maxVersion": "2.11.0",
+    "maxVersion": "2.11.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -9899,13 +10001,14 @@
         "1.46.0",
         "1.47.0",
         "1.47.1",
-        "1.48.0"
+        "1.48.0",
+        "1.48.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.43.0",
-        "maxVersion": "1.48.0"
+        "maxVersion": "1.48.1"
       }
     },
     "availableVersions": [
@@ -9917,10 +10020,11 @@
       "1.46.0",
       "1.47.0",
       "1.47.1",
-      "1.48.0"
+      "1.48.0",
+      "1.48.1"
     ],
     "minVersion": "1.43.0",
-    "maxVersion": "1.48.0",
+    "maxVersion": "1.48.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -10330,7 +10434,8 @@
         "1.2.5135-afd4101",
         "1.2.5143-a5d0850",
         "1.2.5151-a6aa930",
-        "1.2.5177-a325b87"
+        "1.2.5177-a325b87",
+        "1.2.5181-aa1db74"
       ],
       "mce-2.0": [
         "2.5.3489-6dec9c3",
@@ -10374,7 +10479,7 @@
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.2.4355-e5f809f",
-        "maxVersion": "1.2.5177-a325b87"
+        "maxVersion": "1.2.5181-aa1db74"
       },
       "mce-2.0": {
         "minVersion": "2.5.3489-6dec9c3",
@@ -10470,6 +10575,7 @@
       "1.2.5143-a5d0850",
       "1.2.5151-a6aa930",
       "1.2.5177-a325b87",
+      "1.2.5181-aa1db74",
       "2.3.3039-60b8a9a",
       "2.4.3180-7299056",
       "2.4.3189-026033b",
@@ -11910,13 +12016,15 @@
     "channels": [
       "candidate-v0.0",
       "candidate-v0.1",
+      "candidate-v0.2",
       "stable-v0.0",
       "stable-v0.1"
     ],
     "channelVersions": {
       "candidate-v0.0": [
         "0.0.15-rc.1",
-        "0.0.15-rc.3"
+        "0.0.15-rc.3",
+        "0.0.15-rc.7"
       ],
       "candidate-v0.1": [
         "0.1.0-rc.5",
@@ -11928,6 +12036,9 @@
         "0.1.6-rc.0",
         "0.1.8-rc.0",
         "0.1.9-rc.0"
+      ],
+      "candidate-v0.2": [
+        "0.2.0-rc.1"
       ],
       "stable-v0.0": [
         "0.0.4",
@@ -11948,17 +12059,22 @@
         "0.1.5",
         "0.1.7",
         "0.1.8",
-        "0.1.9"
+        "0.1.9",
+        "0.1.10"
       ]
     },
     "channelVersionRanges": {
       "candidate-v0.0": {
         "minVersion": "0.0.15-rc.1",
-        "maxVersion": "0.0.15-rc.3"
+        "maxVersion": "0.0.15-rc.7"
       },
       "candidate-v0.1": {
         "minVersion": "0.1.0-rc.5",
         "maxVersion": "0.1.9-rc.0"
+      },
+      "candidate-v0.2": {
+        "minVersion": "0.2.0-rc.1",
+        "maxVersion": "0.2.0-rc.1"
       },
       "stable-v0.0": {
         "minVersion": "0.0.4",
@@ -11966,7 +12082,7 @@
       },
       "stable-v0.1": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.1.9"
+        "maxVersion": "0.1.10"
       }
     },
     "availableVersions": [
@@ -11981,6 +12097,7 @@
       "0.0.14",
       "0.0.15-rc.1",
       "0.0.15-rc.3",
+      "0.0.15-rc.7",
       "0.1.0",
       "0.1.0-rc.5",
       "0.1.1-rc.0",
@@ -11997,10 +12114,12 @@
       "0.1.8",
       "0.1.8-rc.0",
       "0.1.9",
-      "0.1.9-rc.0"
+      "0.1.9-rc.0",
+      "0.1.10",
+      "0.2.0-rc.1"
     ],
     "minVersion": "0.0.4",
-    "maxVersion": "0.1.9-rc.0",
+    "maxVersion": "0.2.0-rc.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -12312,21 +12431,23 @@
     "channelVersions": {
       "alpha": [
         "0.0.3",
-        "0.0.4"
+        "0.0.4",
+        "0.0.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "0.0.4"
+        "maxVersion": "0.0.5"
       }
     },
     "availableVersions": [
       "0.0.3",
-      "0.0.4"
+      "0.0.4",
+      "0.0.5"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "0.0.4",
+    "maxVersion": "0.0.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -14665,13 +14786,14 @@
         "0.143.0",
         "0.144.0",
         "0.145.0",
-        "0.148.0"
+        "0.148.0",
+        "0.149.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.105.0",
-        "maxVersion": "0.148.0"
+        "maxVersion": "0.149.0"
       }
     },
     "availableVersions": [
@@ -14712,10 +14834,11 @@
       "0.143.0",
       "0.144.0",
       "0.145.0",
-      "0.148.0"
+      "0.148.0",
+      "0.149.0"
     ],
     "minVersion": "0.105.0",
-    "maxVersion": "0.148.0",
+    "maxVersion": "0.149.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"
@@ -16270,11 +16393,6 @@
     ],
     "channelVersions": {
       "1.29-nightly": [
-        "1.29.0-nightly-2026-04-04",
-        "1.29.0-nightly-2026-04-05",
-        "1.29.0-nightly-2026-04-06",
-        "1.29.0-nightly-2026-04-07",
-        "1.29.0-nightly-2026-04-08",
         "1.29.0-nightly-2026-04-09"
       ],
       "1.30-nightly": [
@@ -16286,7 +16404,10 @@
         "1.30.0-nightly-2026-04-15",
         "1.30.0-nightly-2026-04-16",
         "1.30.0-nightly-2026-04-17",
-        "1.30.0-nightly-2026-04-18"
+        "1.30.0-nightly-2026-04-18",
+        "1.30.0-nightly-2026-04-19",
+        "1.30.0-nightly-2026-04-20",
+        "1.30.0-nightly-2026-04-21"
       ],
       "candidates": [
         "0.1.0",
@@ -16344,12 +16465,12 @@
     },
     "channelVersionRanges": {
       "1.29-nightly": {
-        "minVersion": "1.29.0-nightly-2026-04-04",
+        "minVersion": "1.29.0-nightly-2026-04-09",
         "maxVersion": "1.29.0-nightly-2026-04-09"
       },
       "1.30-nightly": {
         "minVersion": "1.30.0-nightly-2026-04-10",
-        "maxVersion": "1.30.0-nightly-2026-04-18"
+        "maxVersion": "1.30.0-nightly-2026-04-21"
       },
       "candidates": {
         "minVersion": "0.1.0",
@@ -16404,11 +16525,6 @@
       "1.28.2",
       "1.28.3",
       "1.29.0",
-      "1.29.0-nightly-2026-04-04",
-      "1.29.0-nightly-2026-04-05",
-      "1.29.0-nightly-2026-04-06",
-      "1.29.0-nightly-2026-04-07",
-      "1.29.0-nightly-2026-04-08",
       "1.29.0-nightly-2026-04-09",
       "1.29.1",
       "1.30.0-nightly-2026-04-10",
@@ -16419,10 +16535,13 @@
       "1.30.0-nightly-2026-04-15",
       "1.30.0-nightly-2026-04-16",
       "1.30.0-nightly-2026-04-17",
-      "1.30.0-nightly-2026-04-18"
+      "1.30.0-nightly-2026-04-18",
+      "1.30.0-nightly-2026-04-19",
+      "1.30.0-nightly-2026-04-20",
+      "1.30.0-nightly-2026-04-21"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "1.30.0-nightly-2026-04-18",
+    "maxVersion": "1.30.0-nightly-2026-04-21",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.20"

--- a/catalog-data/community-operator-index/v4.21/catalog-info.json
+++ b/catalog-data/community-operator-index/v4.21/catalog-info.json
@@ -2,5 +2,5 @@
   "catalog_type": "community-operator-index",
   "ocp_version": "v4.21",
   "catalog_url": "registry.redhat.io/redhat/community-operator-index:v4.21",
-  "operator_count": 270
+  "operator_count": 271
 }

--- a/catalog-data/community-operator-index/v4.21/operators.json
+++ b/catalog-data/community-operator-index/v4.21/operators.json
@@ -253,13 +253,14 @@
         "1.3.2",
         "1.4.0",
         "1.4.1",
-        "1.4.2"
+        "1.4.2",
+        "1.4.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.4.2"
+        "maxVersion": "1.4.3"
       }
     },
     "availableVersions": [
@@ -282,10 +283,11 @@
       "1.3.2",
       "1.4.0",
       "1.4.1",
-      "1.4.2"
+      "1.4.2",
+      "1.4.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.4.2",
+    "maxVersion": "1.4.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -454,13 +456,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.2.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -508,10 +511,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.2.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -543,13 +547,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -572,10 +577,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -593,13 +599,14 @@
         "1.0.1",
         "1.1.0",
         "1.1.1",
-        "1.1.2"
+        "1.1.2",
+        "1.1.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "1.1.2"
+        "maxVersion": "1.1.3"
       }
     },
     "availableVersions": [
@@ -608,10 +615,11 @@
       "1.0.1",
       "1.1.0",
       "1.1.1",
-      "1.1.2"
+      "1.1.2",
+      "1.1.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "1.1.2",
+    "maxVersion": "1.1.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -735,13 +743,14 @@
         "1.2.2",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.3.3"
       }
     },
     "availableVersions": [
@@ -778,10 +787,11 @@
       "1.2.2",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.3.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -824,13 +834,14 @@
         "1.1.1",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -864,10 +875,11 @@
       "1.1.1",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.1.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -984,13 +996,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1018,10 +1031,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -1041,13 +1055,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.11",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1058,10 +1073,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.11",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -1134,13 +1150,14 @@
         "1.2.1",
         "1.2.2",
         "1.3.0",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.6",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -1166,10 +1183,11 @@
       "1.2.1",
       "1.2.2",
       "1.3.0",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.6",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -1245,13 +1263,14 @@
         "1.6.1",
         "1.7.0",
         "1.7.1",
-        "1.7.2"
+        "1.7.2",
+        "1.7.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.8",
-        "maxVersion": "1.7.2"
+        "maxVersion": "1.7.3"
       }
     },
     "availableVersions": [
@@ -1318,10 +1337,11 @@
       "1.6.1",
       "1.7.0",
       "1.7.1",
-      "1.7.2"
+      "1.7.2",
+      "1.7.3"
     ],
     "minVersion": "0.0.8",
-    "maxVersion": "1.7.2",
+    "maxVersion": "1.7.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -1689,13 +1709,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.12",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1706,10 +1727,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.12",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -1732,13 +1754,14 @@
         "1.1.1",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.9",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1752,10 +1775,11 @@
       "1.1.1",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.9",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -1795,13 +1819,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.4",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -1832,10 +1857,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.4",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -1926,13 +1952,14 @@
         "1.11.2",
         "1.11.3",
         "1.11.4",
-        "1.12.0"
+        "1.12.0",
+        "1.12.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.12.0"
+        "maxVersion": "1.12.2"
       }
     },
     "availableVersions": [
@@ -2014,10 +2041,11 @@
       "1.11.2",
       "1.11.3",
       "1.11.4",
-      "1.12.0"
+      "1.12.0",
+      "1.12.2"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.12.0",
+    "maxVersion": "1.12.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -2081,13 +2109,14 @@
         "1.3.1",
         "1.3.2",
         "1.3.3",
-        "1.3.4"
+        "1.3.4",
+        "1.3.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.8",
-        "maxVersion": "1.3.4"
+        "maxVersion": "1.3.5"
       }
     },
     "availableVersions": [
@@ -2142,10 +2171,11 @@
       "1.3.1",
       "1.3.2",
       "1.3.3",
-      "1.3.4"
+      "1.3.4",
+      "1.3.5"
     ],
     "minVersion": "0.0.8",
-    "maxVersion": "1.3.4",
+    "maxVersion": "1.3.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -2188,13 +2218,14 @@
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.3.3"
+        "1.3.3",
+        "1.3.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.3.3"
+        "maxVersion": "1.3.5"
       }
     },
     "availableVersions": [
@@ -2228,10 +2259,11 @@
       "1.3.0",
       "1.3.1",
       "1.3.2",
-      "1.3.3"
+      "1.3.3",
+      "1.3.5"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.3.3",
+    "maxVersion": "1.3.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -2279,13 +2311,14 @@
         "1.2.0",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.3.3"
       }
     },
     "availableVersions": [
@@ -2324,10 +2357,11 @@
       "1.2.0",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.3.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -2373,13 +2407,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -2416,10 +2451,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -2434,22 +2470,24 @@
       "alpha": [
         "0.1.0",
         "0.2.0",
-        "0.2.2"
+        "0.2.2",
+        "0.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.2.2"
+        "maxVersion": "0.2.3"
       }
     },
     "availableVersions": [
       "0.1.0",
       "0.2.0",
-      "0.2.2"
+      "0.2.2",
+      "0.2.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.2.2",
+    "maxVersion": "0.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -2468,13 +2506,14 @@
         "0.2.2",
         "0.3.0",
         "0.3.1",
-        "0.3.2"
+        "0.3.2",
+        "0.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.3.2"
+        "maxVersion": "0.3.3"
       }
     },
     "availableVersions": [
@@ -2484,10 +2523,11 @@
       "0.2.2",
       "0.3.0",
       "0.3.1",
-      "0.3.2"
+      "0.3.2",
+      "0.3.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.3.2",
+    "maxVersion": "0.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -2691,13 +2731,14 @@
         "1.3.2",
         "1.4.0",
         "1.4.1",
-        "1.5.0"
+        "1.5.0",
+        "1.5.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.5.0"
+        "maxVersion": "1.5.1"
       }
     },
     "availableVersions": [
@@ -2738,10 +2779,11 @@
       "1.3.2",
       "1.4.0",
       "1.4.1",
-      "1.5.0"
+      "1.5.0",
+      "1.5.1"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.5.0",
+    "maxVersion": "1.5.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -2787,13 +2829,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -2830,10 +2873,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -2994,13 +3038,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -3058,10 +3103,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -3134,13 +3180,14 @@
         "1.9.2",
         "1.10.0",
         "1.10.1",
-        "1.10.2"
+        "1.10.2",
+        "1.12.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.10.2"
+        "maxVersion": "1.12.2"
       }
     },
     "availableVersions": [
@@ -3204,10 +3251,11 @@
       "1.9.2",
       "1.10.0",
       "1.10.1",
-      "1.10.2"
+      "1.10.2",
+      "1.12.2"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.10.2",
+    "maxVersion": "1.12.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -3250,13 +3298,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -3290,10 +3339,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -3462,13 +3512,14 @@
         "0.2.2",
         "0.3.0",
         "0.3.1",
-        "0.3.2"
+        "0.3.2",
+        "0.3.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.3.2"
+        "maxVersion": "0.3.3"
       }
     },
     "availableVersions": [
@@ -3480,10 +3531,11 @@
       "0.2.2",
       "0.3.0",
       "0.3.1",
-      "0.3.2"
+      "0.3.2",
+      "0.3.3"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.3.2",
+    "maxVersion": "0.3.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -3533,13 +3585,15 @@
         "1.2.0",
         "1.2.1",
         "1.2.2",
-        "1.2.3"
+        "1.2.3",
+        "1.2.4",
+        "1.2.5"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.4",
-        "maxVersion": "1.2.3"
+        "maxVersion": "1.2.5"
       }
     },
     "availableVersions": [
@@ -3580,10 +3634,12 @@
       "1.2.0",
       "1.2.1",
       "1.2.2",
-      "1.2.3"
+      "1.2.3",
+      "1.2.4",
+      "1.2.5"
     ],
     "minVersion": "0.0.4",
-    "maxVersion": "1.2.3",
+    "maxVersion": "1.2.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -3617,13 +3673,14 @@
         "1.2.0",
         "1.2.1",
         "1.2.2",
-        "1.2.3"
+        "1.2.3",
+        "1.2.4"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.6",
-        "maxVersion": "1.2.3"
+        "maxVersion": "1.2.4"
       }
     },
     "availableVersions": [
@@ -3648,10 +3705,11 @@
       "1.2.0",
       "1.2.1",
       "1.2.2",
-      "1.2.3"
+      "1.2.3",
+      "1.2.4"
     ],
     "minVersion": "0.0.6",
-    "maxVersion": "1.2.3",
+    "maxVersion": "1.2.4",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -3691,13 +3749,14 @@
         "1.1.3",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -3728,10 +3787,11 @@
       "1.1.3",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -3779,13 +3839,14 @@
         "1.3.2",
         "1.4.0",
         "1.4.1",
-        "1.4.2"
+        "1.4.2",
+        "1.4.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.3",
-        "maxVersion": "1.4.2"
+        "maxVersion": "1.4.3"
       }
     },
     "availableVersions": [
@@ -3824,10 +3885,11 @@
       "1.3.2",
       "1.4.0",
       "1.4.1",
-      "1.4.2"
+      "1.4.2",
+      "1.4.3"
     ],
     "minVersion": "0.0.3",
-    "maxVersion": "1.4.2",
+    "maxVersion": "1.4.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -3841,21 +3903,23 @@
     "channelVersions": {
       "alpha": [
         "0.1.0",
-        "0.1.1"
+        "0.1.1",
+        "0.2.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.1.1"
+        "maxVersion": "0.2.1"
       }
     },
     "availableVersions": [
       "0.1.0",
-      "0.1.1"
+      "0.1.1",
+      "0.2.1"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "0.1.1",
+    "maxVersion": "0.2.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -4110,13 +4174,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4140,10 +4205,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -4186,13 +4252,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.2",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -4226,10 +4293,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.2",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -4264,13 +4332,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.2",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4296,10 +4365,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.2",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -4376,13 +4446,15 @@
         "1.2.2",
         "1.3.0",
         "1.3.1",
-        "1.3.2"
+        "1.3.2",
+        "1.3.3",
+        "1.3.4"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.7",
-        "maxVersion": "1.3.2"
+        "maxVersion": "1.3.4"
       }
     },
     "availableVersions": [
@@ -4450,10 +4522,12 @@
       "1.2.2",
       "1.3.0",
       "1.3.1",
-      "1.3.2"
+      "1.3.2",
+      "1.3.3",
+      "1.3.4"
     ],
     "minVersion": "0.0.7",
-    "maxVersion": "1.3.2",
+    "maxVersion": "1.3.4",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -4472,13 +4546,14 @@
         "1.1.1",
         "1.1.2",
         "1.2.0",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.0.10",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4488,10 +4563,11 @@
       "1.1.1",
       "1.1.2",
       "1.2.0",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.0.10",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -4512,13 +4588,14 @@
         "1.7.0",
         "1.7.1",
         "1.7.2",
-        "1.7.3"
+        "1.7.3",
+        "1.7.4"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.4.0",
-        "maxVersion": "1.7.3"
+        "maxVersion": "1.7.4"
       }
     },
     "availableVersions": [
@@ -4530,10 +4607,11 @@
       "1.7.0",
       "1.7.1",
       "1.7.2",
-      "1.7.3"
+      "1.7.3",
+      "1.7.4"
     ],
     "minVersion": "1.4.0",
-    "maxVersion": "1.7.3",
+    "maxVersion": "1.7.4",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -4572,13 +4650,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4608,10 +4687,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -4629,13 +4709,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.1.0",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4644,10 +4725,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "1.1.0",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -4710,13 +4792,14 @@
         "1.1.2",
         "1.2.0",
         "1.2.1",
-        "1.2.2"
+        "1.2.2",
+        "1.2.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.5",
-        "maxVersion": "1.2.2"
+        "maxVersion": "1.2.3"
       }
     },
     "availableVersions": [
@@ -4770,10 +4853,11 @@
       "1.1.2",
       "1.2.0",
       "1.2.1",
-      "1.2.2"
+      "1.2.2",
+      "1.2.3"
     ],
     "minVersion": "0.0.5",
-    "maxVersion": "1.2.2",
+    "maxVersion": "1.2.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -4794,13 +4878,14 @@
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.4.0"
+        "1.4.0",
+        "1.4.1"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.1.16",
-        "maxVersion": "1.4.0"
+        "maxVersion": "1.4.1"
       }
     },
     "availableVersions": [
@@ -4812,10 +4897,11 @@
       "1.3.0",
       "1.3.1",
       "1.3.2",
-      "1.4.0"
+      "1.4.0",
+      "1.4.1"
     ],
     "minVersion": "1.1.16",
-    "maxVersion": "1.4.0",
+    "maxVersion": "1.4.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -4869,13 +4955,14 @@
         "1.3.0",
         "1.3.1",
         "1.4.0",
-        "1.4.2"
+        "1.4.2",
+        "1.4.3"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.4.2"
+        "maxVersion": "1.4.3"
       }
     },
     "availableVersions": [
@@ -4920,10 +5007,11 @@
       "1.3.0",
       "1.3.1",
       "1.4.0",
-      "1.4.2"
+      "1.4.2",
+      "1.4.3"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.4.2",
+    "maxVersion": "1.4.3",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -4955,13 +5043,14 @@
         "1.2.0",
         "1.2.1",
         "1.3.0",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -4984,10 +5073,11 @@
       "1.2.0",
       "1.2.1",
       "1.3.0",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -5021,13 +5111,14 @@
         "1.2.1",
         "1.2.2",
         "1.3.0",
-        "1.3.1"
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.3.1"
+        "maxVersion": "1.3.2"
       }
     },
     "availableVersions": [
@@ -5052,10 +5143,11 @@
       "1.2.1",
       "1.2.2",
       "1.3.0",
-      "1.3.1"
+      "1.3.1",
+      "1.3.2"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.3.1",
+    "maxVersion": "1.3.2",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -5093,7 +5185,8 @@
         "4.1.1",
         "4.1.2",
         "4.2.0",
-        "4.3.0"
+        "4.3.0",
+        "4.4.0"
       ]
     },
     "channelVersionRanges": {
@@ -5103,7 +5196,7 @@
       },
       "stable": {
         "minVersion": "3.0.0",
-        "maxVersion": "4.3.0"
+        "maxVersion": "4.4.0"
       }
     },
     "availableVersions": [
@@ -5129,10 +5222,11 @@
       "4.1.1",
       "4.1.2",
       "4.2.0",
-      "4.3.0"
+      "4.3.0",
+      "4.4.0"
     ],
     "minVersion": "2.1.0",
-    "maxVersion": "4.3.0",
+    "maxVersion": "4.4.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -6752,7 +6846,8 @@
         "1.0.0",
         "1.1.1",
         "1.1.2",
-        "1.1.3"
+        "1.1.3",
+        "1.1.4"
       ],
       "Stable": [
         "0.0.1",
@@ -6763,17 +6858,18 @@
         "1.0.0",
         "1.1.1",
         "1.1.2",
-        "1.1.3"
+        "1.1.3",
+        "1.1.4"
       ]
     },
     "channelVersionRanges": {
       "Fast": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.1.3"
+        "maxVersion": "1.1.4"
       },
       "Stable": {
         "minVersion": "0.0.1",
-        "maxVersion": "1.1.3"
+        "maxVersion": "1.1.4"
       }
     },
     "availableVersions": [
@@ -6785,10 +6881,11 @@
       "1.0.0",
       "1.1.1",
       "1.1.2",
-      "1.1.3"
+      "1.1.3",
+      "1.1.4"
     ],
     "minVersion": "0.0.1",
-    "maxVersion": "1.1.3",
+    "maxVersion": "1.1.4",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -9626,33 +9723,36 @@
         "2.10.0",
         "2.10.1",
         "2.10.2",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ],
       "unstable": [
         "2.10.0",
         "2.10.1",
         "2.10.2",
-        "2.11.0"
+        "2.11.0",
+        "2.11.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "2.10.0",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       },
       "unstable": {
         "minVersion": "2.10.0",
-        "maxVersion": "2.11.0"
+        "maxVersion": "2.11.1"
       }
     },
     "availableVersions": [
       "2.10.0",
       "2.10.1",
       "2.10.2",
-      "2.11.0"
+      "2.11.0",
+      "2.11.1"
     ],
     "minVersion": "2.10.0",
-    "maxVersion": "2.11.0",
+    "maxVersion": "2.11.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -10062,7 +10162,8 @@
         "1.2.5135-afd4101",
         "1.2.5143-a5d0850",
         "1.2.5151-a6aa930",
-        "1.2.5177-a325b87"
+        "1.2.5177-a325b87",
+        "1.2.5181-aa1db74"
       ],
       "mce-2.0": [
         "2.5.3489-6dec9c3",
@@ -10106,7 +10207,7 @@
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.2.4355-e5f809f",
-        "maxVersion": "1.2.5177-a325b87"
+        "maxVersion": "1.2.5181-aa1db74"
       },
       "mce-2.0": {
         "minVersion": "2.5.3489-6dec9c3",
@@ -10202,6 +10303,7 @@
       "1.2.5143-a5d0850",
       "1.2.5151-a6aa930",
       "1.2.5177-a325b87",
+      "1.2.5181-aa1db74",
       "2.3.3039-60b8a9a",
       "2.4.3180-7299056",
       "2.4.3189-026033b",
@@ -11639,13 +11741,15 @@
     "channels": [
       "candidate-v0.0",
       "candidate-v0.1",
+      "candidate-v0.2",
       "stable-v0.0",
       "stable-v0.1"
     ],
     "channelVersions": {
       "candidate-v0.0": [
         "0.0.15-rc.1",
-        "0.0.15-rc.3"
+        "0.0.15-rc.3",
+        "0.0.15-rc.7"
       ],
       "candidate-v0.1": [
         "0.1.0-rc.5",
@@ -11657,6 +11761,9 @@
         "0.1.6-rc.0",
         "0.1.8-rc.0",
         "0.1.9-rc.0"
+      ],
+      "candidate-v0.2": [
+        "0.2.0-rc.1"
       ],
       "stable-v0.0": [
         "0.0.4",
@@ -11677,17 +11784,22 @@
         "0.1.5",
         "0.1.7",
         "0.1.8",
-        "0.1.9"
+        "0.1.9",
+        "0.1.10"
       ]
     },
     "channelVersionRanges": {
       "candidate-v0.0": {
         "minVersion": "0.0.15-rc.1",
-        "maxVersion": "0.0.15-rc.3"
+        "maxVersion": "0.0.15-rc.7"
       },
       "candidate-v0.1": {
         "minVersion": "0.1.0-rc.5",
         "maxVersion": "0.1.9-rc.0"
+      },
+      "candidate-v0.2": {
+        "minVersion": "0.2.0-rc.1",
+        "maxVersion": "0.2.0-rc.1"
       },
       "stable-v0.0": {
         "minVersion": "0.0.4",
@@ -11695,7 +11807,7 @@
       },
       "stable-v0.1": {
         "minVersion": "0.1.0",
-        "maxVersion": "0.1.9"
+        "maxVersion": "0.1.10"
       }
     },
     "availableVersions": [
@@ -11710,6 +11822,7 @@
       "0.0.14",
       "0.0.15-rc.1",
       "0.0.15-rc.3",
+      "0.0.15-rc.7",
       "0.1.0",
       "0.1.0-rc.5",
       "0.1.1-rc.0",
@@ -11726,10 +11839,12 @@
       "0.1.8",
       "0.1.8-rc.0",
       "0.1.9",
-      "0.1.9-rc.0"
+      "0.1.9-rc.0",
+      "0.1.10",
+      "0.2.0-rc.1"
     ],
     "minVersion": "0.0.4",
-    "maxVersion": "0.1.9-rc.0",
+    "maxVersion": "0.2.0-rc.1",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -12028,6 +12143,32 @@
     ],
     "minVersion": "0.0.8",
     "maxVersion": "0.1.8",
+    "catalog": "community-operator-index",
+    "ocpVersion": "v4.21",
+    "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
+  },
+  {
+    "name": "kruize-operator",
+    "defaultChannel": "alpha",
+    "channels": [
+      "alpha"
+    ],
+    "channelVersions": {
+      "alpha": [
+        "0.0.5"
+      ]
+    },
+    "channelVersionRanges": {
+      "alpha": {
+        "minVersion": "0.0.5",
+        "maxVersion": "0.0.5"
+      }
+    },
+    "availableVersions": [
+      "0.0.5"
+    ],
+    "minVersion": "0.0.5",
+    "maxVersion": "0.0.5",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -14251,13 +14392,14 @@
         "0.143.0",
         "0.144.0",
         "0.145.0",
-        "0.148.0"
+        "0.148.0",
+        "0.149.0"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.105.0",
-        "maxVersion": "0.148.0"
+        "maxVersion": "0.149.0"
       }
     },
     "availableVersions": [
@@ -14298,10 +14440,11 @@
       "0.143.0",
       "0.144.0",
       "0.145.0",
-      "0.148.0"
+      "0.148.0",
+      "0.149.0"
     ],
     "minVersion": "0.105.0",
-    "maxVersion": "0.148.0",
+    "maxVersion": "0.149.0",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"
@@ -15822,11 +15965,6 @@
     ],
     "channelVersions": {
       "1.29-nightly": [
-        "1.29.0-nightly-2026-04-04",
-        "1.29.0-nightly-2026-04-05",
-        "1.29.0-nightly-2026-04-06",
-        "1.29.0-nightly-2026-04-07",
-        "1.29.0-nightly-2026-04-08",
         "1.29.0-nightly-2026-04-09"
       ],
       "1.30-nightly": [
@@ -15838,7 +15976,10 @@
         "1.30.0-nightly-2026-04-15",
         "1.30.0-nightly-2026-04-16",
         "1.30.0-nightly-2026-04-17",
-        "1.30.0-nightly-2026-04-18"
+        "1.30.0-nightly-2026-04-18",
+        "1.30.0-nightly-2026-04-19",
+        "1.30.0-nightly-2026-04-20",
+        "1.30.0-nightly-2026-04-21"
       ],
       "candidates": [
         "0.1.0",
@@ -15896,12 +16037,12 @@
     },
     "channelVersionRanges": {
       "1.29-nightly": {
-        "minVersion": "1.29.0-nightly-2026-04-04",
+        "minVersion": "1.29.0-nightly-2026-04-09",
         "maxVersion": "1.29.0-nightly-2026-04-09"
       },
       "1.30-nightly": {
         "minVersion": "1.30.0-nightly-2026-04-10",
-        "maxVersion": "1.30.0-nightly-2026-04-18"
+        "maxVersion": "1.30.0-nightly-2026-04-21"
       },
       "candidates": {
         "minVersion": "0.1.0",
@@ -15956,11 +16097,6 @@
       "1.28.2",
       "1.28.3",
       "1.29.0",
-      "1.29.0-nightly-2026-04-04",
-      "1.29.0-nightly-2026-04-05",
-      "1.29.0-nightly-2026-04-06",
-      "1.29.0-nightly-2026-04-07",
-      "1.29.0-nightly-2026-04-08",
       "1.29.0-nightly-2026-04-09",
       "1.29.1",
       "1.30.0-nightly-2026-04-10",
@@ -15971,10 +16107,13 @@
       "1.30.0-nightly-2026-04-15",
       "1.30.0-nightly-2026-04-16",
       "1.30.0-nightly-2026-04-17",
-      "1.30.0-nightly-2026-04-18"
+      "1.30.0-nightly-2026-04-18",
+      "1.30.0-nightly-2026-04-19",
+      "1.30.0-nightly-2026-04-20",
+      "1.30.0-nightly-2026-04-21"
     ],
     "minVersion": "0.1.0",
-    "maxVersion": "1.30.0-nightly-2026-04-18",
+    "maxVersion": "1.30.0-nightly-2026-04-21",
     "catalog": "community-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/community-operator-index:v4.21"

--- a/catalog-data/redhat-operator-index/v4.16/operators.json
+++ b/catalog-data/redhat-operator-index/v4.16/operators.json
@@ -3670,13 +3670,14 @@
         "4.1.0",
         "4.2.0",
         "4.3.0",
-        "4.3.1"
+        "4.3.1",
+        "4.4.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.0.0",
-        "maxVersion": "4.3.1"
+        "maxVersion": "4.4.0"
       }
     },
     "availableVersions": [
@@ -3704,10 +3705,11 @@
       "4.1.0",
       "4.2.0",
       "4.3.0",
-      "4.3.1"
+      "4.3.1",
+      "4.4.0"
     ],
     "minVersion": "1.0.0",
-    "maxVersion": "4.3.1",
+    "maxVersion": "4.4.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -4058,13 +4060,14 @@
         "0.7.11",
         "0.7.12",
         "0.7.13",
-        "0.7.14"
+        "0.7.14",
+        "0.7.15"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.7.5",
-        "maxVersion": "0.7.14"
+        "maxVersion": "0.7.15"
       }
     },
     "availableVersions": [
@@ -4074,10 +4077,11 @@
       "0.7.11",
       "0.7.12",
       "0.7.13",
-      "0.7.14"
+      "0.7.14",
+      "0.7.15"
     ],
     "minVersion": "0.7.5",
-    "maxVersion": "0.7.14",
+    "maxVersion": "0.7.15",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -4170,13 +4174,14 @@
         "3.25.0",
         "3.26.0",
         "3.26.1",
-        "3.27.0"
+        "3.27.0",
+        "3.27.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "3.3.0",
-        "maxVersion": "3.27.0"
+        "maxVersion": "3.27.1"
       }
     },
     "availableVersions": [
@@ -4222,10 +4227,11 @@
       "3.25.0",
       "3.26.0",
       "3.26.1",
-      "3.27.0"
+      "3.27.0",
+      "3.27.1"
     ],
     "minVersion": "3.3.0",
-    "maxVersion": "3.27.0",
+    "maxVersion": "3.27.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -4281,13 +4287,14 @@
         "0.37.0",
         "0.38.0",
         "0.39.0",
-        "0.40.0"
+        "0.40.0",
+        "0.40.1"
       ]
     },
     "channelVersionRanges": {
       "fast": {
         "minVersion": "0.9.0",
-        "maxVersion": "0.40.0"
+        "maxVersion": "0.40.1"
       }
     },
     "availableVersions": [
@@ -4334,10 +4341,11 @@
       "0.37.0",
       "0.38.0",
       "0.39.0",
-      "0.40.0"
+      "0.40.0",
+      "0.40.1"
     ],
     "minVersion": "0.9.0",
-    "maxVersion": "0.40.0",
+    "maxVersion": "0.40.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -5083,7 +5091,8 @@
         "7.13.0+0.1774370015.p",
         "7.13.0+0.1775139554.p",
         "7.13.0+0.1775735859.p",
-        "7.13.0+0.1776065698.p"
+        "7.13.0+0.1776065698.p",
+        "7.13.0+0.1776378942.p"
       ],
       "fuse-apicurito-7.9.x": [
         "7.9.3"
@@ -5104,7 +5113,7 @@
       },
       "fuse-apicurito-7.13.x": {
         "minVersion": "7.9.3",
-        "maxVersion": "7.13.0+0.1776065698.p"
+        "maxVersion": "7.13.0+0.1776378942.p"
       },
       "fuse-apicurito-7.9.x": {
         "minVersion": "7.9.3",
@@ -5184,10 +5193,11 @@
       "7.13.0+0.1774370015.p",
       "7.13.0+0.1775139554.p",
       "7.13.0+0.1775735859.p",
-      "7.13.0+0.1776065698.p"
+      "7.13.0+0.1776065698.p",
+      "7.13.0+0.1776378942.p"
     ],
     "minVersion": "7.9.3",
-    "maxVersion": "7.13.0+0.1776065698.p",
+    "maxVersion": "7.13.0+0.1776378942.p",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -5255,7 +5265,8 @@
         "7.13.0+0.1771828310.p",
         "7.13.0+0.1773829909.p",
         "7.13.0+0.1775139556.p",
-        "7.13.0+0.1776065698.p"
+        "7.13.0+0.1776065698.p",
+        "7.13.0+0.1776378943.p"
       ],
       "7.9.x": [
         "7.9.0"
@@ -5276,7 +5287,7 @@
       },
       "7.13.x": {
         "minVersion": "7.12.1",
-        "maxVersion": "7.13.0+0.1776065698.p"
+        "maxVersion": "7.13.0+0.1776378943.p"
       },
       "7.9.x": {
         "minVersion": "7.9.0",
@@ -5329,10 +5340,11 @@
       "7.13.0+0.1771828310.p",
       "7.13.0+0.1773829909.p",
       "7.13.0+0.1775139556.p",
-      "7.13.0+0.1776065698.p"
+      "7.13.0+0.1776065698.p",
+      "7.13.0+0.1776378943.p"
     ],
     "minVersion": "7.9.0",
-    "maxVersion": "7.13.0+0.1776065698.p",
+    "maxVersion": "7.13.0+0.1776378943.p",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -5629,6 +5641,7 @@
       "3.18",
       "3.19",
       "3.20",
+      "3.21",
       "stable"
     ],
     "channelVersions": {
@@ -5780,6 +5793,9 @@
       "3.20": [
         "3.20.0"
       ],
+      "3.21": [
+        "3.21.0"
+      ],
       "stable": [
         "0.2.2",
         "0.2.3",
@@ -5808,7 +5824,8 @@
         "3.18.0",
         "3.19.0",
         "3.19.1",
-        "3.20.0"
+        "3.20.0",
+        "3.21.0"
       ]
     },
     "channelVersionRanges": {
@@ -5840,9 +5857,13 @@
         "minVersion": "3.20.0",
         "maxVersion": "3.20.0"
       },
+      "3.21": {
+        "minVersion": "3.21.0",
+        "maxVersion": "3.21.0"
+      },
       "stable": {
         "minVersion": "0.2.2",
-        "maxVersion": "3.20.0"
+        "maxVersion": "3.21.0"
       }
     },
     "availableVersions": [
@@ -5888,10 +5909,11 @@
       "3.18.1",
       "3.19.0",
       "3.19.1",
-      "3.20.0"
+      "3.20.0",
+      "3.21.0"
     ],
     "minVersion": "0.2.2",
-    "maxVersion": "3.20.0",
+    "maxVersion": "3.21.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -8233,7 +8255,8 @@
         "8.0.1"
       ],
       "stable-v8.1": [
-        "8.1.0"
+        "8.1.0",
+        "8.1.1"
       ]
     },
     "channelVersionRanges": {
@@ -8271,7 +8294,7 @@
       },
       "stable-v8.1": {
         "minVersion": "8.1.0",
-        "maxVersion": "8.1.0"
+        "maxVersion": "8.1.1"
       }
     },
     "availableVersions": [
@@ -8303,10 +8326,11 @@
       "7.3.2",
       "8.0.0",
       "8.0.1",
-      "8.1.0"
+      "8.1.0",
+      "8.1.1"
     ],
     "minVersion": "6.0.0",
-    "maxVersion": "8.1.0",
+    "maxVersion": "8.1.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -8693,7 +8717,8 @@
         "2.6.6",
         "2.6.7",
         "2.6.8",
-        "2.6.9"
+        "2.6.9",
+        "2.6.10"
       ],
       "stable-2.7": [
         "2.7.0",
@@ -8728,7 +8753,7 @@
       },
       "stable-2.6": {
         "minVersion": "2.6.0",
-        "maxVersion": "2.6.9"
+        "maxVersion": "2.6.10"
       },
       "stable-2.7": {
         "minVersion": "2.7.0",
@@ -8765,6 +8790,7 @@
       "2.6.7",
       "2.6.8",
       "2.6.9",
+      "2.6.10",
       "2.7.0",
       "2.7.1",
       "2.7.2",
@@ -11079,16 +11105,19 @@
         "1.18.1",
         "1.18.2",
         "1.18.3",
-        "1.18.4"
+        "1.18.4",
+        "1.18.5"
       ],
       "gitops-1.19": [
         "1.19.0",
         "1.19.1",
-        "1.19.2"
+        "1.19.2",
+        "1.19.3"
       ],
       "gitops-1.20": [
         "1.20.0",
-        "1.20.1"
+        "1.20.1",
+        "1.20.2"
       ],
       "gitops-1.6": [
         "1.5.2",
@@ -11209,7 +11238,8 @@
         "1.19.1",
         "1.19.2",
         "1.20.0",
-        "1.20.1"
+        "1.20.1",
+        "1.20.2"
       ]
     },
     "channelVersionRanges": {
@@ -11247,15 +11277,15 @@
       },
       "gitops-1.18": {
         "minVersion": "1.18.0",
-        "maxVersion": "1.18.4"
+        "maxVersion": "1.18.5"
       },
       "gitops-1.19": {
         "minVersion": "1.19.0",
-        "maxVersion": "1.19.2"
+        "maxVersion": "1.19.3"
       },
       "gitops-1.20": {
         "minVersion": "1.20.0",
-        "maxVersion": "1.20.1"
+        "maxVersion": "1.20.2"
       },
       "gitops-1.6": {
         "minVersion": "1.5.2",
@@ -11275,7 +11305,7 @@
       },
       "latest": {
         "minVersion": "1.5.2",
-        "maxVersion": "1.20.1"
+        "maxVersion": "1.20.2"
       }
     },
     "availableVersions": [
@@ -11371,14 +11401,17 @@
       "1.18.2",
       "1.18.3",
       "1.18.4",
+      "1.18.5",
       "1.19.0",
       "1.19.1",
       "1.19.2",
+      "1.19.3",
       "1.20.0",
-      "1.20.1"
+      "1.20.1",
+      "1.20.2"
     ],
     "minVersion": "1.5.2",
-    "maxVersion": "1.20.1",
+    "maxVersion": "1.20.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -11395,7 +11428,8 @@
       "pipelines-1.18",
       "pipelines-1.19",
       "pipelines-1.20",
-      "pipelines-1.21"
+      "pipelines-1.21",
+      "pipelines-1.22"
     ],
     "channelVersions": {
       "latest": [
@@ -11430,8 +11464,10 @@
         "1.20.1",
         "1.20.2",
         "1.20.3",
+        "1.20.4",
         "1.21.0",
-        "1.21.1"
+        "1.21.1",
+        "1.22.0"
       ],
       "pipelines-1.14": [
         "1.14.0",
@@ -11476,17 +11512,21 @@
         "1.20.0",
         "1.20.1",
         "1.20.2",
-        "1.20.3"
+        "1.20.3",
+        "1.20.4"
       ],
       "pipelines-1.21": [
         "1.21.0",
         "1.21.1"
+      ],
+      "pipelines-1.22": [
+        "1.22.0"
       ]
     },
     "channelVersionRanges": {
       "latest": {
         "minVersion": "1.14.0",
-        "maxVersion": "1.21.1"
+        "maxVersion": "1.22.0"
       },
       "pipelines-1.14": {
         "minVersion": "1.14.0",
@@ -11514,11 +11554,15 @@
       },
       "pipelines-1.20": {
         "minVersion": "1.20.0",
-        "maxVersion": "1.20.3"
+        "maxVersion": "1.20.4"
       },
       "pipelines-1.21": {
         "minVersion": "1.21.0",
         "maxVersion": "1.21.1"
+      },
+      "pipelines-1.22": {
+        "minVersion": "1.22.0",
+        "maxVersion": "1.22.0"
       }
     },
     "availableVersions": [
@@ -11553,11 +11597,13 @@
       "1.20.1",
       "1.20.2",
       "1.20.3",
+      "1.20.4",
       "1.21.0",
-      "1.21.1"
+      "1.21.1",
+      "1.22.0"
     ],
     "minVersion": "1.14.0",
-    "maxVersion": "1.21.1",
+    "maxVersion": "1.22.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -11771,13 +11817,14 @@
         "0.135.0-1",
         "0.140.0-1",
         "0.140.0-2",
-        "0.144.0-1"
+        "0.144.0-1",
+        "0.144.0-2"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.56.0-1",
-        "maxVersion": "0.144.0-1"
+        "maxVersion": "0.144.0-2"
       }
     },
     "availableVersions": [
@@ -11804,10 +11851,11 @@
       "0.135.0-1",
       "0.140.0-1",
       "0.140.0-2",
-      "0.144.0-1"
+      "0.144.0-1",
+      "0.144.0-2"
     ],
     "minVersion": "0.56.0-1",
-    "maxVersion": "0.144.0-1",
+    "maxVersion": "0.144.0-2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -15217,6 +15265,7 @@
         "1.8.3",
         "1.8.4",
         "1.8.5",
+        "1.8.6",
         "1.9.0",
         "1.9.1",
         "1.9.2",
@@ -15275,7 +15324,8 @@
         "1.8.2",
         "1.8.3",
         "1.8.4",
-        "1.8.5"
+        "1.8.5",
+        "1.8.6"
       ],
       "fast-1.9": [
         "1.9.0",
@@ -15319,7 +15369,7 @@
       },
       "fast-1.8": {
         "minVersion": "1.8.0",
-        "maxVersion": "1.8.5"
+        "maxVersion": "1.8.6"
       },
       "fast-1.9": {
         "minVersion": "1.9.0",
@@ -15362,6 +15412,7 @@
       "1.8.3",
       "1.8.4",
       "1.8.5",
+      "1.8.6",
       "1.9.0",
       "1.9.1",
       "1.9.2",
@@ -15441,7 +15492,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "beta": [
         "1.20.1-8",
@@ -15566,7 +15618,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "eus-2.8": [
         "1.20.1-8",
@@ -15644,7 +15697,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "stable": [
         "1.20.1-8",
@@ -15691,7 +15745,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "stable-2.10": [
         "1.20.1-8",
@@ -15923,7 +15978,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "stable-2.8": [
         "1.20.1-8",
@@ -15957,7 +16013,7 @@
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "beta": {
         "minVersion": "1.20.1-8",
@@ -15973,7 +16029,7 @@
       },
       "eus-2.25": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "eus-2.8": {
         "minVersion": "1.20.1-8",
@@ -15981,11 +16037,11 @@
       },
       "fast": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "stable": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "stable-2.10": {
         "minVersion": "1.20.1-8",
@@ -16009,7 +16065,7 @@
       },
       "stable-2.25": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "stable-2.8": {
         "minVersion": "1.20.1-8",
@@ -16079,10 +16135,11 @@
       "2.25.1",
       "2.25.2",
       "2.25.3",
-      "2.25.4"
+      "2.25.4",
+      "2.25.5"
     ],
     "minVersion": "1.20.1-8",
-    "maxVersion": "2.25.4",
+    "maxVersion": "2.25.5",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -16330,7 +16387,8 @@
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.3.3"
+        "1.3.3",
+        "1.3.4"
       ],
       "stable-v1.1": [
         "1.1.0",
@@ -16346,13 +16404,14 @@
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.3.3"
+        "1.3.3",
+        "1.3.4"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.1.0",
-        "maxVersion": "1.3.3"
+        "maxVersion": "1.3.4"
       },
       "stable-v1.1": {
         "minVersion": "1.1.0",
@@ -16364,7 +16423,7 @@
       },
       "stable-v1.3": {
         "minVersion": "1.3.0",
-        "maxVersion": "1.3.3"
+        "maxVersion": "1.3.4"
       }
     },
     "availableVersions": [
@@ -16377,10 +16436,11 @@
       "1.3.0",
       "1.3.1",
       "1.3.2",
-      "1.3.3"
+      "1.3.3",
+      "1.3.4"
     ],
     "minVersion": "1.1.0",
-    "maxVersion": "1.3.3",
+    "maxVersion": "1.3.4",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -16559,21 +16619,23 @@
     "channelVersions": {
       "stable": [
         "1.0.0",
-        "1.0.1"
+        "1.0.1",
+        "1.0.2"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.0.0",
-        "maxVersion": "1.0.1"
+        "maxVersion": "1.0.2"
       }
     },
     "availableVersions": [
       "1.0.0",
-      "1.0.1"
+      "1.0.1",
+      "1.0.2"
     ],
     "minVersion": "1.0.0",
-    "maxVersion": "1.0.1",
+    "maxVersion": "1.0.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -17552,13 +17614,15 @@
         "3.0.7",
         "3.0.8",
         "3.0.9",
+        "3.0.10",
         "3.1.0",
         "3.1.1",
         "3.1.2",
         "3.1.3",
         "3.1.4",
         "3.1.5",
-        "3.1.6"
+        "3.1.6",
+        "3.1.7"
       ],
       "stable-3.0": [
         "3.0.0",
@@ -17570,7 +17634,8 @@
         "3.0.6",
         "3.0.7",
         "3.0.8",
-        "3.0.9"
+        "3.0.9",
+        "3.0.10"
       ],
       "stable-3.1": [
         "3.1.0",
@@ -17579,7 +17644,8 @@
         "3.1.3",
         "3.1.4",
         "3.1.5",
-        "3.1.6"
+        "3.1.6",
+        "3.1.7"
       ]
     },
     "channelVersionRanges": {
@@ -17589,15 +17655,15 @@
       },
       "stable": {
         "minVersion": "3.0.0",
-        "maxVersion": "3.1.6"
+        "maxVersion": "3.1.7"
       },
       "stable-3.0": {
         "minVersion": "3.0.0",
-        "maxVersion": "3.0.9"
+        "maxVersion": "3.0.10"
       },
       "stable-3.1": {
         "minVersion": "3.1.0",
-        "maxVersion": "3.1.6"
+        "maxVersion": "3.1.7"
       }
     },
     "availableVersions": [
@@ -17613,16 +17679,18 @@
       "3.0.7",
       "3.0.8",
       "3.0.9",
+      "3.0.10",
       "3.1.0",
       "3.1.1",
       "3.1.2",
       "3.1.3",
       "3.1.4",
       "3.1.5",
-      "3.1.6"
+      "3.1.6",
+      "3.1.7"
     ],
     "minVersion": "3.0.0",
-    "maxVersion": "3.1.6",
+    "maxVersion": "3.1.7",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"
@@ -18463,13 +18531,14 @@
         "0.19.0-2",
         "0.19.0-3",
         "0.20.0-1",
-        "0.20.0-2"
+        "0.20.0-2",
+        "0.20.0-3"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.1.0-6",
-        "maxVersion": "0.20.0-2"
+        "maxVersion": "0.20.0-3"
       }
     },
     "availableVersions": [
@@ -18496,10 +18565,11 @@
       "0.19.0-2",
       "0.19.0-3",
       "0.20.0-1",
-      "0.20.0-2"
+      "0.20.0-2",
+      "0.20.0-3"
     ],
     "minVersion": "0.1.0-6",
-    "maxVersion": "0.20.0-2",
+    "maxVersion": "0.20.0-3",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.16",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.16"

--- a/catalog-data/redhat-operator-index/v4.17/operators.json
+++ b/catalog-data/redhat-operator-index/v4.17/operators.json
@@ -3486,13 +3486,14 @@
         "4.1.0",
         "4.2.0",
         "4.3.0",
-        "4.3.1"
+        "4.3.1",
+        "4.4.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.0.0",
-        "maxVersion": "4.3.1"
+        "maxVersion": "4.4.0"
       }
     },
     "availableVersions": [
@@ -3520,10 +3521,11 @@
       "4.1.0",
       "4.2.0",
       "4.3.0",
-      "4.3.1"
+      "4.3.1",
+      "4.4.0"
     ],
     "minVersion": "1.0.0",
-    "maxVersion": "4.3.1",
+    "maxVersion": "4.4.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -3874,13 +3876,14 @@
         "0.7.11",
         "0.7.12",
         "0.7.13",
-        "0.7.14"
+        "0.7.14",
+        "0.7.15"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.7.5",
-        "maxVersion": "0.7.14"
+        "maxVersion": "0.7.15"
       }
     },
     "availableVersions": [
@@ -3890,10 +3893,11 @@
       "0.7.11",
       "0.7.12",
       "0.7.13",
-      "0.7.14"
+      "0.7.14",
+      "0.7.15"
     ],
     "minVersion": "0.7.5",
-    "maxVersion": "0.7.14",
+    "maxVersion": "0.7.15",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -3948,13 +3952,14 @@
         "3.25.0",
         "3.26.0",
         "3.26.1",
-        "3.27.0"
+        "3.27.0",
+        "3.27.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "3.3.0",
-        "maxVersion": "3.27.0"
+        "maxVersion": "3.27.1"
       }
     },
     "availableVersions": [
@@ -4000,10 +4005,11 @@
       "3.25.0",
       "3.26.0",
       "3.26.1",
-      "3.27.0"
+      "3.27.0",
+      "3.27.1"
     ],
     "minVersion": "3.3.0",
-    "maxVersion": "3.27.0",
+    "maxVersion": "3.27.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -4059,13 +4065,14 @@
         "0.37.0",
         "0.38.0",
         "0.39.0",
-        "0.40.0"
+        "0.40.0",
+        "0.40.1"
       ]
     },
     "channelVersionRanges": {
       "fast": {
         "minVersion": "0.9.0",
-        "maxVersion": "0.40.0"
+        "maxVersion": "0.40.1"
       }
     },
     "availableVersions": [
@@ -4112,10 +4119,11 @@
       "0.37.0",
       "0.38.0",
       "0.39.0",
-      "0.40.0"
+      "0.40.0",
+      "0.40.1"
     ],
     "minVersion": "0.9.0",
-    "maxVersion": "0.40.0",
+    "maxVersion": "0.40.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -4855,7 +4863,8 @@
         "7.13.0+0.1774370015.p",
         "7.13.0+0.1775139554.p",
         "7.13.0+0.1775735859.p",
-        "7.13.0+0.1776065698.p"
+        "7.13.0+0.1776065698.p",
+        "7.13.0+0.1776378942.p"
       ],
       "fuse-apicurito-7.9.x": [
         "7.9.3"
@@ -4876,7 +4885,7 @@
       },
       "fuse-apicurito-7.13.x": {
         "minVersion": "7.9.3",
-        "maxVersion": "7.13.0+0.1776065698.p"
+        "maxVersion": "7.13.0+0.1776378942.p"
       },
       "fuse-apicurito-7.9.x": {
         "minVersion": "7.9.3",
@@ -4956,10 +4965,11 @@
       "7.13.0+0.1774370015.p",
       "7.13.0+0.1775139554.p",
       "7.13.0+0.1775735859.p",
-      "7.13.0+0.1776065698.p"
+      "7.13.0+0.1776065698.p",
+      "7.13.0+0.1776378942.p"
     ],
     "minVersion": "7.9.3",
-    "maxVersion": "7.13.0+0.1776065698.p",
+    "maxVersion": "7.13.0+0.1776378942.p",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -5027,7 +5037,8 @@
         "7.13.0+0.1771828310.p",
         "7.13.0+0.1773829909.p",
         "7.13.0+0.1775139556.p",
-        "7.13.0+0.1776065698.p"
+        "7.13.0+0.1776065698.p",
+        "7.13.0+0.1776378943.p"
       ],
       "7.9.x": [
         "7.9.0"
@@ -5048,7 +5059,7 @@
       },
       "7.13.x": {
         "minVersion": "7.12.1",
-        "maxVersion": "7.13.0+0.1776065698.p"
+        "maxVersion": "7.13.0+0.1776378943.p"
       },
       "7.9.x": {
         "minVersion": "7.9.0",
@@ -5101,10 +5112,11 @@
       "7.13.0+0.1771828310.p",
       "7.13.0+0.1773829909.p",
       "7.13.0+0.1775139556.p",
-      "7.13.0+0.1776065698.p"
+      "7.13.0+0.1776065698.p",
+      "7.13.0+0.1776378943.p"
     ],
     "minVersion": "7.9.0",
-    "maxVersion": "7.13.0+0.1776065698.p",
+    "maxVersion": "7.13.0+0.1776378943.p",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -5401,6 +5413,7 @@
       "3.18",
       "3.19",
       "3.20",
+      "3.21",
       "stable"
     ],
     "channelVersions": {
@@ -5552,6 +5565,9 @@
       "3.20": [
         "3.20.0"
       ],
+      "3.21": [
+        "3.21.0"
+      ],
       "stable": [
         "0.2.2",
         "0.2.3",
@@ -5580,7 +5596,8 @@
         "3.18.0",
         "3.19.0",
         "3.19.1",
-        "3.20.0"
+        "3.20.0",
+        "3.21.0"
       ]
     },
     "channelVersionRanges": {
@@ -5612,9 +5629,13 @@
         "minVersion": "3.20.0",
         "maxVersion": "3.20.0"
       },
+      "3.21": {
+        "minVersion": "3.21.0",
+        "maxVersion": "3.21.0"
+      },
       "stable": {
         "minVersion": "0.2.2",
-        "maxVersion": "3.20.0"
+        "maxVersion": "3.21.0"
       }
     },
     "availableVersions": [
@@ -5660,10 +5681,11 @@
       "3.18.1",
       "3.19.0",
       "3.19.1",
-      "3.20.0"
+      "3.20.0",
+      "3.21.0"
     ],
     "minVersion": "0.2.2",
-    "maxVersion": "3.20.0",
+    "maxVersion": "3.21.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -7603,7 +7625,8 @@
         "8.0.1"
       ],
       "stable-v8.1": [
-        "8.1.0"
+        "8.1.0",
+        "8.1.1"
       ]
     },
     "channelVersionRanges": {
@@ -7641,7 +7664,7 @@
       },
       "stable-v8.1": {
         "minVersion": "8.1.0",
-        "maxVersion": "8.1.0"
+        "maxVersion": "8.1.1"
       }
     },
     "availableVersions": [
@@ -7673,10 +7696,11 @@
       "7.3.2",
       "8.0.0",
       "8.0.1",
-      "8.1.0"
+      "8.1.0",
+      "8.1.1"
     ],
     "minVersion": "6.0.0",
-    "maxVersion": "8.1.0",
+    "maxVersion": "8.1.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -7979,7 +8003,8 @@
         "2.6.6",
         "2.6.7",
         "2.6.8",
-        "2.6.9"
+        "2.6.9",
+        "2.6.10"
       ],
       "stable-2.7": [
         "2.7.0",
@@ -8014,7 +8039,7 @@
       },
       "stable-2.6": {
         "minVersion": "2.6.0",
-        "maxVersion": "2.6.9"
+        "maxVersion": "2.6.10"
       },
       "stable-2.7": {
         "minVersion": "2.7.0",
@@ -8040,6 +8065,7 @@
       "2.6.7",
       "2.6.8",
       "2.6.9",
+      "2.6.10",
       "2.7.0",
       "2.7.1",
       "2.7.2",
@@ -10195,16 +10221,19 @@
         "1.18.1",
         "1.18.2",
         "1.18.3",
-        "1.18.4"
+        "1.18.4",
+        "1.18.5"
       ],
       "gitops-1.19": [
         "1.19.0",
         "1.19.1",
-        "1.19.2"
+        "1.19.2",
+        "1.19.3"
       ],
       "gitops-1.20": [
         "1.20.0",
-        "1.20.1"
+        "1.20.1",
+        "1.20.2"
       ],
       "gitops-1.6": [
         "1.5.2",
@@ -10325,7 +10354,8 @@
         "1.19.1",
         "1.19.2",
         "1.20.0",
-        "1.20.1"
+        "1.20.1",
+        "1.20.2"
       ]
     },
     "channelVersionRanges": {
@@ -10363,15 +10393,15 @@
       },
       "gitops-1.18": {
         "minVersion": "1.18.0",
-        "maxVersion": "1.18.4"
+        "maxVersion": "1.18.5"
       },
       "gitops-1.19": {
         "minVersion": "1.19.0",
-        "maxVersion": "1.19.2"
+        "maxVersion": "1.19.3"
       },
       "gitops-1.20": {
         "minVersion": "1.20.0",
-        "maxVersion": "1.20.1"
+        "maxVersion": "1.20.2"
       },
       "gitops-1.6": {
         "minVersion": "1.5.2",
@@ -10391,7 +10421,7 @@
       },
       "latest": {
         "minVersion": "1.5.2",
-        "maxVersion": "1.20.1"
+        "maxVersion": "1.20.2"
       }
     },
     "availableVersions": [
@@ -10487,14 +10517,17 @@
       "1.18.2",
       "1.18.3",
       "1.18.4",
+      "1.18.5",
       "1.19.0",
       "1.19.1",
       "1.19.2",
+      "1.19.3",
       "1.20.0",
-      "1.20.1"
+      "1.20.1",
+      "1.20.2"
     ],
     "minVersion": "1.5.2",
-    "maxVersion": "1.20.1",
+    "maxVersion": "1.20.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -10511,7 +10544,8 @@
       "pipelines-1.18",
       "pipelines-1.19",
       "pipelines-1.20",
-      "pipelines-1.21"
+      "pipelines-1.21",
+      "pipelines-1.22"
     ],
     "channelVersions": {
       "latest": [
@@ -10546,8 +10580,10 @@
         "1.20.1",
         "1.20.2",
         "1.20.3",
+        "1.20.4",
         "1.21.0",
-        "1.21.1"
+        "1.21.1",
+        "1.22.0"
       ],
       "pipelines-1.14": [
         "1.14.0",
@@ -10592,17 +10628,21 @@
         "1.20.0",
         "1.20.1",
         "1.20.2",
-        "1.20.3"
+        "1.20.3",
+        "1.20.4"
       ],
       "pipelines-1.21": [
         "1.21.0",
         "1.21.1"
+      ],
+      "pipelines-1.22": [
+        "1.22.0"
       ]
     },
     "channelVersionRanges": {
       "latest": {
         "minVersion": "1.14.0",
-        "maxVersion": "1.21.1"
+        "maxVersion": "1.22.0"
       },
       "pipelines-1.14": {
         "minVersion": "1.14.0",
@@ -10630,11 +10670,15 @@
       },
       "pipelines-1.20": {
         "minVersion": "1.20.0",
-        "maxVersion": "1.20.3"
+        "maxVersion": "1.20.4"
       },
       "pipelines-1.21": {
         "minVersion": "1.21.0",
         "maxVersion": "1.21.1"
+      },
+      "pipelines-1.22": {
+        "minVersion": "1.22.0",
+        "maxVersion": "1.22.0"
       }
     },
     "availableVersions": [
@@ -10669,11 +10713,13 @@
       "1.20.1",
       "1.20.2",
       "1.20.3",
+      "1.20.4",
       "1.21.0",
-      "1.21.1"
+      "1.21.1",
+      "1.22.0"
     ],
     "minVersion": "1.14.0",
-    "maxVersion": "1.21.1",
+    "maxVersion": "1.22.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -10751,13 +10797,14 @@
         "0.135.0-1",
         "0.140.0-1",
         "0.140.0-2",
-        "0.144.0-1"
+        "0.144.0-1",
+        "0.144.0-2"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.56.0-1",
-        "maxVersion": "0.144.0-1"
+        "maxVersion": "0.144.0-2"
       }
     },
     "availableVersions": [
@@ -10784,10 +10831,11 @@
       "0.135.0-1",
       "0.140.0-1",
       "0.140.0-2",
-      "0.144.0-1"
+      "0.144.0-1",
+      "0.144.0-2"
     ],
     "minVersion": "0.56.0-1",
-    "maxVersion": "0.144.0-1",
+    "maxVersion": "0.144.0-2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -14080,6 +14128,7 @@
         "1.8.3",
         "1.8.4",
         "1.8.5",
+        "1.8.6",
         "1.9.0",
         "1.9.1",
         "1.9.2",
@@ -14138,7 +14187,8 @@
         "1.8.2",
         "1.8.3",
         "1.8.4",
-        "1.8.5"
+        "1.8.5",
+        "1.8.6"
       ],
       "fast-1.9": [
         "1.9.0",
@@ -14182,7 +14232,7 @@
       },
       "fast-1.8": {
         "minVersion": "1.8.0",
-        "maxVersion": "1.8.5"
+        "maxVersion": "1.8.6"
       },
       "fast-1.9": {
         "minVersion": "1.9.0",
@@ -14225,6 +14275,7 @@
       "1.8.3",
       "1.8.4",
       "1.8.5",
+      "1.8.6",
       "1.9.0",
       "1.9.1",
       "1.9.2",
@@ -14304,7 +14355,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "beta": [
         "1.20.1-8",
@@ -14429,7 +14481,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "eus-2.8": [
         "1.20.1-8",
@@ -14507,7 +14560,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "stable": [
         "1.20.1-8",
@@ -14554,7 +14608,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "stable-2.10": [
         "1.20.1-8",
@@ -14786,7 +14841,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "stable-2.8": [
         "1.20.1-8",
@@ -14820,7 +14876,7 @@
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "beta": {
         "minVersion": "1.20.1-8",
@@ -14836,7 +14892,7 @@
       },
       "eus-2.25": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "eus-2.8": {
         "minVersion": "1.20.1-8",
@@ -14844,11 +14900,11 @@
       },
       "fast": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "stable": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "stable-2.10": {
         "minVersion": "1.20.1-8",
@@ -14872,7 +14928,7 @@
       },
       "stable-2.25": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "stable-2.8": {
         "minVersion": "1.20.1-8",
@@ -14942,10 +14998,11 @@
       "2.25.1",
       "2.25.2",
       "2.25.3",
-      "2.25.4"
+      "2.25.4",
+      "2.25.5"
     ],
     "minVersion": "1.20.1-8",
-    "maxVersion": "2.25.4",
+    "maxVersion": "2.25.5",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -15195,6 +15252,7 @@
         "1.3.1",
         "1.3.2",
         "1.3.3",
+        "1.3.4",
         "1.4.0"
       ],
       "stable-v1.1": [
@@ -15211,7 +15269,8 @@
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.3.3"
+        "1.3.3",
+        "1.3.4"
       ],
       "stable-v1.4": [
         "1.4.0"
@@ -15232,7 +15291,7 @@
       },
       "stable-v1.3": {
         "minVersion": "1.3.0",
-        "maxVersion": "1.3.3"
+        "maxVersion": "1.3.4"
       },
       "stable-v1.4": {
         "minVersion": "1.4.0",
@@ -15250,6 +15309,7 @@
       "1.3.1",
       "1.3.2",
       "1.3.3",
+      "1.3.4",
       "1.4.0"
     ],
     "minVersion": "1.1.0",
@@ -15281,7 +15341,8 @@
         "1.1.0",
         "1.1.1",
         "1.1.2",
-        "1.1.3"
+        "1.1.3",
+        "1.1.4"
       ]
     },
     "channelVersionRanges": {
@@ -15295,7 +15356,7 @@
       },
       "stable-v1.1": {
         "minVersion": "1.1.0",
-        "maxVersion": "1.1.3"
+        "maxVersion": "1.1.4"
       }
     },
     "availableVersions": [
@@ -15305,10 +15366,11 @@
       "1.1.0",
       "1.1.1",
       "1.1.2",
-      "1.1.3"
+      "1.1.3",
+      "1.1.4"
     ],
     "minVersion": "1.0.0",
-    "maxVersion": "1.1.3",
+    "maxVersion": "1.1.4",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -15497,21 +15559,23 @@
     "channelVersions": {
       "stable": [
         "1.0.0",
-        "1.0.1"
+        "1.0.1",
+        "1.0.2"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.0.0",
-        "maxVersion": "1.0.1"
+        "maxVersion": "1.0.2"
       }
     },
     "availableVersions": [
       "1.0.0",
-      "1.0.1"
+      "1.0.1",
+      "1.0.2"
     ],
     "minVersion": "1.0.0",
-    "maxVersion": "1.0.1",
+    "maxVersion": "1.0.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -16480,13 +16544,15 @@
         "3.0.7",
         "3.0.8",
         "3.0.9",
+        "3.0.10",
         "3.1.0",
         "3.1.1",
         "3.1.2",
         "3.1.3",
         "3.1.4",
         "3.1.5",
-        "3.1.6"
+        "3.1.6",
+        "3.1.7"
       ],
       "stable-3.0": [
         "3.0.0",
@@ -16498,7 +16564,8 @@
         "3.0.6",
         "3.0.7",
         "3.0.8",
-        "3.0.9"
+        "3.0.9",
+        "3.0.10"
       ],
       "stable-3.1": [
         "3.1.0",
@@ -16507,7 +16574,8 @@
         "3.1.3",
         "3.1.4",
         "3.1.5",
-        "3.1.6"
+        "3.1.6",
+        "3.1.7"
       ]
     },
     "channelVersionRanges": {
@@ -16517,15 +16585,15 @@
       },
       "stable": {
         "minVersion": "3.0.0",
-        "maxVersion": "3.1.6"
+        "maxVersion": "3.1.7"
       },
       "stable-3.0": {
         "minVersion": "3.0.0",
-        "maxVersion": "3.0.9"
+        "maxVersion": "3.0.10"
       },
       "stable-3.1": {
         "minVersion": "3.1.0",
-        "maxVersion": "3.1.6"
+        "maxVersion": "3.1.7"
       }
     },
     "availableVersions": [
@@ -16541,16 +16609,18 @@
       "3.0.7",
       "3.0.8",
       "3.0.9",
+      "3.0.10",
       "3.1.0",
       "3.1.1",
       "3.1.2",
       "3.1.3",
       "3.1.4",
       "3.1.5",
-      "3.1.6"
+      "3.1.6",
+      "3.1.7"
     ],
     "minVersion": "3.0.0",
-    "maxVersion": "3.1.6",
+    "maxVersion": "3.1.7",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"
@@ -17251,13 +17321,15 @@
         "0.19.0-1",
         "0.19.0-2",
         "0.19.0-3",
-        "0.20.0-1"
+        "0.20.0-1",
+        "0.20.0-2",
+        "0.20.0-3"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.1.0-6",
-        "maxVersion": "0.20.0-1"
+        "maxVersion": "0.20.0-3"
       }
     },
     "availableVersions": [
@@ -17283,10 +17355,12 @@
       "0.19.0-1",
       "0.19.0-2",
       "0.19.0-3",
-      "0.20.0-1"
+      "0.20.0-1",
+      "0.20.0-2",
+      "0.20.0-3"
     ],
     "minVersion": "0.1.0-6",
-    "maxVersion": "0.20.0-1",
+    "maxVersion": "0.20.0-3",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.17",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.17"

--- a/catalog-data/redhat-operator-index/v4.18/operators.json
+++ b/catalog-data/redhat-operator-index/v4.18/operators.json
@@ -1946,13 +1946,14 @@
         "4.18.0-202602170043",
         "4.18.0-202603040208",
         "4.18.0-202603181756",
-        "4.18.0-202604010244"
+        "4.18.0-202604010244",
+        "4.18.0-202604141055"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.18.0-202502110432",
-        "maxVersion": "4.18.0-202604010244"
+        "maxVersion": "4.18.0-202604141055"
       }
     },
     "availableVersions": [
@@ -1987,10 +1988,11 @@
       "4.18.0-202602170043",
       "4.18.0-202603040208",
       "4.18.0-202603181756",
-      "4.18.0-202604010244"
+      "4.18.0-202604010244",
+      "4.18.0-202604141055"
     ],
     "minVersion": "4.18.0-202502110432",
-    "maxVersion": "4.18.0-202604010244",
+    "maxVersion": "4.18.0-202604141055",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -2557,7 +2559,7 @@
   },
   {
     "name": "cluster-logging",
-    "defaultChannel": "stable-6.3",
+    "defaultChannel": "stable-6.4",
     "channels": [
       "stable-6.1",
       "stable-6.2",
@@ -2600,7 +2602,8 @@
         "6.4.0",
         "6.4.1",
         "6.4.2",
-        "6.4.3"
+        "6.4.3",
+        "6.4.4"
       ]
     },
     "channelVersionRanges": {
@@ -2618,7 +2621,7 @@
       },
       "stable-6.4": {
         "minVersion": "6.4.0",
-        "maxVersion": "6.4.3"
+        "maxVersion": "6.4.4"
       }
     },
     "availableVersions": [
@@ -2650,10 +2653,11 @@
       "6.4.0",
       "6.4.1",
       "6.4.2",
-      "6.4.3"
+      "6.4.3",
+      "6.4.4"
     ],
     "minVersion": "6.1.0",
-    "maxVersion": "6.4.3",
+    "maxVersion": "6.4.4",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -2734,13 +2738,14 @@
         "4.18.0-202601302238",
         "4.18.0-202602132343",
         "4.18.0-202602261953",
-        "4.18.0-202603262350"
+        "4.18.0-202603262350",
+        "4.18.0-202604141055"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.18.0-202501231202",
-        "maxVersion": "4.18.0-202603262350"
+        "maxVersion": "4.18.0-202604141055"
       }
     },
     "availableVersions": [
@@ -2770,10 +2775,11 @@
       "4.18.0-202601302238",
       "4.18.0-202602132343",
       "4.18.0-202602261953",
-      "4.18.0-202603262350"
+      "4.18.0-202603262350",
+      "4.18.0-202604141055"
     ],
     "minVersion": "4.18.0-202501231202",
-    "maxVersion": "4.18.0-202603262350",
+    "maxVersion": "4.18.0-202604141055",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -3287,13 +3293,14 @@
         "4.1.0",
         "4.2.0",
         "4.3.0",
-        "4.3.1"
+        "4.3.1",
+        "4.4.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.0.0",
-        "maxVersion": "4.3.1"
+        "maxVersion": "4.4.0"
       }
     },
     "availableVersions": [
@@ -3321,10 +3328,11 @@
       "4.1.0",
       "4.2.0",
       "4.3.0",
-      "4.3.1"
+      "4.3.1",
+      "4.4.0"
     ],
     "minVersion": "1.0.0",
-    "maxVersion": "4.3.1",
+    "maxVersion": "4.4.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -3675,13 +3683,14 @@
         "0.7.11",
         "0.7.12",
         "0.7.13",
-        "0.7.14"
+        "0.7.14",
+        "0.7.15"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.7.5",
-        "maxVersion": "0.7.14"
+        "maxVersion": "0.7.15"
       }
     },
     "availableVersions": [
@@ -3691,10 +3700,11 @@
       "0.7.11",
       "0.7.12",
       "0.7.13",
-      "0.7.14"
+      "0.7.14",
+      "0.7.15"
     ],
     "minVersion": "0.7.5",
-    "maxVersion": "0.7.14",
+    "maxVersion": "0.7.15",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -3749,13 +3759,14 @@
         "3.25.0",
         "3.26.0",
         "3.26.1",
-        "3.27.0"
+        "3.27.0",
+        "3.27.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "3.3.0",
-        "maxVersion": "3.27.0"
+        "maxVersion": "3.27.1"
       }
     },
     "availableVersions": [
@@ -3801,10 +3812,11 @@
       "3.25.0",
       "3.26.0",
       "3.26.1",
-      "3.27.0"
+      "3.27.0",
+      "3.27.1"
     ],
     "minVersion": "3.3.0",
-    "maxVersion": "3.27.0",
+    "maxVersion": "3.27.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -3860,13 +3872,14 @@
         "0.37.0",
         "0.38.0",
         "0.39.0",
-        "0.40.0"
+        "0.40.0",
+        "0.40.1"
       ]
     },
     "channelVersionRanges": {
       "fast": {
         "minVersion": "0.9.0",
-        "maxVersion": "0.40.0"
+        "maxVersion": "0.40.1"
       }
     },
     "availableVersions": [
@@ -3913,10 +3926,11 @@
       "0.37.0",
       "0.38.0",
       "0.39.0",
-      "0.40.0"
+      "0.40.0",
+      "0.40.1"
     ],
     "minVersion": "0.9.0",
-    "maxVersion": "0.40.0",
+    "maxVersion": "0.40.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -4011,13 +4025,14 @@
         "4.18.0-202601302238",
         "4.18.0-202602132343",
         "4.18.0-202602261953",
-        "4.18.0-202603262350"
+        "4.18.0-202603262350",
+        "4.18.0-202604141055"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.18.0-202501230001",
-        "maxVersion": "4.18.0-202603262350"
+        "maxVersion": "4.18.0-202604141055"
       }
     },
     "availableVersions": [
@@ -4045,10 +4060,11 @@
       "4.18.0-202601302238",
       "4.18.0-202602132343",
       "4.18.0-202602261953",
-      "4.18.0-202603262350"
+      "4.18.0-202603262350",
+      "4.18.0-202604141055"
     ],
     "minVersion": "4.18.0-202501230001",
-    "maxVersion": "4.18.0-202603262350",
+    "maxVersion": "4.18.0-202604141055",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -4630,7 +4646,8 @@
         "7.13.0+0.1774370015.p",
         "7.13.0+0.1775139554.p",
         "7.13.0+0.1775735859.p",
-        "7.13.0+0.1776065698.p"
+        "7.13.0+0.1776065698.p",
+        "7.13.0+0.1776378942.p"
       ],
       "fuse-apicurito-7.9.x": [
         "7.9.3"
@@ -4651,7 +4668,7 @@
       },
       "fuse-apicurito-7.13.x": {
         "minVersion": "7.9.3",
-        "maxVersion": "7.13.0+0.1776065698.p"
+        "maxVersion": "7.13.0+0.1776378942.p"
       },
       "fuse-apicurito-7.9.x": {
         "minVersion": "7.9.3",
@@ -4731,10 +4748,11 @@
       "7.13.0+0.1774370015.p",
       "7.13.0+0.1775139554.p",
       "7.13.0+0.1775735859.p",
-      "7.13.0+0.1776065698.p"
+      "7.13.0+0.1776065698.p",
+      "7.13.0+0.1776378942.p"
     ],
     "minVersion": "7.9.3",
-    "maxVersion": "7.13.0+0.1776065698.p",
+    "maxVersion": "7.13.0+0.1776378942.p",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -4802,7 +4820,8 @@
         "7.13.0+0.1771828310.p",
         "7.13.0+0.1773829909.p",
         "7.13.0+0.1775139556.p",
-        "7.13.0+0.1776065698.p"
+        "7.13.0+0.1776065698.p",
+        "7.13.0+0.1776378943.p"
       ],
       "7.9.x": [
         "7.9.0"
@@ -4823,7 +4842,7 @@
       },
       "7.13.x": {
         "minVersion": "7.12.1",
-        "maxVersion": "7.13.0+0.1776065698.p"
+        "maxVersion": "7.13.0+0.1776378943.p"
       },
       "7.9.x": {
         "minVersion": "7.9.0",
@@ -4876,10 +4895,11 @@
       "7.13.0+0.1771828310.p",
       "7.13.0+0.1773829909.p",
       "7.13.0+0.1775139556.p",
-      "7.13.0+0.1776065698.p"
+      "7.13.0+0.1776065698.p",
+      "7.13.0+0.1776378943.p"
     ],
     "minVersion": "7.9.0",
-    "maxVersion": "7.13.0+0.1776065698.p",
+    "maxVersion": "7.13.0+0.1776378943.p",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -5176,6 +5196,7 @@
       "3.18",
       "3.19",
       "3.20",
+      "3.21",
       "stable"
     ],
     "channelVersions": {
@@ -5327,6 +5348,9 @@
       "3.20": [
         "3.20.0"
       ],
+      "3.21": [
+        "3.21.0"
+      ],
       "stable": [
         "0.2.2",
         "0.2.3",
@@ -5355,7 +5379,8 @@
         "3.18.0",
         "3.19.0",
         "3.19.1",
-        "3.20.0"
+        "3.20.0",
+        "3.21.0"
       ]
     },
     "channelVersionRanges": {
@@ -5387,9 +5412,13 @@
         "minVersion": "3.20.0",
         "maxVersion": "3.20.0"
       },
+      "3.21": {
+        "minVersion": "3.21.0",
+        "maxVersion": "3.21.0"
+      },
       "stable": {
         "minVersion": "0.2.2",
-        "maxVersion": "3.20.0"
+        "maxVersion": "3.21.0"
       }
     },
     "availableVersions": [
@@ -5435,10 +5464,11 @@
       "3.18.1",
       "3.19.0",
       "3.19.1",
-      "3.20.0"
+      "3.20.0",
+      "3.21.0"
     ],
     "minVersion": "0.2.2",
-    "maxVersion": "3.20.0",
+    "maxVersion": "3.21.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -5477,13 +5507,14 @@
         "4.18.0-202602132343",
         "4.18.0-202602261953",
         "4.18.0-202603131924",
-        "4.18.0-202603270855"
+        "4.18.0-202603270855",
+        "4.18.0-202604141055"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.18.0-202501230001",
-        "maxVersion": "4.18.0-202603270855"
+        "maxVersion": "4.18.0-202604141055"
       }
     },
     "availableVersions": [
@@ -5513,10 +5544,11 @@
       "4.18.0-202602132343",
       "4.18.0-202602261953",
       "4.18.0-202603131924",
-      "4.18.0-202603270855"
+      "4.18.0-202603270855",
+      "4.18.0-202604141055"
     ],
     "minVersion": "4.18.0-202501230001",
-    "maxVersion": "4.18.0-202603270855",
+    "maxVersion": "4.18.0-202604141055",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -5553,13 +5585,14 @@
         "4.18.0-202601302238",
         "4.18.0-202602132343",
         "4.18.0-202602261953",
-        "4.18.0-202603262350"
+        "4.18.0-202603262350",
+        "4.18.0-202604141055"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.18.0-202501230001",
-        "maxVersion": "4.18.0-202603262350"
+        "maxVersion": "4.18.0-202604141055"
       }
     },
     "availableVersions": [
@@ -5587,10 +5620,11 @@
       "4.18.0-202601302238",
       "4.18.0-202602132343",
       "4.18.0-202602261953",
-      "4.18.0-202603262350"
+      "4.18.0-202603262350",
+      "4.18.0-202604141055"
     ],
     "minVersion": "4.18.0-202501230001",
-    "maxVersion": "4.18.0-202603262350",
+    "maxVersion": "4.18.0-202604141055",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -6228,13 +6262,14 @@
         "4.18.0-202602172216",
         "4.18.0-202603041813",
         "4.18.0-202603181756",
-        "4.18.0-202604010844"
+        "4.18.0-202604010844",
+        "4.18.0-202604151619"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.18.0-202502110432",
-        "maxVersion": "4.18.0-202604010844"
+        "maxVersion": "4.18.0-202604151619"
       }
     },
     "availableVersions": [
@@ -6270,10 +6305,11 @@
       "4.18.0-202602172216",
       "4.18.0-202603041813",
       "4.18.0-202603181756",
-      "4.18.0-202604010844"
+      "4.18.0-202604010844",
+      "4.18.0-202604151619"
     ],
     "minVersion": "4.18.0-202502110432",
-    "maxVersion": "4.18.0-202604010844",
+    "maxVersion": "4.18.0-202604151619",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -6352,7 +6388,8 @@
         "4.18.13",
         "4.18.17",
         "4.18.23",
-        "4.18.29"
+        "4.18.29",
+        "4.18.32"
       ]
     },
     "channelVersionRanges": {
@@ -6362,7 +6399,7 @@
       },
       "stable": {
         "minVersion": "4.12.0",
-        "maxVersion": "4.18.29"
+        "maxVersion": "4.18.32"
       }
     },
     "availableVersions": [
@@ -6683,13 +6720,14 @@
         "4.18.0-202602132343",
         "4.18.0-202602272244",
         "4.18.0-202603152157",
-        "4.18.0-202603262350"
+        "4.18.0-202603262350",
+        "4.18.0-202604150511"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.18.0-202502040032",
-        "maxVersion": "4.18.0-202603262350"
+        "maxVersion": "4.18.0-202604150511"
       }
     },
     "availableVersions": [
@@ -6720,10 +6758,11 @@
       "4.18.0-202602132343",
       "4.18.0-202602272244",
       "4.18.0-202603152157",
-      "4.18.0-202603262350"
+      "4.18.0-202603262350",
+      "4.18.0-202604150511"
     ],
     "minVersion": "4.18.0-202502040032",
-    "maxVersion": "4.18.0-202603262350",
+    "maxVersion": "4.18.0-202604150511",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -6794,7 +6833,7 @@
   },
   {
     "name": "loki-operator",
-    "defaultChannel": "stable-6.3",
+    "defaultChannel": "stable-6.4",
     "channels": [
       "stable-6.1",
       "stable-6.2",
@@ -6837,7 +6876,8 @@
         "6.4.0",
         "6.4.1",
         "6.4.2",
-        "6.4.3"
+        "6.4.3",
+        "6.4.4"
       ]
     },
     "channelVersionRanges": {
@@ -6855,7 +6895,7 @@
       },
       "stable-6.4": {
         "minVersion": "6.4.0",
-        "maxVersion": "6.4.3"
+        "maxVersion": "6.4.4"
       }
     },
     "availableVersions": [
@@ -6887,10 +6927,11 @@
       "6.4.0",
       "6.4.1",
       "6.4.2",
-      "6.4.3"
+      "6.4.3",
+      "6.4.4"
     ],
     "minVersion": "6.1.0",
-    "maxVersion": "6.4.3",
+    "maxVersion": "6.4.4",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -7181,13 +7222,14 @@
         "4.18.0-202602140741",
         "4.18.0-202603040208",
         "4.18.0-202603181756",
-        "4.18.0-202603262350"
+        "4.18.0-202603262350",
+        "4.18.0-202604141055"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.18.0-202502041632",
-        "maxVersion": "4.18.0-202603262350"
+        "maxVersion": "4.18.0-202604141055"
       }
     },
     "availableVersions": [
@@ -7220,10 +7262,11 @@
       "4.18.0-202602140741",
       "4.18.0-202603040208",
       "4.18.0-202603181756",
-      "4.18.0-202603262350"
+      "4.18.0-202603262350",
+      "4.18.0-202604141055"
     ],
     "minVersion": "4.18.0-202502041632",
-    "maxVersion": "4.18.0-202603262350",
+    "maxVersion": "4.18.0-202604141055",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -7320,7 +7363,8 @@
         "8.0.1"
       ],
       "stable-v8.1": [
-        "8.1.0"
+        "8.1.0",
+        "8.1.1"
       ]
     },
     "channelVersionRanges": {
@@ -7358,7 +7402,7 @@
       },
       "stable-v8.1": {
         "minVersion": "8.1.0",
-        "maxVersion": "8.1.0"
+        "maxVersion": "8.1.1"
       }
     },
     "availableVersions": [
@@ -7390,10 +7434,11 @@
       "7.3.2",
       "8.0.0",
       "8.0.1",
-      "8.1.0"
+      "8.1.0",
+      "8.1.1"
     ],
     "minVersion": "6.0.0",
-    "maxVersion": "8.1.0",
+    "maxVersion": "8.1.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -7976,13 +8021,14 @@
         "4.18.0-202602132343",
         "4.18.0-202602261953",
         "4.18.0-202603181756",
-        "4.18.0-202603262350"
+        "4.18.0-202603262350",
+        "4.18.0-202604141055"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.18.0-202502101733",
-        "maxVersion": "4.18.0-202603262350"
+        "maxVersion": "4.18.0-202604141055"
       }
     },
     "availableVersions": [
@@ -8013,10 +8059,11 @@
       "4.18.0-202602132343",
       "4.18.0-202602261953",
       "4.18.0-202603181756",
-      "4.18.0-202603262350"
+      "4.18.0-202603262350",
+      "4.18.0-202604141055"
     ],
     "minVersion": "4.18.0-202502101733",
-    "maxVersion": "4.18.0-202603262350",
+    "maxVersion": "4.18.0-202604141055",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -9370,7 +9417,8 @@
       "stable-v1.15",
       "stable-v1.16",
       "stable-v1.17",
-      "stable-v1.18"
+      "stable-v1.18",
+      "stable-v1.19"
     ],
     "channelVersions": {
       "stable-v1": [
@@ -9380,7 +9428,8 @@
         "1.16.1",
         "1.17.0",
         "1.18.0",
-        "1.18.1"
+        "1.18.1",
+        "1.19.0"
       ],
       "stable-v1.15": [
         "1.15.0",
@@ -9410,12 +9459,22 @@
         "1.17.0",
         "1.18.0",
         "1.18.1"
+      ],
+      "stable-v1.19": [
+        "1.15.0",
+        "1.15.1",
+        "1.16.0",
+        "1.16.1",
+        "1.17.0",
+        "1.18.0",
+        "1.18.1",
+        "1.19.0"
       ]
     },
     "channelVersionRanges": {
       "stable-v1": {
         "minVersion": "1.15.0",
-        "maxVersion": "1.18.1"
+        "maxVersion": "1.19.0"
       },
       "stable-v1.15": {
         "minVersion": "1.15.0",
@@ -9432,6 +9491,10 @@
       "stable-v1.18": {
         "minVersion": "1.15.0",
         "maxVersion": "1.18.1"
+      },
+      "stable-v1.19": {
+        "minVersion": "1.15.0",
+        "maxVersion": "1.19.0"
       }
     },
     "availableVersions": [
@@ -9444,10 +9507,11 @@
       "1.17.0",
       "1.17.1",
       "1.18.0",
-      "1.18.1"
+      "1.18.1",
+      "1.19.0"
     ],
     "minVersion": "1.15.0",
-    "maxVersion": "1.18.1",
+    "maxVersion": "1.19.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -9810,16 +9874,19 @@
         "1.18.1",
         "1.18.2",
         "1.18.3",
-        "1.18.4"
+        "1.18.4",
+        "1.18.5"
       ],
       "gitops-1.19": [
         "1.19.0",
         "1.19.1",
-        "1.19.2"
+        "1.19.2",
+        "1.19.3"
       ],
       "gitops-1.20": [
         "1.20.0",
-        "1.20.1"
+        "1.20.1",
+        "1.20.2"
       ],
       "gitops-1.6": [
         "1.5.2",
@@ -9940,7 +10007,8 @@
         "1.19.1",
         "1.19.2",
         "1.20.0",
-        "1.20.1"
+        "1.20.1",
+        "1.20.2"
       ]
     },
     "channelVersionRanges": {
@@ -9978,15 +10046,15 @@
       },
       "gitops-1.18": {
         "minVersion": "1.18.0",
-        "maxVersion": "1.18.4"
+        "maxVersion": "1.18.5"
       },
       "gitops-1.19": {
         "minVersion": "1.19.0",
-        "maxVersion": "1.19.2"
+        "maxVersion": "1.19.3"
       },
       "gitops-1.20": {
         "minVersion": "1.20.0",
-        "maxVersion": "1.20.1"
+        "maxVersion": "1.20.2"
       },
       "gitops-1.6": {
         "minVersion": "1.5.2",
@@ -10006,7 +10074,7 @@
       },
       "latest": {
         "minVersion": "1.5.2",
-        "maxVersion": "1.20.1"
+        "maxVersion": "1.20.2"
       }
     },
     "availableVersions": [
@@ -10102,14 +10170,17 @@
       "1.18.2",
       "1.18.3",
       "1.18.4",
+      "1.18.5",
       "1.19.0",
       "1.19.1",
       "1.19.2",
+      "1.19.3",
       "1.20.0",
-      "1.20.1"
+      "1.20.1",
+      "1.20.2"
     ],
     "minVersion": "1.5.2",
-    "maxVersion": "1.20.1",
+    "maxVersion": "1.20.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -10126,7 +10197,8 @@
       "pipelines-1.18",
       "pipelines-1.19",
       "pipelines-1.20",
-      "pipelines-1.21"
+      "pipelines-1.21",
+      "pipelines-1.22"
     ],
     "channelVersions": {
       "latest": [
@@ -10161,8 +10233,10 @@
         "1.20.1",
         "1.20.2",
         "1.20.3",
+        "1.20.4",
         "1.21.0",
-        "1.21.1"
+        "1.21.1",
+        "1.22.0"
       ],
       "pipelines-1.14": [
         "1.14.0",
@@ -10207,17 +10281,21 @@
         "1.20.0",
         "1.20.1",
         "1.20.2",
-        "1.20.3"
+        "1.20.3",
+        "1.20.4"
       ],
       "pipelines-1.21": [
         "1.21.0",
         "1.21.1"
+      ],
+      "pipelines-1.22": [
+        "1.22.0"
       ]
     },
     "channelVersionRanges": {
       "latest": {
         "minVersion": "1.14.0",
-        "maxVersion": "1.21.1"
+        "maxVersion": "1.22.0"
       },
       "pipelines-1.14": {
         "minVersion": "1.14.0",
@@ -10245,11 +10323,15 @@
       },
       "pipelines-1.20": {
         "minVersion": "1.20.0",
-        "maxVersion": "1.20.3"
+        "maxVersion": "1.20.4"
       },
       "pipelines-1.21": {
         "minVersion": "1.21.0",
         "maxVersion": "1.21.1"
+      },
+      "pipelines-1.22": {
+        "minVersion": "1.22.0",
+        "maxVersion": "1.22.0"
       }
     },
     "availableVersions": [
@@ -10284,11 +10366,13 @@
       "1.20.1",
       "1.20.2",
       "1.20.3",
+      "1.20.4",
       "1.21.0",
-      "1.21.1"
+      "1.21.1",
+      "1.22.0"
     ],
     "minVersion": "1.14.0",
-    "maxVersion": "1.21.1",
+    "maxVersion": "1.22.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -10463,13 +10547,14 @@
         "0.135.0-1",
         "0.140.0-1",
         "0.140.0-2",
-        "0.144.0-1"
+        "0.144.0-1",
+        "0.144.0-2"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.56.0-1",
-        "maxVersion": "0.144.0-1"
+        "maxVersion": "0.144.0-2"
       }
     },
     "availableVersions": [
@@ -10496,10 +10581,11 @@
       "0.135.0-1",
       "0.140.0-1",
       "0.140.0-2",
-      "0.144.0-1"
+      "0.144.0-1",
+      "0.144.0-2"
     ],
     "minVersion": "0.56.0-1",
-    "maxVersion": "0.144.0-1",
+    "maxVersion": "0.144.0-2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -10566,13 +10652,14 @@
         "4.18.0-202601302238",
         "4.18.0-202602132343",
         "4.18.0-202602261953",
-        "4.18.0-202603262350"
+        "4.18.0-202603262350",
+        "4.18.0-202604141055"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.18.0-202501230001",
-        "maxVersion": "4.18.0-202603262350"
+        "maxVersion": "4.18.0-202604141055"
       }
     },
     "availableVersions": [
@@ -10596,10 +10683,11 @@
       "4.18.0-202601302238",
       "4.18.0-202602132343",
       "4.18.0-202602261953",
-      "4.18.0-202603262350"
+      "4.18.0-202603262350",
+      "4.18.0-202604141055"
     ],
     "minVersion": "4.18.0-202501230001",
-    "maxVersion": "4.18.0-202603262350",
+    "maxVersion": "4.18.0-202604141055",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -10719,13 +10807,14 @@
         "4.18.0-202602132343",
         "4.18.0-202602261953",
         "4.18.0-202603171536",
-        "4.18.0-202603262350"
+        "4.18.0-202603262350",
+        "4.18.0-202604141055"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.18.0-202501230001",
-        "maxVersion": "4.18.0-202603262350"
+        "maxVersion": "4.18.0-202604141055"
       }
     },
     "availableVersions": [
@@ -10757,10 +10846,11 @@
       "4.18.0-202602132343",
       "4.18.0-202602261953",
       "4.18.0-202603171536",
-      "4.18.0-202603262350"
+      "4.18.0-202603262350",
+      "4.18.0-202604141055"
     ],
     "minVersion": "4.18.0-202501230001",
-    "maxVersion": "4.18.0-202603262350",
+    "maxVersion": "4.18.0-202604141055",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -13784,6 +13874,7 @@
         "1.8.3",
         "1.8.4",
         "1.8.5",
+        "1.8.6",
         "1.9.0",
         "1.9.1",
         "1.9.2",
@@ -13842,7 +13933,8 @@
         "1.8.2",
         "1.8.3",
         "1.8.4",
-        "1.8.5"
+        "1.8.5",
+        "1.8.6"
       ],
       "fast-1.9": [
         "1.9.0",
@@ -13886,7 +13978,7 @@
       },
       "fast-1.8": {
         "minVersion": "1.8.0",
-        "maxVersion": "1.8.5"
+        "maxVersion": "1.8.6"
       },
       "fast-1.9": {
         "minVersion": "1.9.0",
@@ -13929,6 +14021,7 @@
       "1.8.3",
       "1.8.4",
       "1.8.5",
+      "1.8.6",
       "1.9.0",
       "1.9.1",
       "1.9.2",
@@ -14008,7 +14101,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "beta": [
         "1.20.1-8",
@@ -14133,7 +14227,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "eus-2.8": [
         "1.20.1-8",
@@ -14211,7 +14306,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "stable": [
         "1.20.1-8",
@@ -14258,7 +14354,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "stable-2.10": [
         "1.20.1-8",
@@ -14490,7 +14587,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "stable-2.8": [
         "1.20.1-8",
@@ -14524,7 +14622,7 @@
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "beta": {
         "minVersion": "1.20.1-8",
@@ -14540,7 +14638,7 @@
       },
       "eus-2.25": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "eus-2.8": {
         "minVersion": "1.20.1-8",
@@ -14548,11 +14646,11 @@
       },
       "fast": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "stable": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "stable-2.10": {
         "minVersion": "1.20.1-8",
@@ -14576,7 +14674,7 @@
       },
       "stable-2.25": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "stable-2.8": {
         "minVersion": "1.20.1-8",
@@ -14646,10 +14744,11 @@
       "2.25.1",
       "2.25.2",
       "2.25.3",
-      "2.25.4"
+      "2.25.4",
+      "2.25.5"
     ],
     "minVersion": "1.20.1-8",
-    "maxVersion": "2.25.4",
+    "maxVersion": "2.25.5",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -14899,6 +14998,7 @@
         "1.3.1",
         "1.3.2",
         "1.3.3",
+        "1.3.4",
         "1.4.0"
       ],
       "stable-v1.1": [
@@ -14915,7 +15015,8 @@
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.3.3"
+        "1.3.3",
+        "1.3.4"
       ],
       "stable-v1.4": [
         "1.4.0"
@@ -14936,7 +15037,7 @@
       },
       "stable-v1.3": {
         "minVersion": "1.3.0",
-        "maxVersion": "1.3.3"
+        "maxVersion": "1.3.4"
       },
       "stable-v1.4": {
         "minVersion": "1.4.0",
@@ -14954,6 +15055,7 @@
       "1.3.1",
       "1.3.2",
       "1.3.3",
+      "1.3.4",
       "1.4.0"
     ],
     "minVersion": "1.1.0",
@@ -14985,7 +15087,8 @@
         "1.1.0",
         "1.1.1",
         "1.1.2",
-        "1.1.3"
+        "1.1.3",
+        "1.1.4"
       ]
     },
     "channelVersionRanges": {
@@ -14999,7 +15102,7 @@
       },
       "stable-v1.1": {
         "minVersion": "1.1.0",
-        "maxVersion": "1.1.3"
+        "maxVersion": "1.1.4"
       }
     },
     "availableVersions": [
@@ -15009,10 +15112,11 @@
       "1.1.0",
       "1.1.1",
       "1.1.2",
-      "1.1.3"
+      "1.1.3",
+      "1.1.4"
     ],
     "minVersion": "1.0.0",
-    "maxVersion": "1.1.3",
+    "maxVersion": "1.1.4",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -15189,21 +15293,23 @@
     "channelVersions": {
       "stable": [
         "1.0.0",
-        "1.0.1"
+        "1.0.1",
+        "1.0.2"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.0.0",
-        "maxVersion": "1.0.1"
+        "maxVersion": "1.0.2"
       }
     },
     "availableVersions": [
       "1.0.0",
-      "1.0.1"
+      "1.0.1",
+      "1.0.2"
     ],
     "minVersion": "1.0.0",
-    "maxVersion": "1.0.1",
+    "maxVersion": "1.0.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -15240,7 +15346,8 @@
         "1.10.2",
         "1.10.3",
         "1.11.0",
-        "1.11.1"
+        "1.11.1",
+        "1.12.0"
       ],
       "stable-1.2": [
         "1.2.2"
@@ -15260,7 +15367,7 @@
       },
       "stable": {
         "minVersion": "1.5.0",
-        "maxVersion": "1.11.1"
+        "maxVersion": "1.12.0"
       },
       "stable-1.2": {
         "minVersion": "1.2.2",
@@ -15289,10 +15396,11 @@
       "1.10.2",
       "1.10.3",
       "1.11.0",
-      "1.11.1"
+      "1.11.1",
+      "1.12.0"
     ],
     "minVersion": "1.0.2",
-    "maxVersion": "1.11.1",
+    "maxVersion": "1.12.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -15333,13 +15441,14 @@
         "4.18.0-202602132343",
         "4.18.0-202602261953",
         "4.18.0-202603131924",
-        "4.18.0-202603262350"
+        "4.18.0-202603262350",
+        "4.18.0-202604150511"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.18.0-202502040032",
-        "maxVersion": "4.18.0-202603262350"
+        "maxVersion": "4.18.0-202604150511"
       }
     },
     "availableVersions": [
@@ -15371,10 +15480,11 @@
       "4.18.0-202602132343",
       "4.18.0-202602261953",
       "4.18.0-202603131924",
-      "4.18.0-202603262350"
+      "4.18.0-202603262350",
+      "4.18.0-202604150511"
     ],
     "minVersion": "4.18.0-202502040032",
-    "maxVersion": "4.18.0-202603262350",
+    "maxVersion": "4.18.0-202604150511",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -16150,6 +16260,7 @@
         "3.0.7",
         "3.0.8",
         "3.0.9",
+        "3.0.10",
         "3.1.0",
         "3.1.1",
         "3.1.2",
@@ -16157,12 +16268,15 @@
         "3.1.4",
         "3.1.5",
         "3.1.6",
+        "3.1.7",
         "3.2.0",
         "3.2.1",
         "3.2.2",
         "3.2.3",
+        "3.2.4",
         "3.3.0",
-        "3.3.1"
+        "3.3.1",
+        "3.3.2"
       ],
       "stable-3.0": [
         "3.0.0",
@@ -16174,7 +16288,8 @@
         "3.0.6",
         "3.0.7",
         "3.0.8",
-        "3.0.9"
+        "3.0.9",
+        "3.0.10"
       ],
       "stable-3.1": [
         "3.1.0",
@@ -16183,17 +16298,20 @@
         "3.1.3",
         "3.1.4",
         "3.1.5",
-        "3.1.6"
+        "3.1.6",
+        "3.1.7"
       ],
       "stable-3.2": [
         "3.2.0",
         "3.2.1",
         "3.2.2",
-        "3.2.3"
+        "3.2.3",
+        "3.2.4"
       ],
       "stable-3.3": [
         "3.3.0",
-        "3.3.1"
+        "3.3.1",
+        "3.3.2"
       ]
     },
     "channelVersionRanges": {
@@ -16203,23 +16321,23 @@
       },
       "stable": {
         "minVersion": "3.0.0",
-        "maxVersion": "3.3.1"
+        "maxVersion": "3.3.2"
       },
       "stable-3.0": {
         "minVersion": "3.0.0",
-        "maxVersion": "3.0.9"
+        "maxVersion": "3.0.10"
       },
       "stable-3.1": {
         "minVersion": "3.1.0",
-        "maxVersion": "3.1.6"
+        "maxVersion": "3.1.7"
       },
       "stable-3.2": {
         "minVersion": "3.2.0",
-        "maxVersion": "3.2.3"
+        "maxVersion": "3.2.4"
       },
       "stable-3.3": {
         "minVersion": "3.3.0",
-        "maxVersion": "3.3.1"
+        "maxVersion": "3.3.2"
       }
     },
     "availableVersions": [
@@ -16235,6 +16353,7 @@
       "3.0.7",
       "3.0.8",
       "3.0.9",
+      "3.0.10",
       "3.1.0",
       "3.1.1",
       "3.1.2",
@@ -16242,15 +16361,18 @@
       "3.1.4",
       "3.1.5",
       "3.1.6",
+      "3.1.7",
       "3.2.0",
       "3.2.1",
       "3.2.2",
       "3.2.3",
+      "3.2.4",
       "3.3.0",
-      "3.3.1"
+      "3.3.1",
+      "3.3.2"
     ],
     "minVersion": "3.0.0",
-    "maxVersion": "3.3.1",
+    "maxVersion": "3.3.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -16641,13 +16763,14 @@
         "4.18.0-202601302238",
         "4.18.0-202602132343",
         "4.18.0-202602261953",
-        "4.18.0-202603262350"
+        "4.18.0-202603262350",
+        "4.18.0-202604141055"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.18.0-202501230001",
-        "maxVersion": "4.18.0-202603262350"
+        "maxVersion": "4.18.0-202604141055"
       }
     },
     "availableVersions": [
@@ -16676,10 +16799,11 @@
       "4.18.0-202601302238",
       "4.18.0-202602132343",
       "4.18.0-202602261953",
-      "4.18.0-202603262350"
+      "4.18.0-202603262350",
+      "4.18.0-202604141055"
     ],
     "minVersion": "4.18.0-202501230001",
-    "maxVersion": "4.18.0-202603262350",
+    "maxVersion": "4.18.0-202604141055",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -16720,13 +16844,14 @@
         "4.18.0-202602132343",
         "4.18.0-202602261953",
         "4.18.0-202603111324",
-        "4.18.0-202603311545"
+        "4.18.0-202603311545",
+        "4.18.0-202604141055"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.18.0-202501230001",
-        "maxVersion": "4.18.0-202603311545"
+        "maxVersion": "4.18.0-202604141055"
       }
     },
     "availableVersions": [
@@ -16758,10 +16883,11 @@
       "4.18.0-202602132343",
       "4.18.0-202602261953",
       "4.18.0-202603111324",
-      "4.18.0-202603311545"
+      "4.18.0-202603311545",
+      "4.18.0-202604141055"
     ],
     "minVersion": "4.18.0-202501230001",
-    "maxVersion": "4.18.0-202603311545",
+    "maxVersion": "4.18.0-202604141055",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -16908,13 +17034,14 @@
         "0.19.0-2",
         "0.19.0-3",
         "0.20.0-1",
-        "0.20.0-2"
+        "0.20.0-2",
+        "0.20.0-3"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.1.0-6",
-        "maxVersion": "0.20.0-2"
+        "maxVersion": "0.20.0-3"
       }
     },
     "availableVersions": [
@@ -16941,10 +17068,11 @@
       "0.19.0-2",
       "0.19.0-3",
       "0.20.0-1",
-      "0.20.0-2"
+      "0.20.0-2",
+      "0.20.0-3"
     ],
     "minVersion": "0.1.0-6",
-    "maxVersion": "0.20.0-2",
+    "maxVersion": "0.20.0-3",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"
@@ -17062,13 +17190,14 @@
         "4.18.0-202601302238",
         "4.18.0-202602132343",
         "4.18.0-202602261953",
-        "4.18.0-202603302315"
+        "4.18.0-202603302315",
+        "4.18.0-202604141055"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.18.0-202501230001",
-        "maxVersion": "4.18.0-202603302315"
+        "maxVersion": "4.18.0-202604141055"
       }
     },
     "availableVersions": [
@@ -17096,10 +17225,11 @@
       "4.18.0-202601302238",
       "4.18.0-202602132343",
       "4.18.0-202602261953",
-      "4.18.0-202603302315"
+      "4.18.0-202603302315",
+      "4.18.0-202604141055"
     ],
     "minVersion": "4.18.0-202501230001",
-    "maxVersion": "4.18.0-202603302315",
+    "maxVersion": "4.18.0-202604141055",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.18",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.18"

--- a/catalog-data/redhat-operator-index/v4.19/operators.json
+++ b/catalog-data/redhat-operator-index/v4.19/operators.json
@@ -2517,7 +2517,8 @@
         "6.4.0",
         "6.4.1",
         "6.4.2",
-        "6.4.3"
+        "6.4.3",
+        "6.4.4"
       ],
       "stable-6.5": [
         "6.5.0"
@@ -2534,7 +2535,7 @@
       },
       "stable-6.4": {
         "minVersion": "6.4.0",
-        "maxVersion": "6.4.3"
+        "maxVersion": "6.4.4"
       },
       "stable-6.5": {
         "minVersion": "6.5.0",
@@ -2561,6 +2562,7 @@
       "6.4.1",
       "6.4.2",
       "6.4.3",
+      "6.4.4",
       "6.5.0"
     ],
     "minVersion": "6.2.0",
@@ -3190,13 +3192,14 @@
         "4.1.0",
         "4.2.0",
         "4.3.0",
-        "4.3.1"
+        "4.3.1",
+        "4.4.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.0.0",
-        "maxVersion": "4.3.1"
+        "maxVersion": "4.4.0"
       }
     },
     "availableVersions": [
@@ -3224,10 +3227,11 @@
       "4.1.0",
       "4.2.0",
       "4.3.0",
-      "4.3.1"
+      "4.3.1",
+      "4.4.0"
     ],
     "minVersion": "1.0.0",
-    "maxVersion": "4.3.1",
+    "maxVersion": "4.4.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -3604,13 +3608,14 @@
         "0.7.11",
         "0.7.12",
         "0.7.13",
-        "0.7.14"
+        "0.7.14",
+        "0.7.15"
       ]
     },
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "0.7.5",
-        "maxVersion": "0.7.14"
+        "maxVersion": "0.7.15"
       }
     },
     "availableVersions": [
@@ -3620,10 +3625,11 @@
       "0.7.11",
       "0.7.12",
       "0.7.13",
-      "0.7.14"
+      "0.7.14",
+      "0.7.15"
     ],
     "minVersion": "0.7.5",
-    "maxVersion": "0.7.14",
+    "maxVersion": "0.7.15",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -3678,13 +3684,14 @@
         "3.25.0",
         "3.26.0",
         "3.26.1",
-        "3.27.0"
+        "3.27.0",
+        "3.27.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "3.3.0",
-        "maxVersion": "3.27.0"
+        "maxVersion": "3.27.1"
       }
     },
     "availableVersions": [
@@ -3730,10 +3737,11 @@
       "3.25.0",
       "3.26.0",
       "3.26.1",
-      "3.27.0"
+      "3.27.0",
+      "3.27.1"
     ],
     "minVersion": "3.3.0",
-    "maxVersion": "3.27.0",
+    "maxVersion": "3.27.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -3789,13 +3797,14 @@
         "0.37.0",
         "0.38.0",
         "0.39.0",
-        "0.40.0"
+        "0.40.0",
+        "0.40.1"
       ]
     },
     "channelVersionRanges": {
       "fast": {
         "minVersion": "0.9.0",
-        "maxVersion": "0.40.0"
+        "maxVersion": "0.40.1"
       }
     },
     "availableVersions": [
@@ -3842,10 +3851,11 @@
       "0.37.0",
       "0.38.0",
       "0.39.0",
-      "0.40.0"
+      "0.40.0",
+      "0.40.1"
     ],
     "minVersion": "0.9.0",
-    "maxVersion": "0.40.0",
+    "maxVersion": "0.40.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -4436,7 +4446,8 @@
         "7.13.0+0.1774370015.p",
         "7.13.0+0.1775139554.p",
         "7.13.0+0.1775735859.p",
-        "7.13.0+0.1776065698.p"
+        "7.13.0+0.1776065698.p",
+        "7.13.0+0.1776378942.p"
       ],
       "fuse-apicurito-7.9.x": [
         "7.9.3"
@@ -4457,7 +4468,7 @@
       },
       "fuse-apicurito-7.13.x": {
         "minVersion": "7.9.3",
-        "maxVersion": "7.13.0+0.1776065698.p"
+        "maxVersion": "7.13.0+0.1776378942.p"
       },
       "fuse-apicurito-7.9.x": {
         "minVersion": "7.9.3",
@@ -4537,10 +4548,11 @@
       "7.13.0+0.1774370015.p",
       "7.13.0+0.1775139554.p",
       "7.13.0+0.1775735859.p",
-      "7.13.0+0.1776065698.p"
+      "7.13.0+0.1776065698.p",
+      "7.13.0+0.1776378942.p"
     ],
     "minVersion": "7.9.3",
-    "maxVersion": "7.13.0+0.1776065698.p",
+    "maxVersion": "7.13.0+0.1776378942.p",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -4608,7 +4620,8 @@
         "7.13.0+0.1771828310.p",
         "7.13.0+0.1773829909.p",
         "7.13.0+0.1775139556.p",
-        "7.13.0+0.1776065698.p"
+        "7.13.0+0.1776065698.p",
+        "7.13.0+0.1776378943.p"
       ],
       "7.9.x": [
         "7.9.0"
@@ -4629,7 +4642,7 @@
       },
       "7.13.x": {
         "minVersion": "7.12.1",
-        "maxVersion": "7.13.0+0.1776065698.p"
+        "maxVersion": "7.13.0+0.1776378943.p"
       },
       "7.9.x": {
         "minVersion": "7.9.0",
@@ -4682,10 +4695,11 @@
       "7.13.0+0.1771828310.p",
       "7.13.0+0.1773829909.p",
       "7.13.0+0.1775139556.p",
-      "7.13.0+0.1776065698.p"
+      "7.13.0+0.1776065698.p",
+      "7.13.0+0.1776378943.p"
     ],
     "minVersion": "7.9.0",
-    "maxVersion": "7.13.0+0.1776065698.p",
+    "maxVersion": "7.13.0+0.1776378943.p",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -4982,6 +4996,7 @@
       "3.18",
       "3.19",
       "3.20",
+      "3.21",
       "stable"
     ],
     "channelVersions": {
@@ -5109,6 +5124,9 @@
       "3.20": [
         "3.20.0"
       ],
+      "3.21": [
+        "3.21.0"
+      ],
       "stable": [
         "0.2.2",
         "0.2.3",
@@ -5133,7 +5151,8 @@
         "3.18.0",
         "3.19.0",
         "3.19.1",
-        "3.20.0"
+        "3.20.0",
+        "3.21.0"
       ]
     },
     "channelVersionRanges": {
@@ -5165,9 +5184,13 @@
         "minVersion": "3.20.0",
         "maxVersion": "3.20.0"
       },
+      "3.21": {
+        "minVersion": "3.21.0",
+        "maxVersion": "3.21.0"
+      },
       "stable": {
         "minVersion": "0.2.2",
-        "maxVersion": "3.20.0"
+        "maxVersion": "3.21.0"
       }
     },
     "availableVersions": [
@@ -5209,10 +5232,11 @@
       "3.18.1",
       "3.19.0",
       "3.19.1",
-      "3.20.0"
+      "3.20.0",
+      "3.21.0"
     ],
     "minVersion": "0.2.2",
-    "maxVersion": "3.20.0",
+    "maxVersion": "3.21.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -5987,7 +6011,8 @@
         "4.19.18",
         "4.19.19",
         "4.19.20",
-        "4.19.21"
+        "4.19.21",
+        "4.19.22"
       ],
       "stable": [
         "4.12.0",
@@ -6031,7 +6056,7 @@
     "channelVersionRanges": {
       "candidate": {
         "minVersion": "4.19.1",
-        "maxVersion": "4.19.21"
+        "maxVersion": "4.19.22"
       },
       "stable": {
         "minVersion": "4.12.0",
@@ -6088,10 +6113,11 @@
       "4.19.18",
       "4.19.19",
       "4.19.20",
-      "4.19.21"
+      "4.19.21",
+      "4.19.22"
     ],
     "minVersion": "4.12.0",
-    "maxVersion": "4.19.21",
+    "maxVersion": "4.19.22",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -6483,7 +6509,8 @@
         "6.4.0",
         "6.4.1",
         "6.4.2",
-        "6.4.3"
+        "6.4.3",
+        "6.4.4"
       ],
       "stable-6.5": [
         "6.5.0"
@@ -6500,7 +6527,7 @@
       },
       "stable-6.4": {
         "minVersion": "6.4.0",
-        "maxVersion": "6.4.3"
+        "maxVersion": "6.4.4"
       },
       "stable-6.5": {
         "minVersion": "6.5.0",
@@ -6527,6 +6554,7 @@
       "6.4.1",
       "6.4.2",
       "6.4.3",
+      "6.4.4",
       "6.5.0"
     ],
     "minVersion": "6.2.0",
@@ -6922,7 +6950,8 @@
         "8.0.1"
       ],
       "stable-v8.1": [
-        "8.1.0"
+        "8.1.0",
+        "8.1.1"
       ]
     },
     "channelVersionRanges": {
@@ -6960,7 +6989,7 @@
       },
       "stable-v8.1": {
         "minVersion": "8.1.0",
-        "maxVersion": "8.1.0"
+        "maxVersion": "8.1.1"
       }
     },
     "availableVersions": [
@@ -6992,10 +7021,11 @@
       "7.3.2",
       "8.0.0",
       "8.0.1",
-      "8.1.0"
+      "8.1.0",
+      "8.1.1"
     ],
     "minVersion": "6.0.0",
-    "maxVersion": "8.1.0",
+    "maxVersion": "8.1.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -7145,7 +7175,7 @@
   },
   {
     "name": "mtv-operator",
-    "defaultChannel": "release-v2.10",
+    "defaultChannel": "release-v2.11",
     "channels": [
       "release-v2.10",
       "release-v2.11",
@@ -7165,7 +7195,8 @@
         "2.11.0",
         "2.11.1",
         "2.11.2",
-        "2.11.3"
+        "2.11.3",
+        "2.11.4"
       ],
       "release-v2.9": [
         "2.9.0",
@@ -7185,7 +7216,7 @@
       },
       "release-v2.11": {
         "minVersion": "2.11.0",
-        "maxVersion": "2.11.3"
+        "maxVersion": "2.11.4"
       },
       "release-v2.9": {
         "minVersion": "2.9.0",
@@ -7211,10 +7242,11 @@
       "2.11.0",
       "2.11.1",
       "2.11.2",
-      "2.11.3"
+      "2.11.3",
+      "2.11.4"
     ],
     "minVersion": "2.9.0",
-    "maxVersion": "2.11.3",
+    "maxVersion": "2.11.4",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -8791,7 +8823,8 @@
       "stable-v1.15",
       "stable-v1.16",
       "stable-v1.17",
-      "stable-v1.18"
+      "stable-v1.18",
+      "stable-v1.19"
     ],
     "channelVersions": {
       "stable-v1": [
@@ -8801,7 +8834,8 @@
         "1.16.1",
         "1.17.0",
         "1.18.0",
-        "1.18.1"
+        "1.18.1",
+        "1.19.0"
       ],
       "stable-v1.15": [
         "1.15.0",
@@ -8831,12 +8865,22 @@
         "1.17.0",
         "1.18.0",
         "1.18.1"
+      ],
+      "stable-v1.19": [
+        "1.15.0",
+        "1.15.1",
+        "1.16.0",
+        "1.16.1",
+        "1.17.0",
+        "1.18.0",
+        "1.18.1",
+        "1.19.0"
       ]
     },
     "channelVersionRanges": {
       "stable-v1": {
         "minVersion": "1.15.0",
-        "maxVersion": "1.18.1"
+        "maxVersion": "1.19.0"
       },
       "stable-v1.15": {
         "minVersion": "1.15.0",
@@ -8853,6 +8897,10 @@
       "stable-v1.18": {
         "minVersion": "1.15.0",
         "maxVersion": "1.18.1"
+      },
+      "stable-v1.19": {
+        "minVersion": "1.15.0",
+        "maxVersion": "1.19.0"
       }
     },
     "availableVersions": [
@@ -8865,10 +8913,11 @@
       "1.17.0",
       "1.17.1",
       "1.18.0",
-      "1.18.1"
+      "1.18.1",
+      "1.19.0"
     ],
     "minVersion": "1.15.0",
-    "maxVersion": "1.18.1",
+    "maxVersion": "1.19.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -9240,16 +9289,19 @@
         "1.18.1",
         "1.18.2",
         "1.18.3",
-        "1.18.4"
+        "1.18.4",
+        "1.18.5"
       ],
       "gitops-1.19": [
         "1.19.0",
         "1.19.1",
-        "1.19.2"
+        "1.19.2",
+        "1.19.3"
       ],
       "gitops-1.20": [
         "1.20.0",
-        "1.20.1"
+        "1.20.1",
+        "1.20.2"
       ],
       "gitops-1.6": [
         "1.5.2",
@@ -9370,7 +9422,8 @@
         "1.19.1",
         "1.19.2",
         "1.20.0",
-        "1.20.1"
+        "1.20.1",
+        "1.20.2"
       ]
     },
     "channelVersionRanges": {
@@ -9408,15 +9461,15 @@
       },
       "gitops-1.18": {
         "minVersion": "1.18.0",
-        "maxVersion": "1.18.4"
+        "maxVersion": "1.18.5"
       },
       "gitops-1.19": {
         "minVersion": "1.19.0",
-        "maxVersion": "1.19.2"
+        "maxVersion": "1.19.3"
       },
       "gitops-1.20": {
         "minVersion": "1.20.0",
-        "maxVersion": "1.20.1"
+        "maxVersion": "1.20.2"
       },
       "gitops-1.6": {
         "minVersion": "1.5.2",
@@ -9436,7 +9489,7 @@
       },
       "latest": {
         "minVersion": "1.5.2",
-        "maxVersion": "1.20.1"
+        "maxVersion": "1.20.2"
       }
     },
     "availableVersions": [
@@ -9532,14 +9585,17 @@
       "1.18.2",
       "1.18.3",
       "1.18.4",
+      "1.18.5",
       "1.19.0",
       "1.19.1",
       "1.19.2",
+      "1.19.3",
       "1.20.0",
-      "1.20.1"
+      "1.20.1",
+      "1.20.2"
     ],
     "minVersion": "1.5.2",
-    "maxVersion": "1.20.1",
+    "maxVersion": "1.20.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -9556,7 +9612,8 @@
       "pipelines-1.18",
       "pipelines-1.19",
       "pipelines-1.20",
-      "pipelines-1.21"
+      "pipelines-1.21",
+      "pipelines-1.22"
     ],
     "channelVersions": {
       "latest": [
@@ -9591,8 +9648,10 @@
         "1.20.1",
         "1.20.2",
         "1.20.3",
+        "1.20.4",
         "1.21.0",
-        "1.21.1"
+        "1.21.1",
+        "1.22.0"
       ],
       "pipelines-1.14": [
         "1.14.0",
@@ -9637,17 +9696,21 @@
         "1.20.0",
         "1.20.1",
         "1.20.2",
-        "1.20.3"
+        "1.20.3",
+        "1.20.4"
       ],
       "pipelines-1.21": [
         "1.21.0",
         "1.21.1"
+      ],
+      "pipelines-1.22": [
+        "1.22.0"
       ]
     },
     "channelVersionRanges": {
       "latest": {
         "minVersion": "1.14.0",
-        "maxVersion": "1.21.1"
+        "maxVersion": "1.22.0"
       },
       "pipelines-1.14": {
         "minVersion": "1.14.0",
@@ -9675,11 +9738,15 @@
       },
       "pipelines-1.20": {
         "minVersion": "1.20.0",
-        "maxVersion": "1.20.3"
+        "maxVersion": "1.20.4"
       },
       "pipelines-1.21": {
         "minVersion": "1.21.0",
         "maxVersion": "1.21.1"
+      },
+      "pipelines-1.22": {
+        "minVersion": "1.22.0",
+        "maxVersion": "1.22.0"
       }
     },
     "availableVersions": [
@@ -9714,11 +9781,13 @@
       "1.20.1",
       "1.20.2",
       "1.20.3",
+      "1.20.4",
       "1.21.0",
-      "1.21.1"
+      "1.21.1",
+      "1.22.0"
     ],
     "minVersion": "1.14.0",
-    "maxVersion": "1.21.1",
+    "maxVersion": "1.22.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -9850,13 +9919,14 @@
         "0.135.0-1",
         "0.140.0-1",
         "0.140.0-2",
-        "0.144.0-1"
+        "0.144.0-1",
+        "0.144.0-2"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.56.0-1",
-        "maxVersion": "0.144.0-1"
+        "maxVersion": "0.144.0-2"
       }
     },
     "availableVersions": [
@@ -9883,10 +9953,11 @@
       "0.135.0-1",
       "0.140.0-1",
       "0.140.0-2",
-      "0.144.0-1"
+      "0.144.0-1",
+      "0.144.0-2"
     ],
     "minVersion": "0.56.0-1",
-    "maxVersion": "0.144.0-1",
+    "maxVersion": "0.144.0-2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -13088,6 +13159,7 @@
         "1.8.3",
         "1.8.4",
         "1.8.5",
+        "1.8.6",
         "1.9.0",
         "1.9.1",
         "1.9.2",
@@ -13146,7 +13218,8 @@
         "1.8.2",
         "1.8.3",
         "1.8.4",
-        "1.8.5"
+        "1.8.5",
+        "1.8.6"
       ],
       "fast-1.9": [
         "1.9.0",
@@ -13190,7 +13263,7 @@
       },
       "fast-1.8": {
         "minVersion": "1.8.0",
-        "maxVersion": "1.8.5"
+        "maxVersion": "1.8.6"
       },
       "fast-1.9": {
         "minVersion": "1.9.0",
@@ -13233,6 +13306,7 @@
       "1.8.3",
       "1.8.4",
       "1.8.5",
+      "1.8.6",
       "1.9.0",
       "1.9.1",
       "1.9.2",
@@ -13321,10 +13395,11 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "beta": [
-        "3.4.0-ea.1"
+        "3.4.0-ea.2"
       ],
       "embedded": [
         "1.20.1-8",
@@ -13429,7 +13504,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "eus-2.8": [
         "1.20.1-8",
@@ -13507,7 +13583,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "fast-3.x": [
         "3.0.0",
@@ -13561,7 +13638,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "stable-2.10": [
         "1.20.1-8",
@@ -13793,7 +13871,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "stable-2.8": [
         "1.20.1-8",
@@ -13844,11 +13923,11 @@
       },
       "alpha": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "beta": {
-        "minVersion": "3.4.0-ea.1",
-        "maxVersion": "3.4.0-ea.1"
+        "minVersion": "3.4.0-ea.2",
+        "maxVersion": "3.4.0-ea.2"
       },
       "embedded": {
         "minVersion": "1.20.1-8",
@@ -13860,7 +13939,7 @@
       },
       "eus-2.25": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "eus-2.8": {
         "minVersion": "1.20.1-8",
@@ -13868,7 +13947,7 @@
       },
       "fast": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "fast-3.x": {
         "minVersion": "3.0.0",
@@ -13876,7 +13955,7 @@
       },
       "stable": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "stable-2.10": {
         "minVersion": "1.20.1-8",
@@ -13900,7 +13979,7 @@
       },
       "stable-2.25": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "stable-2.8": {
         "minVersion": "1.20.1-8",
@@ -13983,16 +14062,17 @@
       "2.25.2",
       "2.25.3",
       "2.25.4",
+      "2.25.5",
       "3.0.0",
       "3.2.0",
       "3.2.1",
       "3.3.0",
       "3.3.1",
       "3.3.2",
-      "3.4.0-ea.1"
+      "3.4.0-ea.2"
     ],
     "minVersion": "1.20.1-8",
-    "maxVersion": "3.4.0-ea.1",
+    "maxVersion": "3.4.0-ea.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -14268,6 +14348,7 @@
         "1.3.1",
         "1.3.2",
         "1.3.3",
+        "1.3.4",
         "1.4.0"
       ],
       "stable-v1.1": [
@@ -14284,7 +14365,8 @@
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.3.3"
+        "1.3.3",
+        "1.3.4"
       ],
       "stable-v1.4": [
         "1.4.0"
@@ -14305,7 +14387,7 @@
       },
       "stable-v1.3": {
         "minVersion": "1.3.0",
-        "maxVersion": "1.3.3"
+        "maxVersion": "1.3.4"
       },
       "stable-v1.4": {
         "minVersion": "1.4.0",
@@ -14323,6 +14405,7 @@
       "1.3.1",
       "1.3.2",
       "1.3.3",
+      "1.3.4",
       "1.4.0"
     ],
     "minVersion": "1.1.0",
@@ -14354,7 +14437,8 @@
         "1.1.0",
         "1.1.1",
         "1.1.2",
-        "1.1.3"
+        "1.1.3",
+        "1.1.4"
       ]
     },
     "channelVersionRanges": {
@@ -14368,7 +14452,7 @@
       },
       "stable-v1.1": {
         "minVersion": "1.1.0",
-        "maxVersion": "1.1.3"
+        "maxVersion": "1.1.4"
       }
     },
     "availableVersions": [
@@ -14378,10 +14462,11 @@
       "1.1.0",
       "1.1.1",
       "1.1.2",
-      "1.1.3"
+      "1.1.3",
+      "1.1.4"
     ],
     "minVersion": "1.0.0",
-    "maxVersion": "1.1.3",
+    "maxVersion": "1.1.4",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -14544,21 +14629,23 @@
     "channelVersions": {
       "stable": [
         "1.0.0",
-        "1.0.1"
+        "1.0.1",
+        "1.0.2"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.0.0",
-        "maxVersion": "1.0.1"
+        "maxVersion": "1.0.2"
       }
     },
     "availableVersions": [
       "1.0.0",
-      "1.0.1"
+      "1.0.1",
+      "1.0.2"
     ],
     "minVersion": "1.0.0",
-    "maxVersion": "1.0.1",
+    "maxVersion": "1.0.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -15463,6 +15550,7 @@
         "3.0.7",
         "3.0.8",
         "3.0.9",
+        "3.0.10",
         "3.1.0",
         "3.1.1",
         "3.1.2",
@@ -15470,12 +15558,15 @@
         "3.1.4",
         "3.1.5",
         "3.1.6",
+        "3.1.7",
         "3.2.0",
         "3.2.1",
         "3.2.2",
         "3.2.3",
+        "3.2.4",
         "3.3.0",
-        "3.3.1"
+        "3.3.1",
+        "3.3.2"
       ],
       "stable-3.0": [
         "3.0.0",
@@ -15487,7 +15578,8 @@
         "3.0.6",
         "3.0.7",
         "3.0.8",
-        "3.0.9"
+        "3.0.9",
+        "3.0.10"
       ],
       "stable-3.1": [
         "3.1.0",
@@ -15496,17 +15588,20 @@
         "3.1.3",
         "3.1.4",
         "3.1.5",
-        "3.1.6"
+        "3.1.6",
+        "3.1.7"
       ],
       "stable-3.2": [
         "3.2.0",
         "3.2.1",
         "3.2.2",
-        "3.2.3"
+        "3.2.3",
+        "3.2.4"
       ],
       "stable-3.3": [
         "3.3.0",
-        "3.3.1"
+        "3.3.1",
+        "3.3.2"
       ]
     },
     "channelVersionRanges": {
@@ -15516,23 +15611,23 @@
       },
       "stable": {
         "minVersion": "3.0.0",
-        "maxVersion": "3.3.1"
+        "maxVersion": "3.3.2"
       },
       "stable-3.0": {
         "minVersion": "3.0.0",
-        "maxVersion": "3.0.9"
+        "maxVersion": "3.0.10"
       },
       "stable-3.1": {
         "minVersion": "3.1.0",
-        "maxVersion": "3.1.6"
+        "maxVersion": "3.1.7"
       },
       "stable-3.2": {
         "minVersion": "3.2.0",
-        "maxVersion": "3.2.3"
+        "maxVersion": "3.2.4"
       },
       "stable-3.3": {
         "minVersion": "3.3.0",
-        "maxVersion": "3.3.1"
+        "maxVersion": "3.3.2"
       }
     },
     "availableVersions": [
@@ -15548,6 +15643,7 @@
       "3.0.7",
       "3.0.8",
       "3.0.9",
+      "3.0.10",
       "3.1.0",
       "3.1.1",
       "3.1.2",
@@ -15555,15 +15651,18 @@
       "3.1.4",
       "3.1.5",
       "3.1.6",
+      "3.1.7",
       "3.2.0",
       "3.2.1",
       "3.2.2",
       "3.2.3",
+      "3.2.4",
       "3.3.0",
-      "3.3.1"
+      "3.3.1",
+      "3.3.2"
     ],
     "minVersion": "3.0.0",
-    "maxVersion": "3.3.1",
+    "maxVersion": "3.3.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"
@@ -16160,13 +16259,14 @@
         "0.19.0-2",
         "0.19.0-3",
         "0.20.0-1",
-        "0.20.0-2"
+        "0.20.0-2",
+        "0.20.0-3"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.1.0-6",
-        "maxVersion": "0.20.0-2"
+        "maxVersion": "0.20.0-3"
       }
     },
     "availableVersions": [
@@ -16193,10 +16293,11 @@
       "0.19.0-2",
       "0.19.0-3",
       "0.20.0-1",
-      "0.20.0-2"
+      "0.20.0-2",
+      "0.20.0-3"
     ],
     "minVersion": "0.1.0-6",
-    "maxVersion": "0.20.0-2",
+    "maxVersion": "0.20.0-3",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.19",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.19"

--- a/catalog-data/redhat-operator-index/v4.20/catalog-info.json
+++ b/catalog-data/redhat-operator-index/v4.20/catalog-info.json
@@ -2,5 +2,5 @@
   "catalog_type": "redhat-operator-index",
   "ocp_version": "v4.20",
   "catalog_url": "registry.redhat.io/redhat/redhat-operator-index:v4.20",
-  "operator_count": 149
+  "operator_count": 150
 }

--- a/catalog-data/redhat-operator-index/v4.20/operators.json
+++ b/catalog-data/redhat-operator-index/v4.20/operators.json
@@ -1809,13 +1809,14 @@
         "4.20.0-202602170320",
         "4.20.0-202603040216",
         "4.20.0-202603110559",
-        "4.20.0-202604010054"
+        "4.20.0-202604010054",
+        "4.20.0-202604140241"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.20.0-202509262039",
-        "maxVersion": "4.20.0-202604010054"
+        "maxVersion": "4.20.0-202604140241"
       }
     },
     "availableVersions": [
@@ -1833,10 +1834,11 @@
       "4.20.0-202602170320",
       "4.20.0-202603040216",
       "4.20.0-202603110559",
-      "4.20.0-202604010054"
+      "4.20.0-202604010054",
+      "4.20.0-202604140241"
     ],
     "minVersion": "4.20.0-202509262039",
-    "maxVersion": "4.20.0-202604010054",
+    "maxVersion": "4.20.0-202604140241",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -2440,7 +2442,8 @@
         "6.4.0",
         "6.4.1",
         "6.4.2",
-        "6.4.3"
+        "6.4.3",
+        "6.4.4"
       ],
       "stable-6.5": [
         "6.5.0"
@@ -2457,7 +2460,7 @@
       },
       "stable-6.4": {
         "minVersion": "6.4.0",
-        "maxVersion": "6.4.3"
+        "maxVersion": "6.4.4"
       },
       "stable-6.5": {
         "minVersion": "6.5.0",
@@ -2484,6 +2487,7 @@
       "6.4.1",
       "6.4.2",
       "6.4.3",
+      "6.4.4",
       "6.5.0"
     ],
     "minVersion": "6.2.0",
@@ -2554,13 +2558,14 @@
         "4.20.0-202601292039",
         "4.20.0-202602091941",
         "4.20.0-202602261925",
-        "4.20.0-202603271717"
+        "4.20.0-202603271717",
+        "4.20.0-202604140241"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.20.0-202509262039",
-        "maxVersion": "4.20.0-202603271717"
+        "maxVersion": "4.20.0-202604140241"
       }
     },
     "availableVersions": [
@@ -2576,10 +2581,11 @@
       "4.20.0-202601292039",
       "4.20.0-202602091941",
       "4.20.0-202602261925",
-      "4.20.0-202603271717"
+      "4.20.0-202603271717",
+      "4.20.0-202604140241"
     ],
     "minVersion": "4.20.0-202509262039",
-    "maxVersion": "4.20.0-202603271717",
+    "maxVersion": "4.20.0-202604140241",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -3093,13 +3099,14 @@
         "4.1.0",
         "4.2.0",
         "4.3.0",
-        "4.3.1"
+        "4.3.1",
+        "4.4.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.0.0",
-        "maxVersion": "4.3.1"
+        "maxVersion": "4.4.0"
       }
     },
     "availableVersions": [
@@ -3127,10 +3134,11 @@
       "4.1.0",
       "4.2.0",
       "4.3.0",
-      "4.3.1"
+      "4.3.1",
+      "4.4.0"
     ],
     "minVersion": "1.0.0",
-    "maxVersion": "4.3.1",
+    "maxVersion": "4.4.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -3468,6 +3476,46 @@
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
   },
   {
+    "name": "deployment-validation-operator",
+    "defaultChannel": "alpha",
+    "channels": [
+      "alpha"
+    ],
+    "channelVersions": {
+      "alpha": [
+        "0.7.5",
+        "0.7.8",
+        "0.7.9",
+        "0.7.11",
+        "0.7.12",
+        "0.7.13",
+        "0.7.14",
+        "0.7.15"
+      ]
+    },
+    "channelVersionRanges": {
+      "alpha": {
+        "minVersion": "0.7.5",
+        "maxVersion": "0.7.15"
+      }
+    },
+    "availableVersions": [
+      "0.7.5",
+      "0.7.8",
+      "0.7.9",
+      "0.7.11",
+      "0.7.12",
+      "0.7.13",
+      "0.7.14",
+      "0.7.15"
+    ],
+    "minVersion": "0.7.5",
+    "maxVersion": "0.7.15",
+    "catalog": "redhat-operator-index",
+    "ocpVersion": "v4.20",
+    "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
+  },
+  {
     "name": "devspaces",
     "defaultChannel": "stable",
     "channels": [
@@ -3517,13 +3565,14 @@
         "3.25.0",
         "3.26.0",
         "3.26.1",
-        "3.27.0"
+        "3.27.0",
+        "3.27.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "3.3.0",
-        "maxVersion": "3.27.0"
+        "maxVersion": "3.27.1"
       }
     },
     "availableVersions": [
@@ -3569,10 +3618,11 @@
       "3.25.0",
       "3.26.0",
       "3.26.1",
-      "3.27.0"
+      "3.27.0",
+      "3.27.1"
     ],
     "minVersion": "3.3.0",
-    "maxVersion": "3.27.0",
+    "maxVersion": "3.27.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -3628,13 +3678,14 @@
         "0.37.0",
         "0.38.0",
         "0.39.0",
-        "0.40.0"
+        "0.40.0",
+        "0.40.1"
       ]
     },
     "channelVersionRanges": {
       "fast": {
         "minVersion": "0.9.0",
-        "maxVersion": "0.40.0"
+        "maxVersion": "0.40.1"
       }
     },
     "availableVersions": [
@@ -3681,10 +3732,11 @@
       "0.37.0",
       "0.38.0",
       "0.39.0",
-      "0.40.0"
+      "0.40.0",
+      "0.40.1"
     ],
     "minVersion": "0.9.0",
-    "maxVersion": "0.40.0",
+    "maxVersion": "0.40.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -3769,13 +3821,14 @@
         "4.20.0-202601292039",
         "4.20.0-202602100650",
         "4.20.0-202602261925",
-        "4.20.0-202604010919"
+        "4.20.0-202604010919",
+        "4.20.0-202604150517"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.20.0-202509262039",
-        "maxVersion": "4.20.0-202604010919"
+        "maxVersion": "4.20.0-202604150517"
       }
     },
     "availableVersions": [
@@ -3791,10 +3844,11 @@
       "4.20.0-202601292039",
       "4.20.0-202602100650",
       "4.20.0-202602261925",
-      "4.20.0-202604010919"
+      "4.20.0-202604010919",
+      "4.20.0-202604150517"
     ],
     "minVersion": "4.20.0-202509262039",
-    "maxVersion": "4.20.0-202604010919",
+    "maxVersion": "4.20.0-202604150517",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -4232,7 +4286,8 @@
         "7.13.0+0.1774370015.p",
         "7.13.0+0.1775139554.p",
         "7.13.0+0.1775735859.p",
-        "7.13.0+0.1776065698.p"
+        "7.13.0+0.1776065698.p",
+        "7.13.0+0.1776378942.p"
       ],
       "fuse-apicurito-7.9.x": [
         "7.9.3"
@@ -4253,7 +4308,7 @@
       },
       "fuse-apicurito-7.13.x": {
         "minVersion": "7.9.3",
-        "maxVersion": "7.13.0+0.1776065698.p"
+        "maxVersion": "7.13.0+0.1776378942.p"
       },
       "fuse-apicurito-7.9.x": {
         "minVersion": "7.9.3",
@@ -4333,10 +4388,11 @@
       "7.13.0+0.1774370015.p",
       "7.13.0+0.1775139554.p",
       "7.13.0+0.1775735859.p",
-      "7.13.0+0.1776065698.p"
+      "7.13.0+0.1776065698.p",
+      "7.13.0+0.1776378942.p"
     ],
     "minVersion": "7.9.3",
-    "maxVersion": "7.13.0+0.1776065698.p",
+    "maxVersion": "7.13.0+0.1776378942.p",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -4404,7 +4460,8 @@
         "7.13.0+0.1771828310.p",
         "7.13.0+0.1773829909.p",
         "7.13.0+0.1775139556.p",
-        "7.13.0+0.1776065698.p"
+        "7.13.0+0.1776065698.p",
+        "7.13.0+0.1776378943.p"
       ],
       "7.9.x": [
         "7.9.0"
@@ -4425,7 +4482,7 @@
       },
       "7.13.x": {
         "minVersion": "7.12.1",
-        "maxVersion": "7.13.0+0.1776065698.p"
+        "maxVersion": "7.13.0+0.1776378943.p"
       },
       "7.9.x": {
         "minVersion": "7.9.0",
@@ -4478,10 +4535,11 @@
       "7.13.0+0.1771828310.p",
       "7.13.0+0.1773829909.p",
       "7.13.0+0.1775139556.p",
-      "7.13.0+0.1776065698.p"
+      "7.13.0+0.1776065698.p",
+      "7.13.0+0.1776378943.p"
     ],
     "minVersion": "7.9.0",
-    "maxVersion": "7.13.0+0.1776065698.p",
+    "maxVersion": "7.13.0+0.1776378943.p",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -4776,6 +4834,7 @@
       "3.18",
       "3.19",
       "3.20",
+      "3.21",
       "stable"
     ],
     "channelVersions": {
@@ -4805,6 +4864,9 @@
       "3.20": [
         "3.20.0"
       ],
+      "3.21": [
+        "3.21.0"
+      ],
       "stable": [
         "3.15.1",
         "3.15.1+0.1725401534.p",
@@ -4816,7 +4878,8 @@
         "3.18.0",
         "3.19.0",
         "3.19.1",
-        "3.20.0"
+        "3.20.0",
+        "3.21.0"
       ]
     },
     "channelVersionRanges": {
@@ -4840,9 +4903,13 @@
         "minVersion": "3.20.0",
         "maxVersion": "3.20.0"
       },
+      "3.21": {
+        "minVersion": "3.21.0",
+        "maxVersion": "3.21.0"
+      },
       "stable": {
         "minVersion": "3.15.1",
-        "maxVersion": "3.20.0"
+        "maxVersion": "3.21.0"
       }
     },
     "availableVersions": [
@@ -4861,10 +4928,11 @@
       "3.18.1",
       "3.19.0",
       "3.19.1",
-      "3.20.0"
+      "3.20.0",
+      "3.21.0"
     ],
     "minVersion": "3.15.1",
-    "maxVersion": "3.20.0",
+    "maxVersion": "3.21.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -4890,13 +4958,14 @@
         "4.20.0-202602091941",
         "4.20.0-202602261925",
         "4.20.0-202603052148",
-        "4.20.0-202603272224"
+        "4.20.0-202603272224",
+        "4.20.0-202604140241"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.20.0-202509262039",
-        "maxVersion": "4.20.0-202603272224"
+        "maxVersion": "4.20.0-202604140241"
       }
     },
     "availableVersions": [
@@ -4913,10 +4982,11 @@
       "4.20.0-202602091941",
       "4.20.0-202602261925",
       "4.20.0-202603052148",
-      "4.20.0-202603272224"
+      "4.20.0-202603272224",
+      "4.20.0-202604140241"
     ],
     "minVersion": "4.20.0-202509262039",
-    "maxVersion": "4.20.0-202603272224",
+    "maxVersion": "4.20.0-202604140241",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -4941,13 +5011,14 @@
         "4.20.0-202601292039",
         "4.20.0-202602091941",
         "4.20.0-202602261925",
-        "4.20.0-202603271717"
+        "4.20.0-202603271717",
+        "4.20.0-202604140241"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.20.0-202509262039",
-        "maxVersion": "4.20.0-202603271717"
+        "maxVersion": "4.20.0-202604140241"
       }
     },
     "availableVersions": [
@@ -4963,10 +5034,11 @@
       "4.20.0-202601292039",
       "4.20.0-202602091941",
       "4.20.0-202602261925",
-      "4.20.0-202603271717"
+      "4.20.0-202603271717",
+      "4.20.0-202604140241"
     ],
     "minVersion": "4.20.0-202509262039",
-    "maxVersion": "4.20.0-202603271717",
+    "maxVersion": "4.20.0-202604140241",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -5523,13 +5595,14 @@
         "4.20.0-202601292039",
         "4.20.0-202602180432",
         "4.20.0-202602261925",
-        "4.20.0-202603271717"
+        "4.20.0-202603271717",
+        "4.20.0-202604140241"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.20.0-202510151915",
-        "maxVersion": "4.20.0-202603271717"
+        "maxVersion": "4.20.0-202604140241"
       }
     },
     "availableVersions": [
@@ -5546,10 +5619,11 @@
       "4.20.0-202601292039",
       "4.20.0-202602180432",
       "4.20.0-202602261925",
-      "4.20.0-202603271717"
+      "4.20.0-202603271717",
+      "4.20.0-202604140241"
     ],
     "minVersion": "4.20.0-202510151915",
-    "maxVersion": "4.20.0-202603271717",
+    "maxVersion": "4.20.0-202604140241",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -5613,7 +5687,8 @@
         "4.20.1",
         "4.20.3",
         "4.20.7",
-        "4.20.8"
+        "4.20.8",
+        "4.20.11"
       ]
     },
     "channelVersionRanges": {
@@ -5623,7 +5698,7 @@
       },
       "stable": {
         "minVersion": "4.12.0",
-        "maxVersion": "4.20.8"
+        "maxVersion": "4.20.11"
       }
     },
     "availableVersions": [
@@ -5888,13 +5963,14 @@
         "4.20.0-202602032049",
         "4.20.0-202602091941",
         "4.20.0-202603030647",
-        "4.20.0-202603272224"
+        "4.20.0-202603272224",
+        "4.20.0-202604140241"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.20.0-202509262224",
-        "maxVersion": "4.20.0-202603272224"
+        "maxVersion": "4.20.0-202604140241"
       }
     },
     "availableVersions": [
@@ -5910,10 +5986,11 @@
       "4.20.0-202602032049",
       "4.20.0-202602091941",
       "4.20.0-202603030647",
-      "4.20.0-202603272224"
+      "4.20.0-202603272224",
+      "4.20.0-202604140241"
     ],
     "minVersion": "4.20.0-202509262224",
-    "maxVersion": "4.20.0-202603272224",
+    "maxVersion": "4.20.0-202604140241",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -6015,7 +6092,8 @@
         "6.4.0",
         "6.4.1",
         "6.4.2",
-        "6.4.3"
+        "6.4.3",
+        "6.4.4"
       ],
       "stable-6.5": [
         "6.5.0"
@@ -6032,7 +6110,7 @@
       },
       "stable-6.4": {
         "minVersion": "6.4.0",
-        "maxVersion": "6.4.3"
+        "maxVersion": "6.4.4"
       },
       "stable-6.5": {
         "minVersion": "6.5.0",
@@ -6059,6 +6137,7 @@
       "6.4.1",
       "6.4.2",
       "6.4.3",
+      "6.4.4",
       "6.5.0"
     ],
     "minVersion": "6.2.0",
@@ -6237,13 +6316,14 @@
         "4.20.0-202602091941",
         "4.20.0-202602261925",
         "4.20.0-202603152019",
-        "4.20.0-202603271717"
+        "4.20.0-202603271717",
+        "4.20.0-202604140241"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.20.0-202509271248",
-        "maxVersion": "4.20.0-202603271717"
+        "maxVersion": "4.20.0-202604140241"
       }
     },
     "availableVersions": [
@@ -6261,10 +6341,11 @@
       "4.20.0-202602091941",
       "4.20.0-202602261925",
       "4.20.0-202603152019",
-      "4.20.0-202603271717"
+      "4.20.0-202603271717",
+      "4.20.0-202604140241"
     ],
     "minVersion": "4.20.0-202509271248",
-    "maxVersion": "4.20.0-202603271717",
+    "maxVersion": "4.20.0-202604140241",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -6361,7 +6442,8 @@
         "8.0.1"
       ],
       "stable-v8.1": [
-        "8.1.0"
+        "8.1.0",
+        "8.1.1"
       ]
     },
     "channelVersionRanges": {
@@ -6399,7 +6481,7 @@
       },
       "stable-v8.1": {
         "minVersion": "8.1.0",
-        "maxVersion": "8.1.0"
+        "maxVersion": "8.1.1"
       }
     },
     "availableVersions": [
@@ -6431,10 +6513,11 @@
       "7.3.2",
       "8.0.0",
       "8.0.1",
-      "8.1.0"
+      "8.1.0",
+      "8.1.1"
     ],
     "minVersion": "6.0.0",
-    "maxVersion": "8.1.0",
+    "maxVersion": "8.1.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -6580,7 +6663,7 @@
   },
   {
     "name": "mtv-operator",
-    "defaultChannel": "release-v2.10",
+    "defaultChannel": "release-v2.11",
     "channels": [
       "release-v2.10",
       "release-v2.11"
@@ -6599,7 +6682,8 @@
         "2.11.0",
         "2.11.1",
         "2.11.2",
-        "2.11.3"
+        "2.11.3",
+        "2.11.4"
       ]
     },
     "channelVersionRanges": {
@@ -6609,7 +6693,7 @@
       },
       "release-v2.11": {
         "minVersion": "2.11.0",
-        "maxVersion": "2.11.3"
+        "maxVersion": "2.11.4"
       }
     },
     "availableVersions": [
@@ -6623,10 +6707,11 @@
       "2.11.0",
       "2.11.1",
       "2.11.2",
-      "2.11.3"
+      "2.11.3",
+      "2.11.4"
     ],
     "minVersion": "2.10.0",
-    "maxVersion": "2.11.3",
+    "maxVersion": "2.11.4",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -6858,13 +6943,14 @@
         "4.20.0-202602091941",
         "4.20.0-202602261925",
         "4.20.0-202603051149",
-        "4.20.0-202603272224"
+        "4.20.0-202603272224",
+        "4.20.0-202604140241"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.20.0-202509262039",
-        "maxVersion": "4.20.0-202603272224"
+        "maxVersion": "4.20.0-202604140241"
       }
     },
     "availableVersions": [
@@ -6881,10 +6967,11 @@
       "4.20.0-202602091941",
       "4.20.0-202602261925",
       "4.20.0-202603051149",
-      "4.20.0-202603272224"
+      "4.20.0-202603272224",
+      "4.20.0-202604140241"
     ],
     "minVersion": "4.20.0-202509262039",
-    "maxVersion": "4.20.0-202603272224",
+    "maxVersion": "4.20.0-202604140241",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -7885,13 +7972,15 @@
     "channels": [
       "stable-v1",
       "stable-v1.17",
-      "stable-v1.18"
+      "stable-v1.18",
+      "stable-v1.19"
     ],
     "channelVersions": {
       "stable-v1": [
         "1.17.0",
         "1.18.0",
-        "1.18.1"
+        "1.18.1",
+        "1.19.0"
       ],
       "stable-v1.17": [
         "1.17.0",
@@ -7901,12 +7990,18 @@
         "1.17.0",
         "1.18.0",
         "1.18.1"
+      ],
+      "stable-v1.19": [
+        "1.17.0",
+        "1.18.0",
+        "1.18.1",
+        "1.19.0"
       ]
     },
     "channelVersionRanges": {
       "stable-v1": {
         "minVersion": "1.17.0",
-        "maxVersion": "1.18.1"
+        "maxVersion": "1.19.0"
       },
       "stable-v1.17": {
         "minVersion": "1.17.0",
@@ -7915,16 +8010,21 @@
       "stable-v1.18": {
         "minVersion": "1.17.0",
         "maxVersion": "1.18.1"
+      },
+      "stable-v1.19": {
+        "minVersion": "1.17.0",
+        "maxVersion": "1.19.0"
       }
     },
     "availableVersions": [
       "1.17.0",
       "1.17.1",
       "1.18.0",
-      "1.18.1"
+      "1.18.1",
+      "1.19.0"
     ],
     "minVersion": "1.17.0",
-    "maxVersion": "1.18.1",
+    "maxVersion": "1.19.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -8297,16 +8397,19 @@
         "1.18.1",
         "1.18.2",
         "1.18.3",
-        "1.18.4"
+        "1.18.4",
+        "1.18.5"
       ],
       "gitops-1.19": [
         "1.19.0",
         "1.19.1",
-        "1.19.2"
+        "1.19.2",
+        "1.19.3"
       ],
       "gitops-1.20": [
         "1.20.0",
-        "1.20.1"
+        "1.20.1",
+        "1.20.2"
       ],
       "gitops-1.6": [
         "1.5.2",
@@ -8427,7 +8530,8 @@
         "1.19.1",
         "1.19.2",
         "1.20.0",
-        "1.20.1"
+        "1.20.1",
+        "1.20.2"
       ]
     },
     "channelVersionRanges": {
@@ -8465,15 +8569,15 @@
       },
       "gitops-1.18": {
         "minVersion": "1.18.0",
-        "maxVersion": "1.18.4"
+        "maxVersion": "1.18.5"
       },
       "gitops-1.19": {
         "minVersion": "1.19.0",
-        "maxVersion": "1.19.2"
+        "maxVersion": "1.19.3"
       },
       "gitops-1.20": {
         "minVersion": "1.20.0",
-        "maxVersion": "1.20.1"
+        "maxVersion": "1.20.2"
       },
       "gitops-1.6": {
         "minVersion": "1.5.2",
@@ -8493,7 +8597,7 @@
       },
       "latest": {
         "minVersion": "1.5.2",
-        "maxVersion": "1.20.1"
+        "maxVersion": "1.20.2"
       }
     },
     "availableVersions": [
@@ -8589,14 +8693,17 @@
       "1.18.2",
       "1.18.3",
       "1.18.4",
+      "1.18.5",
       "1.19.0",
       "1.19.1",
       "1.19.2",
+      "1.19.3",
       "1.20.0",
-      "1.20.1"
+      "1.20.1",
+      "1.20.2"
     ],
     "minVersion": "1.5.2",
-    "maxVersion": "1.20.1",
+    "maxVersion": "1.20.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -8613,7 +8720,8 @@
       "pipelines-1.18",
       "pipelines-1.19",
       "pipelines-1.20",
-      "pipelines-1.21"
+      "pipelines-1.21",
+      "pipelines-1.22"
     ],
     "channelVersions": {
       "latest": [
@@ -8648,8 +8756,10 @@
         "1.20.1",
         "1.20.2",
         "1.20.3",
+        "1.20.4",
         "1.21.0",
-        "1.21.1"
+        "1.21.1",
+        "1.22.0"
       ],
       "pipelines-1.14": [
         "1.14.0",
@@ -8694,17 +8804,21 @@
         "1.20.0",
         "1.20.1",
         "1.20.2",
-        "1.20.3"
+        "1.20.3",
+        "1.20.4"
       ],
       "pipelines-1.21": [
         "1.21.0",
         "1.21.1"
+      ],
+      "pipelines-1.22": [
+        "1.22.0"
       ]
     },
     "channelVersionRanges": {
       "latest": {
         "minVersion": "1.14.0",
-        "maxVersion": "1.21.1"
+        "maxVersion": "1.22.0"
       },
       "pipelines-1.14": {
         "minVersion": "1.14.0",
@@ -8732,11 +8846,15 @@
       },
       "pipelines-1.20": {
         "minVersion": "1.20.0",
-        "maxVersion": "1.20.3"
+        "maxVersion": "1.20.4"
       },
       "pipelines-1.21": {
         "minVersion": "1.21.0",
         "maxVersion": "1.21.1"
+      },
+      "pipelines-1.22": {
+        "minVersion": "1.22.0",
+        "maxVersion": "1.22.0"
       }
     },
     "availableVersions": [
@@ -8771,11 +8889,13 @@
       "1.20.1",
       "1.20.2",
       "1.20.3",
+      "1.20.4",
       "1.21.0",
-      "1.21.1"
+      "1.21.1",
+      "1.22.0"
     ],
     "minVersion": "1.14.0",
-    "maxVersion": "1.21.1",
+    "maxVersion": "1.22.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -8887,13 +9007,14 @@
         "0.135.0-1",
         "0.140.0-1",
         "0.140.0-2",
-        "0.144.0-1"
+        "0.144.0-1",
+        "0.144.0-2"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.56.0-1",
-        "maxVersion": "0.144.0-1"
+        "maxVersion": "0.144.0-2"
       }
     },
     "availableVersions": [
@@ -8920,10 +9041,11 @@
       "0.135.0-1",
       "0.140.0-1",
       "0.140.0-2",
-      "0.144.0-1"
+      "0.144.0-1",
+      "0.144.0-2"
     ],
     "minVersion": "0.56.0-1",
-    "maxVersion": "0.144.0-1",
+    "maxVersion": "0.144.0-2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -8948,13 +9070,14 @@
         "4.20.0-202601292039",
         "4.20.0-202602091941",
         "4.20.0-202602261925",
-        "4.20.0-202603271717"
+        "4.20.0-202603271717",
+        "4.20.0-202604140241"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.20.0-202509262039",
-        "maxVersion": "4.20.0-202603271717"
+        "maxVersion": "4.20.0-202604140241"
       }
     },
     "availableVersions": [
@@ -8970,10 +9093,11 @@
       "4.20.0-202601292039",
       "4.20.0-202602091941",
       "4.20.0-202602261925",
-      "4.20.0-202603271717"
+      "4.20.0-202603271717",
+      "4.20.0-202604140241"
     ],
     "minVersion": "4.20.0-202509262039",
-    "maxVersion": "4.20.0-202603271717",
+    "maxVersion": "4.20.0-202604140241",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -9079,13 +9203,14 @@
         "4.20.0-202602161753",
         "4.20.0-202603030647",
         "4.20.0-202603160950",
-        "4.20.0-202603272224"
+        "4.20.0-202603272224",
+        "4.20.0-202604141324"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.20.0-202509262039",
-        "maxVersion": "4.20.0-202603272224"
+        "maxVersion": "4.20.0-202604141324"
       }
     },
     "availableVersions": [
@@ -9103,10 +9228,11 @@
       "4.20.0-202602161753",
       "4.20.0-202603030647",
       "4.20.0-202603160950",
-      "4.20.0-202603272224"
+      "4.20.0-202603272224",
+      "4.20.0-202604141324"
     ],
     "minVersion": "4.20.0-202509262039",
-    "maxVersion": "4.20.0-202603272224",
+    "maxVersion": "4.20.0-202604141324",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -12077,6 +12203,7 @@
         "1.8.3",
         "1.8.4",
         "1.8.5",
+        "1.8.6",
         "1.9.0",
         "1.9.1",
         "1.9.2",
@@ -12135,7 +12262,8 @@
         "1.8.2",
         "1.8.3",
         "1.8.4",
-        "1.8.5"
+        "1.8.5",
+        "1.8.6"
       ],
       "fast-1.9": [
         "1.9.0",
@@ -12179,7 +12307,7 @@
       },
       "fast-1.8": {
         "minVersion": "1.8.0",
-        "maxVersion": "1.8.5"
+        "maxVersion": "1.8.6"
       },
       "fast-1.9": {
         "minVersion": "1.9.0",
@@ -12222,6 +12350,7 @@
       "1.8.3",
       "1.8.4",
       "1.8.5",
+      "1.8.6",
       "1.9.0",
       "1.9.1",
       "1.9.2",
@@ -12310,10 +12439,11 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "beta": [
-        "3.4.0-ea.1"
+        "3.4.0-ea.2"
       ],
       "embedded": [
         "1.20.1-8",
@@ -12416,7 +12546,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "eus-2.8": [
         "1.20.1-8",
@@ -12494,7 +12625,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "fast-3.x": [
         "3.0.0",
@@ -12548,7 +12680,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "stable-2.10": [
         "1.20.1-8",
@@ -12777,7 +12910,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "stable-2.8": [
         "1.20.1-8",
@@ -12828,11 +12962,11 @@
       },
       "alpha": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "beta": {
-        "minVersion": "3.4.0-ea.1",
-        "maxVersion": "3.4.0-ea.1"
+        "minVersion": "3.4.0-ea.2",
+        "maxVersion": "3.4.0-ea.2"
       },
       "embedded": {
         "minVersion": "1.20.1-8",
@@ -12844,7 +12978,7 @@
       },
       "eus-2.25": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "eus-2.8": {
         "minVersion": "1.20.1-8",
@@ -12852,7 +12986,7 @@
       },
       "fast": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "fast-3.x": {
         "minVersion": "3.0.0",
@@ -12860,7 +12994,7 @@
       },
       "stable": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "stable-2.10": {
         "minVersion": "1.20.1-8",
@@ -12884,7 +13018,7 @@
       },
       "stable-2.25": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "stable-2.8": {
         "minVersion": "1.20.1-8",
@@ -12964,16 +13098,17 @@
       "2.25.2",
       "2.25.3",
       "2.25.4",
+      "2.25.5",
       "3.0.0",
       "3.2.0",
       "3.2.1",
       "3.3.0",
       "3.3.1",
       "3.3.2",
-      "3.4.0-ea.1"
+      "3.4.0-ea.2"
     ],
     "minVersion": "1.20.1-8",
-    "maxVersion": "3.4.0-ea.1",
+    "maxVersion": "3.4.0-ea.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -13248,6 +13383,7 @@
         "1.3.1",
         "1.3.2",
         "1.3.3",
+        "1.3.4",
         "1.4.0"
       ],
       "stable-v1.1": [
@@ -13263,7 +13399,8 @@
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.3.3"
+        "1.3.3",
+        "1.3.4"
       ],
       "stable-v1.4": [
         "1.4.0"
@@ -13284,7 +13421,7 @@
       },
       "stable-v1.3": {
         "minVersion": "1.3.0",
-        "maxVersion": "1.3.3"
+        "maxVersion": "1.3.4"
       },
       "stable-v1.4": {
         "minVersion": "1.4.0",
@@ -13301,6 +13438,7 @@
       "1.3.1",
       "1.3.2",
       "1.3.3",
+      "1.3.4",
       "1.4.0"
     ],
     "minVersion": "1.1.0",
@@ -13320,23 +13458,25 @@
         "1.1.0",
         "1.1.1",
         "1.1.2",
-        "1.1.3"
+        "1.1.3",
+        "1.1.4"
       ]
     },
     "channelVersionRanges": {
       "stable-v1.1": {
         "minVersion": "1.1.0",
-        "maxVersion": "1.1.3"
+        "maxVersion": "1.1.4"
       }
     },
     "availableVersions": [
       "1.1.0",
       "1.1.1",
       "1.1.2",
-      "1.1.3"
+      "1.1.3",
+      "1.1.4"
     ],
     "minVersion": "1.1.0",
-    "maxVersion": "1.1.3",
+    "maxVersion": "1.1.4",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -13479,21 +13619,23 @@
     "channelVersions": {
       "stable": [
         "1.0.0",
-        "1.0.1"
+        "1.0.1",
+        "1.0.2"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.0.0",
-        "maxVersion": "1.0.1"
+        "maxVersion": "1.0.2"
       }
     },
     "availableVersions": [
       "1.0.0",
-      "1.0.1"
+      "1.0.1",
+      "1.0.2"
     ],
     "minVersion": "1.0.0",
-    "maxVersion": "1.0.1",
+    "maxVersion": "1.0.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -13609,13 +13751,14 @@
         "4.20.0-202602032049",
         "4.20.0-202602091941",
         "4.20.0-202603030647",
-        "4.20.0-202603272224"
+        "4.20.0-202603272224",
+        "4.20.0-202604140241"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.20.0-202509262039",
-        "maxVersion": "4.20.0-202603272224"
+        "maxVersion": "4.20.0-202604140241"
       }
     },
     "availableVersions": [
@@ -13631,10 +13774,11 @@
       "4.20.0-202602032049",
       "4.20.0-202602091941",
       "4.20.0-202603030647",
-      "4.20.0-202603272224"
+      "4.20.0-202603272224",
+      "4.20.0-202604140241"
     ],
     "minVersion": "4.20.0-202509262039",
-    "maxVersion": "4.20.0-202603272224",
+    "maxVersion": "4.20.0-202604140241",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -14362,6 +14506,7 @@
         "3.0.7",
         "3.0.8",
         "3.0.9",
+        "3.0.10",
         "3.1.0",
         "3.1.1",
         "3.1.2",
@@ -14369,12 +14514,15 @@
         "3.1.4",
         "3.1.5",
         "3.1.6",
+        "3.1.7",
         "3.2.0",
         "3.2.1",
         "3.2.2",
         "3.2.3",
+        "3.2.4",
         "3.3.0",
-        "3.3.1"
+        "3.3.1",
+        "3.3.2"
       ],
       "stable-3.0": [
         "3.0.0",
@@ -14386,7 +14534,8 @@
         "3.0.6",
         "3.0.7",
         "3.0.8",
-        "3.0.9"
+        "3.0.9",
+        "3.0.10"
       ],
       "stable-3.1": [
         "3.1.0",
@@ -14395,17 +14544,20 @@
         "3.1.3",
         "3.1.4",
         "3.1.5",
-        "3.1.6"
+        "3.1.6",
+        "3.1.7"
       ],
       "stable-3.2": [
         "3.2.0",
         "3.2.1",
         "3.2.2",
-        "3.2.3"
+        "3.2.3",
+        "3.2.4"
       ],
       "stable-3.3": [
         "3.3.0",
-        "3.3.1"
+        "3.3.1",
+        "3.3.2"
       ]
     },
     "channelVersionRanges": {
@@ -14415,23 +14567,23 @@
       },
       "stable": {
         "minVersion": "3.0.0",
-        "maxVersion": "3.3.1"
+        "maxVersion": "3.3.2"
       },
       "stable-3.0": {
         "minVersion": "3.0.0",
-        "maxVersion": "3.0.9"
+        "maxVersion": "3.0.10"
       },
       "stable-3.1": {
         "minVersion": "3.1.0",
-        "maxVersion": "3.1.6"
+        "maxVersion": "3.1.7"
       },
       "stable-3.2": {
         "minVersion": "3.2.0",
-        "maxVersion": "3.2.3"
+        "maxVersion": "3.2.4"
       },
       "stable-3.3": {
         "minVersion": "3.3.0",
-        "maxVersion": "3.3.1"
+        "maxVersion": "3.3.2"
       }
     },
     "availableVersions": [
@@ -14447,6 +14599,7 @@
       "3.0.7",
       "3.0.8",
       "3.0.9",
+      "3.0.10",
       "3.1.0",
       "3.1.1",
       "3.1.2",
@@ -14454,15 +14607,18 @@
       "3.1.4",
       "3.1.5",
       "3.1.6",
+      "3.1.7",
       "3.2.0",
       "3.2.1",
       "3.2.2",
       "3.2.3",
+      "3.2.4",
       "3.3.0",
-      "3.3.1"
+      "3.3.1",
+      "3.3.2"
     ],
     "minVersion": "3.0.0",
-    "maxVersion": "3.3.1",
+    "maxVersion": "3.3.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -14835,13 +14991,14 @@
         "4.20.0-202601292039",
         "4.20.0-202602091941",
         "4.20.0-202602261925",
-        "4.20.0-202603271717"
+        "4.20.0-202603271717",
+        "4.20.0-202604140241"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.20.0-202509262039",
-        "maxVersion": "4.20.0-202603271717"
+        "maxVersion": "4.20.0-202604140241"
       }
     },
     "availableVersions": [
@@ -14856,10 +15013,11 @@
       "4.20.0-202601292039",
       "4.20.0-202602091941",
       "4.20.0-202602261925",
-      "4.20.0-202603271717"
+      "4.20.0-202603271717",
+      "4.20.0-202604140241"
     ],
     "minVersion": "4.20.0-202509262039",
-    "maxVersion": "4.20.0-202603271717",
+    "maxVersion": "4.20.0-202604140241",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -14885,13 +15043,14 @@
         "4.20.0-202601292039",
         "4.20.0-202602091941",
         "4.20.0-202602261925",
-        "4.20.0-202603272224"
+        "4.20.0-202603272224",
+        "4.20.0-202604140241"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.20.0-202509262224",
-        "maxVersion": "4.20.0-202603272224"
+        "maxVersion": "4.20.0-202604140241"
       }
     },
     "availableVersions": [
@@ -14908,10 +15067,11 @@
       "4.20.0-202601292039",
       "4.20.0-202602091941",
       "4.20.0-202602261925",
-      "4.20.0-202603272224"
+      "4.20.0-202603272224",
+      "4.20.0-202604140241"
     ],
     "minVersion": "4.20.0-202509262224",
-    "maxVersion": "4.20.0-202603272224",
+    "maxVersion": "4.20.0-202604140241",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -15011,13 +15171,14 @@
         "4.20.0-202602091941",
         "4.20.0-202603030647",
         "4.20.0-202603130602",
-        "4.20.0-202603272224"
+        "4.20.0-202603272224",
+        "4.20.0-202604140241"
       ]
     },
     "channelVersionRanges": {
       "tech-preview": {
         "minVersion": "4.20.0-202509262039",
-        "maxVersion": "4.20.0-202603272224"
+        "maxVersion": "4.20.0-202604140241"
       }
     },
     "availableVersions": [
@@ -15034,10 +15195,11 @@
       "4.20.0-202602091941",
       "4.20.0-202603030647",
       "4.20.0-202603130602",
-      "4.20.0-202603272224"
+      "4.20.0-202603272224",
+      "4.20.0-202604140241"
     ],
     "minVersion": "4.20.0-202509262039",
-    "maxVersion": "4.20.0-202603272224",
+    "maxVersion": "4.20.0-202604140241",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -15108,13 +15270,14 @@
         "0.19.0-2",
         "0.19.0-3",
         "0.20.0-1",
-        "0.20.0-2"
+        "0.20.0-2",
+        "0.20.0-3"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.1.0-6",
-        "maxVersion": "0.20.0-2"
+        "maxVersion": "0.20.0-3"
       }
     },
     "availableVersions": [
@@ -15141,10 +15304,11 @@
       "0.19.0-2",
       "0.19.0-3",
       "0.20.0-1",
-      "0.20.0-2"
+      "0.20.0-2",
+      "0.20.0-3"
     ],
     "minVersion": "0.1.0-6",
-    "maxVersion": "0.20.0-2",
+    "maxVersion": "0.20.0-3",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
@@ -15246,13 +15410,14 @@
         "4.20.0-202602091941",
         "4.20.0-202602261925",
         "4.20.0-202603060259",
-        "4.20.0-202603271717"
+        "4.20.0-202603271717",
+        "4.20.0-202604140241"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.20.0-202509262039",
-        "maxVersion": "4.20.0-202603271717"
+        "maxVersion": "4.20.0-202604140241"
       }
     },
     "availableVersions": [
@@ -15269,10 +15434,11 @@
       "4.20.0-202602091941",
       "4.20.0-202602261925",
       "4.20.0-202603060259",
-      "4.20.0-202603271717"
+      "4.20.0-202603271717",
+      "4.20.0-202604140241"
     ],
     "minVersion": "4.20.0-202509262039",
-    "maxVersion": "4.20.0-202603271717",
+    "maxVersion": "4.20.0-202604140241",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.20",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.20"

--- a/catalog-data/redhat-operator-index/v4.21/catalog-info.json
+++ b/catalog-data/redhat-operator-index/v4.21/catalog-info.json
@@ -2,5 +2,5 @@
   "catalog_type": "redhat-operator-index",
   "ocp_version": "v4.21",
   "catalog_url": "registry.redhat.io/redhat/redhat-operator-index:v4.21",
-  "operator_count": 143
+  "operator_count": 144
 }

--- a/catalog-data/redhat-operator-index/v4.21/operators.json
+++ b/catalog-data/redhat-operator-index/v4.21/operators.json
@@ -1751,13 +1751,14 @@
         "4.21.0-202603181245",
         "4.21.0-202603251225",
         "4.21.0-202604012149",
-        "4.21.0-202604080925"
+        "4.21.0-202604080925",
+        "4.21.0-202604150520"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601121715",
-        "maxVersion": "4.21.0-202604080925"
+        "maxVersion": "4.21.0-202604150520"
       }
     },
     "availableVersions": [
@@ -1771,10 +1772,11 @@
       "4.21.0-202603181245",
       "4.21.0-202603251225",
       "4.21.0-202604012149",
-      "4.21.0-202604080925"
+      "4.21.0-202604080925",
+      "4.21.0-202604150520"
     ],
     "minVersion": "4.21.0-202601121715",
-    "maxVersion": "4.21.0-202604080925",
+    "maxVersion": "4.21.0-202604150520",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -2320,7 +2322,8 @@
         "6.4.0",
         "6.4.1",
         "6.4.2",
-        "6.4.3"
+        "6.4.3",
+        "6.4.4"
       ],
       "stable-6.5": [
         "6.5.0"
@@ -2329,7 +2332,7 @@
     "channelVersionRanges": {
       "stable-6.4": {
         "minVersion": "6.4.0",
-        "maxVersion": "6.4.3"
+        "maxVersion": "6.4.4"
       },
       "stable-6.5": {
         "minVersion": "6.5.0",
@@ -2341,6 +2344,7 @@
       "6.4.1",
       "6.4.2",
       "6.4.3",
+      "6.4.4",
       "6.5.0"
     ],
     "minVersion": "6.4.0",
@@ -2407,13 +2411,14 @@
         "4.21.0-202603181245",
         "4.21.0-202603230446",
         "4.21.0-202603300221",
-        "4.21.0-202604060715"
+        "4.21.0-202604060715",
+        "4.21.0-202604140043"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601292040",
-        "maxVersion": "4.21.0-202604060715"
+        "maxVersion": "4.21.0-202604140043"
       }
     },
     "availableVersions": [
@@ -2425,10 +2430,11 @@
       "4.21.0-202603181245",
       "4.21.0-202603230446",
       "4.21.0-202603300221",
-      "4.21.0-202604060715"
+      "4.21.0-202604060715",
+      "4.21.0-202604140043"
     ],
     "minVersion": "4.21.0-202601292040",
-    "maxVersion": "4.21.0-202604060715",
+    "maxVersion": "4.21.0-202604140043",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -2942,13 +2948,14 @@
         "4.1.0",
         "4.2.0",
         "4.3.0",
-        "4.3.1"
+        "4.3.1",
+        "4.4.0"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.0.0",
-        "maxVersion": "4.3.1"
+        "maxVersion": "4.4.0"
       }
     },
     "availableVersions": [
@@ -2976,10 +2983,11 @@
       "4.1.0",
       "4.2.0",
       "4.3.0",
-      "4.3.1"
+      "4.3.1",
+      "4.4.0"
     ],
     "minVersion": "1.0.0",
-    "maxVersion": "4.3.1",
+    "maxVersion": "4.4.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -3317,6 +3325,46 @@
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
   },
   {
+    "name": "deployment-validation-operator",
+    "defaultChannel": "alpha",
+    "channels": [
+      "alpha"
+    ],
+    "channelVersions": {
+      "alpha": [
+        "0.7.5",
+        "0.7.8",
+        "0.7.9",
+        "0.7.11",
+        "0.7.12",
+        "0.7.13",
+        "0.7.14",
+        "0.7.15"
+      ]
+    },
+    "channelVersionRanges": {
+      "alpha": {
+        "minVersion": "0.7.5",
+        "maxVersion": "0.7.15"
+      }
+    },
+    "availableVersions": [
+      "0.7.5",
+      "0.7.8",
+      "0.7.9",
+      "0.7.11",
+      "0.7.12",
+      "0.7.13",
+      "0.7.14",
+      "0.7.15"
+    ],
+    "minVersion": "0.7.5",
+    "maxVersion": "0.7.15",
+    "catalog": "redhat-operator-index",
+    "ocpVersion": "v4.21",
+    "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
+  },
+  {
     "name": "devspaces",
     "defaultChannel": "stable",
     "channels": [
@@ -3366,13 +3414,14 @@
         "3.25.0",
         "3.26.0",
         "3.26.1",
-        "3.27.0"
+        "3.27.0",
+        "3.27.1"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "3.3.0",
-        "maxVersion": "3.27.0"
+        "maxVersion": "3.27.1"
       }
     },
     "availableVersions": [
@@ -3418,10 +3467,11 @@
       "3.25.0",
       "3.26.0",
       "3.26.1",
-      "3.27.0"
+      "3.27.0",
+      "3.27.1"
     ],
     "minVersion": "3.3.0",
-    "maxVersion": "3.27.0",
+    "maxVersion": "3.27.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -3477,13 +3527,14 @@
         "0.37.0",
         "0.38.0",
         "0.39.0",
-        "0.40.0"
+        "0.40.0",
+        "0.40.1"
       ]
     },
     "channelVersionRanges": {
       "fast": {
         "minVersion": "0.9.0",
-        "maxVersion": "0.40.0"
+        "maxVersion": "0.40.1"
       }
     },
     "availableVersions": [
@@ -3530,10 +3581,11 @@
       "0.37.0",
       "0.38.0",
       "0.39.0",
-      "0.40.0"
+      "0.40.0",
+      "0.40.1"
     ],
     "minVersion": "0.9.0",
-    "maxVersion": "0.40.0",
+    "maxVersion": "0.40.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -3891,6 +3943,7 @@
       "3.18",
       "3.19",
       "3.20",
+      "3.21",
       "stable"
     ],
     "channelVersions": {
@@ -3911,6 +3964,9 @@
       "3.20": [
         "3.20.0"
       ],
+      "3.21": [
+        "3.21.0"
+      ],
       "stable": [
         "3.17.0",
         "3.17.1",
@@ -3918,7 +3974,8 @@
         "3.18.0",
         "3.19.0",
         "3.19.1",
-        "3.20.0"
+        "3.20.0",
+        "3.21.0"
       ]
     },
     "channelVersionRanges": {
@@ -3938,9 +3995,13 @@
         "minVersion": "3.20.0",
         "maxVersion": "3.20.0"
       },
+      "3.21": {
+        "minVersion": "3.21.0",
+        "maxVersion": "3.21.0"
+      },
       "stable": {
         "minVersion": "3.17.0",
-        "maxVersion": "3.20.0"
+        "maxVersion": "3.21.0"
       }
     },
     "availableVersions": [
@@ -3952,10 +4013,11 @@
       "3.18.1",
       "3.19.0",
       "3.19.1",
-      "3.20.0"
+      "3.20.0",
+      "3.21.0"
     ],
     "minVersion": "3.17.0",
-    "maxVersion": "3.20.0",
+    "maxVersion": "3.21.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -3977,13 +4039,14 @@
         "4.21.0-202603181245",
         "4.21.0-202603250756",
         "4.21.0-202603300623",
-        "4.21.0-202604061320"
+        "4.21.0-202604061320",
+        "4.21.0-202604140043"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601121715",
-        "maxVersion": "4.21.0-202604061320"
+        "maxVersion": "4.21.0-202604140043"
       }
     },
     "availableVersions": [
@@ -3996,10 +4059,11 @@
       "4.21.0-202603181245",
       "4.21.0-202603250756",
       "4.21.0-202603300623",
-      "4.21.0-202604061320"
+      "4.21.0-202604061320",
+      "4.21.0-202604140043"
     ],
     "minVersion": "4.21.0-202601121715",
-    "maxVersion": "4.21.0-202604061320",
+    "maxVersion": "4.21.0-202604140043",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -4021,13 +4085,14 @@
         "4.21.0-202603181245",
         "4.21.0-202603250027",
         "4.21.0-202603300221",
-        "4.21.0-202604061320"
+        "4.21.0-202604061320",
+        "4.21.0-202604140043"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601121715",
-        "maxVersion": "4.21.0-202604061320"
+        "maxVersion": "4.21.0-202604140043"
       }
     },
     "availableVersions": [
@@ -4040,10 +4105,11 @@
       "4.21.0-202603181245",
       "4.21.0-202603250027",
       "4.21.0-202603300221",
-      "4.21.0-202604061320"
+      "4.21.0-202604061320",
+      "4.21.0-202604140043"
     ],
     "minVersion": "4.21.0-202601121715",
-    "maxVersion": "4.21.0-202604061320",
+    "maxVersion": "4.21.0-202604140043",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -4637,7 +4703,8 @@
         "4.21.1",
         "4.21.2",
         "4.21.3",
-        "4.21.4"
+        "4.21.4",
+        "4.21.5"
       ],
       "stable": [
         "4.12.0",
@@ -4683,7 +4750,7 @@
     "channelVersionRanges": {
       "candidate": {
         "minVersion": "4.21.1",
-        "maxVersion": "4.21.4"
+        "maxVersion": "4.21.5"
       },
       "stable": {
         "minVersion": "4.12.0",
@@ -4730,10 +4797,11 @@
       "4.21.1",
       "4.21.2",
       "4.21.3",
-      "4.21.4"
+      "4.21.4",
+      "4.21.5"
     ],
     "minVersion": "4.12.0",
-    "maxVersion": "4.21.4",
+    "maxVersion": "4.21.5",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -4924,13 +4992,14 @@
         "4.21.0-202603181245",
         "4.21.0-202603241611",
         "4.21.0-202603300623",
-        "4.21.0-202604061320"
+        "4.21.0-202604061320",
+        "4.21.0-202604140347"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601121715",
-        "maxVersion": "4.21.0-202604061320"
+        "maxVersion": "4.21.0-202604140347"
       }
     },
     "availableVersions": [
@@ -4943,10 +5012,11 @@
       "4.21.0-202603181245",
       "4.21.0-202603241611",
       "4.21.0-202603300623",
-      "4.21.0-202604061320"
+      "4.21.0-202604061320",
+      "4.21.0-202604140347"
     ],
     "minVersion": "4.21.0-202601121715",
-    "maxVersion": "4.21.0-202604061320",
+    "maxVersion": "4.21.0-202604140347",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -5027,7 +5097,8 @@
         "6.4.0",
         "6.4.1",
         "6.4.2",
-        "6.4.3"
+        "6.4.3",
+        "6.4.4"
       ],
       "stable-6.5": [
         "6.5.0"
@@ -5036,7 +5107,7 @@
     "channelVersionRanges": {
       "stable-6.4": {
         "minVersion": "6.4.0",
-        "maxVersion": "6.4.3"
+        "maxVersion": "6.4.4"
       },
       "stable-6.5": {
         "minVersion": "6.5.0",
@@ -5048,6 +5119,7 @@
       "6.4.1",
       "6.4.2",
       "6.4.3",
+      "6.4.4",
       "6.5.0"
     ],
     "minVersion": "6.4.0",
@@ -5193,13 +5265,14 @@
         "4.21.0-202603181245",
         "4.21.0-202603240526",
         "4.21.0-202603300221",
-        "4.21.0-202604061320"
+        "4.21.0-202604061320",
+        "4.21.0-202604140043"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601121715",
-        "maxVersion": "4.21.0-202604061320"
+        "maxVersion": "4.21.0-202604140043"
       }
     },
     "availableVersions": [
@@ -5212,10 +5285,11 @@
       "4.21.0-202603181245",
       "4.21.0-202603240526",
       "4.21.0-202603300221",
-      "4.21.0-202604061320"
+      "4.21.0-202604061320",
+      "4.21.0-202604140043"
     ],
     "minVersion": "4.21.0-202601121715",
-    "maxVersion": "4.21.0-202604061320",
+    "maxVersion": "4.21.0-202604140043",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -5312,7 +5386,8 @@
         "8.0.1"
       ],
       "stable-v8.1": [
-        "8.1.0"
+        "8.1.0",
+        "8.1.1"
       ]
     },
     "channelVersionRanges": {
@@ -5350,7 +5425,7 @@
       },
       "stable-v8.1": {
         "minVersion": "8.1.0",
-        "maxVersion": "8.1.0"
+        "maxVersion": "8.1.1"
       }
     },
     "availableVersions": [
@@ -5382,10 +5457,11 @@
       "7.3.2",
       "8.0.0",
       "8.0.1",
-      "8.1.0"
+      "8.1.0",
+      "8.1.1"
     ],
     "minVersion": "6.0.0",
-    "maxVersion": "8.1.0",
+    "maxVersion": "8.1.1",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -5457,7 +5533,8 @@
         "2.11.0",
         "2.11.1",
         "2.11.2",
-        "2.11.3"
+        "2.11.3",
+        "2.11.4"
       ]
     },
     "channelVersionRanges": {
@@ -5467,7 +5544,7 @@
       },
       "release-v2.11": {
         "minVersion": "2.11.0",
-        "maxVersion": "2.11.3"
+        "maxVersion": "2.11.4"
       }
     },
     "availableVersions": [
@@ -5475,10 +5552,11 @@
       "2.11.0",
       "2.11.1",
       "2.11.2",
-      "2.11.3"
+      "2.11.3",
+      "2.11.4"
     ],
     "minVersion": "2.10.5",
-    "maxVersion": "2.11.3",
+    "maxVersion": "2.11.4",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -5680,13 +5758,14 @@
         "4.21.0-202603181245",
         "4.21.0-202603230446",
         "4.21.0-202603300623",
-        "4.21.0-202604061320"
+        "4.21.0-202604061320",
+        "4.21.0-202604140347"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601121715",
-        "maxVersion": "4.21.0-202604061320"
+        "maxVersion": "4.21.0-202604140347"
       }
     },
     "availableVersions": [
@@ -5699,10 +5778,11 @@
       "4.21.0-202603181245",
       "4.21.0-202603230446",
       "4.21.0-202603300623",
-      "4.21.0-202604061320"
+      "4.21.0-202604061320",
+      "4.21.0-202604140347"
     ],
     "minVersion": "4.21.0-202601121715",
-    "maxVersion": "4.21.0-202604061320",
+    "maxVersion": "4.21.0-202604140347",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -6519,34 +6599,46 @@
     "defaultChannel": "stable-v1",
     "channels": [
       "stable-v1",
-      "stable-v1.18"
+      "stable-v1.18",
+      "stable-v1.19"
     ],
     "channelVersions": {
       "stable-v1": [
         "1.18.0",
-        "1.18.1"
+        "1.18.1",
+        "1.19.0"
       ],
       "stable-v1.18": [
         "1.18.0",
         "1.18.1"
+      ],
+      "stable-v1.19": [
+        "1.18.0",
+        "1.18.1",
+        "1.19.0"
       ]
     },
     "channelVersionRanges": {
       "stable-v1": {
         "minVersion": "1.18.0",
-        "maxVersion": "1.18.1"
+        "maxVersion": "1.19.0"
       },
       "stable-v1.18": {
         "minVersion": "1.18.0",
         "maxVersion": "1.18.1"
+      },
+      "stable-v1.19": {
+        "minVersion": "1.18.0",
+        "maxVersion": "1.19.0"
       }
     },
     "availableVersions": [
       "1.18.0",
-      "1.18.1"
+      "1.18.1",
+      "1.19.0"
     ],
     "minVersion": "1.18.0",
-    "maxVersion": "1.18.1",
+    "maxVersion": "1.19.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -6919,16 +7011,19 @@
         "1.18.1",
         "1.18.2",
         "1.18.3",
-        "1.18.4"
+        "1.18.4",
+        "1.18.5"
       ],
       "gitops-1.19": [
         "1.19.0",
         "1.19.1",
-        "1.19.2"
+        "1.19.2",
+        "1.19.3"
       ],
       "gitops-1.20": [
         "1.20.0",
-        "1.20.1"
+        "1.20.1",
+        "1.20.2"
       ],
       "gitops-1.6": [
         "1.5.2",
@@ -7049,7 +7144,8 @@
         "1.19.1",
         "1.19.2",
         "1.20.0",
-        "1.20.1"
+        "1.20.1",
+        "1.20.2"
       ]
     },
     "channelVersionRanges": {
@@ -7087,15 +7183,15 @@
       },
       "gitops-1.18": {
         "minVersion": "1.18.0",
-        "maxVersion": "1.18.4"
+        "maxVersion": "1.18.5"
       },
       "gitops-1.19": {
         "minVersion": "1.19.0",
-        "maxVersion": "1.19.2"
+        "maxVersion": "1.19.3"
       },
       "gitops-1.20": {
         "minVersion": "1.20.0",
-        "maxVersion": "1.20.1"
+        "maxVersion": "1.20.2"
       },
       "gitops-1.6": {
         "minVersion": "1.5.2",
@@ -7115,7 +7211,7 @@
       },
       "latest": {
         "minVersion": "1.5.2",
-        "maxVersion": "1.20.1"
+        "maxVersion": "1.20.2"
       }
     },
     "availableVersions": [
@@ -7211,14 +7307,17 @@
       "1.18.2",
       "1.18.3",
       "1.18.4",
+      "1.18.5",
       "1.19.0",
       "1.19.1",
       "1.19.2",
+      "1.19.3",
       "1.20.0",
-      "1.20.1"
+      "1.20.1",
+      "1.20.2"
     ],
     "minVersion": "1.5.2",
-    "maxVersion": "1.20.1",
+    "maxVersion": "1.20.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -7235,7 +7334,8 @@
       "pipelines-1.18",
       "pipelines-1.19",
       "pipelines-1.20",
-      "pipelines-1.21"
+      "pipelines-1.21",
+      "pipelines-1.22"
     ],
     "channelVersions": {
       "latest": [
@@ -7270,8 +7370,10 @@
         "1.20.1",
         "1.20.2",
         "1.20.3",
+        "1.20.4",
         "1.21.0",
-        "1.21.1"
+        "1.21.1",
+        "1.22.0"
       ],
       "pipelines-1.14": [
         "1.14.0",
@@ -7316,17 +7418,21 @@
         "1.20.0",
         "1.20.1",
         "1.20.2",
-        "1.20.3"
+        "1.20.3",
+        "1.20.4"
       ],
       "pipelines-1.21": [
         "1.21.0",
         "1.21.1"
+      ],
+      "pipelines-1.22": [
+        "1.22.0"
       ]
     },
     "channelVersionRanges": {
       "latest": {
         "minVersion": "1.14.0",
-        "maxVersion": "1.21.1"
+        "maxVersion": "1.22.0"
       },
       "pipelines-1.14": {
         "minVersion": "1.14.0",
@@ -7354,11 +7460,15 @@
       },
       "pipelines-1.20": {
         "minVersion": "1.20.0",
-        "maxVersion": "1.20.3"
+        "maxVersion": "1.20.4"
       },
       "pipelines-1.21": {
         "minVersion": "1.21.0",
         "maxVersion": "1.21.1"
+      },
+      "pipelines-1.22": {
+        "minVersion": "1.22.0",
+        "maxVersion": "1.22.0"
       }
     },
     "availableVersions": [
@@ -7393,11 +7503,13 @@
       "1.20.1",
       "1.20.2",
       "1.20.3",
+      "1.20.4",
       "1.21.0",
-      "1.21.1"
+      "1.21.1",
+      "1.22.0"
     ],
     "minVersion": "1.14.0",
-    "maxVersion": "1.21.1",
+    "maxVersion": "1.22.0",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -7491,13 +7603,14 @@
         "0.135.0-1",
         "0.140.0-1",
         "0.140.0-2",
-        "0.144.0-1"
+        "0.144.0-1",
+        "0.144.0-2"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.56.0-1",
-        "maxVersion": "0.144.0-1"
+        "maxVersion": "0.144.0-2"
       }
     },
     "availableVersions": [
@@ -7524,10 +7637,11 @@
       "0.135.0-1",
       "0.140.0-1",
       "0.140.0-2",
-      "0.144.0-1"
+      "0.144.0-1",
+      "0.144.0-2"
     ],
     "minVersion": "0.56.0-1",
-    "maxVersion": "0.144.0-1",
+    "maxVersion": "0.144.0-2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -7549,13 +7663,14 @@
         "4.21.0-202603181245",
         "4.21.0-202603251225",
         "4.21.0-202603300221",
-        "4.21.0-202604061320"
+        "4.21.0-202604061320",
+        "4.21.0-202604140347"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601130153",
-        "maxVersion": "4.21.0-202604061320"
+        "maxVersion": "4.21.0-202604140347"
       }
     },
     "availableVersions": [
@@ -7568,10 +7683,11 @@
       "4.21.0-202603181245",
       "4.21.0-202603251225",
       "4.21.0-202603300221",
-      "4.21.0-202604061320"
+      "4.21.0-202604061320",
+      "4.21.0-202604140347"
     ],
     "minVersion": "4.21.0-202601130153",
-    "maxVersion": "4.21.0-202604061320",
+    "maxVersion": "4.21.0-202604140347",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -7673,13 +7789,14 @@
         "4.21.0-202603181245",
         "4.21.0-202603242057",
         "4.21.0-202604011849",
-        "4.21.0-202604061320"
+        "4.21.0-202604061320",
+        "4.21.0-202604140347"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601121715",
-        "maxVersion": "4.21.0-202604061320"
+        "maxVersion": "4.21.0-202604140347"
       }
     },
     "availableVersions": [
@@ -7693,10 +7810,11 @@
       "4.21.0-202603181245",
       "4.21.0-202603242057",
       "4.21.0-202604011849",
-      "4.21.0-202604061320"
+      "4.21.0-202604061320",
+      "4.21.0-202604140347"
     ],
     "minVersion": "4.21.0-202601121715",
-    "maxVersion": "4.21.0-202604061320",
+    "maxVersion": "4.21.0-202604140347",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -10633,6 +10751,7 @@
         "1.8.3",
         "1.8.4",
         "1.8.5",
+        "1.8.6",
         "1.9.0",
         "1.9.1",
         "1.9.2",
@@ -10691,7 +10810,8 @@
         "1.8.2",
         "1.8.3",
         "1.8.4",
-        "1.8.5"
+        "1.8.5",
+        "1.8.6"
       ],
       "fast-1.9": [
         "1.9.0",
@@ -10735,7 +10855,7 @@
       },
       "fast-1.8": {
         "minVersion": "1.8.0",
-        "maxVersion": "1.8.5"
+        "maxVersion": "1.8.6"
       },
       "fast-1.9": {
         "minVersion": "1.9.0",
@@ -10778,6 +10898,7 @@
       "1.8.3",
       "1.8.4",
       "1.8.5",
+      "1.8.6",
       "1.9.0",
       "1.9.1",
       "1.9.2",
@@ -10861,10 +10982,11 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "beta": [
-        "3.4.0-ea.1"
+        "3.4.0-ea.2"
       ],
       "embedded": [
         "1.20.1-8",
@@ -10967,7 +11089,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "eus-2.8": [
         "1.20.1-8",
@@ -11045,7 +11168,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "fast-3.x": [
         "3.0.0",
@@ -11098,7 +11222,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "stable-2.10": [
         "1.20.1-8",
@@ -11327,7 +11452,8 @@
         "2.25.1",
         "2.25.2",
         "2.25.3",
-        "2.25.4"
+        "2.25.4",
+        "2.25.5"
       ],
       "stable-2.8": [
         "1.20.1-8",
@@ -11374,11 +11500,11 @@
     "channelVersionRanges": {
       "alpha": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "beta": {
-        "minVersion": "3.4.0-ea.1",
-        "maxVersion": "3.4.0-ea.1"
+        "minVersion": "3.4.0-ea.2",
+        "maxVersion": "3.4.0-ea.2"
       },
       "embedded": {
         "minVersion": "1.20.1-8",
@@ -11390,7 +11516,7 @@
       },
       "eus-2.25": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "eus-2.8": {
         "minVersion": "1.20.1-8",
@@ -11398,7 +11524,7 @@
       },
       "fast": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "fast-3.x": {
         "minVersion": "3.0.0",
@@ -11406,7 +11532,7 @@
       },
       "stable": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "stable-2.10": {
         "minVersion": "1.20.1-8",
@@ -11430,7 +11556,7 @@
       },
       "stable-2.25": {
         "minVersion": "1.20.1-8",
-        "maxVersion": "2.25.4"
+        "maxVersion": "2.25.5"
       },
       "stable-2.8": {
         "minVersion": "1.20.1-8",
@@ -11510,15 +11636,16 @@
       "2.25.2",
       "2.25.3",
       "2.25.4",
+      "2.25.5",
       "3.0.0",
       "3.2.0",
       "3.3.0",
       "3.3.1",
       "3.3.2",
-      "3.4.0-ea.1"
+      "3.4.0-ea.2"
     ],
     "minVersion": "1.20.1-8",
-    "maxVersion": "3.4.0-ea.1",
+    "maxVersion": "3.4.0-ea.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -11786,13 +11913,15 @@
         "1.3.1",
         "1.3.2",
         "1.3.3",
+        "1.3.4",
         "1.4.0"
       ],
       "stable-v1.3": [
         "1.3.0",
         "1.3.1",
         "1.3.2",
-        "1.3.3"
+        "1.3.3",
+        "1.3.4"
       ],
       "stable-v1.4": [
         "1.4.0"
@@ -11805,7 +11934,7 @@
       },
       "stable-v1.3": {
         "minVersion": "1.3.0",
-        "maxVersion": "1.3.3"
+        "maxVersion": "1.3.4"
       },
       "stable-v1.4": {
         "minVersion": "1.4.0",
@@ -11817,6 +11946,7 @@
       "1.3.1",
       "1.3.2",
       "1.3.3",
+      "1.3.4",
       "1.4.0"
     ],
     "minVersion": "1.3.0",
@@ -11836,23 +11966,25 @@
         "1.1.0",
         "1.1.1",
         "1.1.2",
-        "1.1.3"
+        "1.1.3",
+        "1.1.4"
       ]
     },
     "channelVersionRanges": {
       "stable-v1.1": {
         "minVersion": "1.1.0",
-        "maxVersion": "1.1.3"
+        "maxVersion": "1.1.4"
       }
     },
     "availableVersions": [
       "1.1.0",
       "1.1.1",
       "1.1.2",
-      "1.1.3"
+      "1.1.3",
+      "1.1.4"
     ],
     "minVersion": "1.1.0",
-    "maxVersion": "1.1.3",
+    "maxVersion": "1.1.4",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -11961,21 +12093,23 @@
     "channelVersions": {
       "stable": [
         "1.0.0",
-        "1.0.1"
+        "1.0.1",
+        "1.0.2"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "1.0.0",
-        "maxVersion": "1.0.1"
+        "maxVersion": "1.0.2"
       }
     },
     "availableVersions": [
       "1.0.0",
-      "1.0.1"
+      "1.0.1",
+      "1.0.2"
     ],
     "minVersion": "1.0.0",
-    "maxVersion": "1.0.1",
+    "maxVersion": "1.0.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -12088,13 +12222,14 @@
         "4.21.0-202603181245",
         "4.21.0-202603241611",
         "4.21.0-202603300623",
-        "4.21.0-202604060715"
+        "4.21.0-202604060715",
+        "4.21.0-202604140347"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601121715",
-        "maxVersion": "4.21.0-202604060715"
+        "maxVersion": "4.21.0-202604140347"
       }
     },
     "availableVersions": [
@@ -12107,10 +12242,11 @@
       "4.21.0-202603181245",
       "4.21.0-202603241611",
       "4.21.0-202603300623",
-      "4.21.0-202604060715"
+      "4.21.0-202604060715",
+      "4.21.0-202604140347"
     ],
     "minVersion": "4.21.0-202601121715",
-    "maxVersion": "4.21.0-202604060715",
+    "maxVersion": "4.21.0-202604140347",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -12810,6 +12946,7 @@
         "3.0.7",
         "3.0.8",
         "3.0.9",
+        "3.0.10",
         "3.1.0",
         "3.1.1",
         "3.1.2",
@@ -12817,12 +12954,15 @@
         "3.1.4",
         "3.1.5",
         "3.1.6",
+        "3.1.7",
         "3.2.0",
         "3.2.1",
         "3.2.2",
         "3.2.3",
+        "3.2.4",
         "3.3.0",
-        "3.3.1"
+        "3.3.1",
+        "3.3.2"
       ],
       "stable-3.0": [
         "3.0.0",
@@ -12834,7 +12974,8 @@
         "3.0.6",
         "3.0.7",
         "3.0.8",
-        "3.0.9"
+        "3.0.9",
+        "3.0.10"
       ],
       "stable-3.1": [
         "3.1.0",
@@ -12843,17 +12984,20 @@
         "3.1.3",
         "3.1.4",
         "3.1.5",
-        "3.1.6"
+        "3.1.6",
+        "3.1.7"
       ],
       "stable-3.2": [
         "3.2.0",
         "3.2.1",
         "3.2.2",
-        "3.2.3"
+        "3.2.3",
+        "3.2.4"
       ],
       "stable-3.3": [
         "3.3.0",
-        "3.3.1"
+        "3.3.1",
+        "3.3.2"
       ]
     },
     "channelVersionRanges": {
@@ -12863,23 +13007,23 @@
       },
       "stable": {
         "minVersion": "3.0.0",
-        "maxVersion": "3.3.1"
+        "maxVersion": "3.3.2"
       },
       "stable-3.0": {
         "minVersion": "3.0.0",
-        "maxVersion": "3.0.9"
+        "maxVersion": "3.0.10"
       },
       "stable-3.1": {
         "minVersion": "3.1.0",
-        "maxVersion": "3.1.6"
+        "maxVersion": "3.1.7"
       },
       "stable-3.2": {
         "minVersion": "3.2.0",
-        "maxVersion": "3.2.3"
+        "maxVersion": "3.2.4"
       },
       "stable-3.3": {
         "minVersion": "3.3.0",
-        "maxVersion": "3.3.1"
+        "maxVersion": "3.3.2"
       }
     },
     "availableVersions": [
@@ -12895,6 +13039,7 @@
       "3.0.7",
       "3.0.8",
       "3.0.9",
+      "3.0.10",
       "3.1.0",
       "3.1.1",
       "3.1.2",
@@ -12902,15 +13047,18 @@
       "3.1.4",
       "3.1.5",
       "3.1.6",
+      "3.1.7",
       "3.2.0",
       "3.2.1",
       "3.2.2",
       "3.2.3",
+      "3.2.4",
       "3.3.0",
-      "3.3.1"
+      "3.3.1",
+      "3.3.2"
     ],
     "minVersion": "3.0.0",
-    "maxVersion": "3.3.1",
+    "maxVersion": "3.3.2",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -13099,13 +13247,14 @@
         "4.21.0-202603181245",
         "4.21.0-202603241611",
         "4.21.0-202603300623",
-        "4.21.0-202604061320"
+        "4.21.0-202604061320",
+        "4.21.0-202604140347"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601121715",
-        "maxVersion": "4.21.0-202604061320"
+        "maxVersion": "4.21.0-202604140347"
       }
     },
     "availableVersions": [
@@ -13118,10 +13267,11 @@
       "4.21.0-202603181245",
       "4.21.0-202603241611",
       "4.21.0-202603300623",
-      "4.21.0-202604061320"
+      "4.21.0-202604061320",
+      "4.21.0-202604140347"
     ],
     "minVersion": "4.21.0-202601121715",
-    "maxVersion": "4.21.0-202604061320",
+    "maxVersion": "4.21.0-202604140347",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -13143,13 +13293,14 @@
         "4.21.0-202603181245",
         "4.21.0-202603250027",
         "4.21.0-202604011521",
-        "4.21.0-202604071949"
+        "4.21.0-202604071949",
+        "4.21.0-202604140043"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601130153",
-        "maxVersion": "4.21.0-202604071949"
+        "maxVersion": "4.21.0-202604140043"
       }
     },
     "availableVersions": [
@@ -13162,10 +13313,11 @@
       "4.21.0-202603181245",
       "4.21.0-202603250027",
       "4.21.0-202604011521",
-      "4.21.0-202604071949"
+      "4.21.0-202604071949",
+      "4.21.0-202604140043"
     ],
     "minVersion": "4.21.0-202601130153",
-    "maxVersion": "4.21.0-202604071949",
+    "maxVersion": "4.21.0-202604140043",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -13244,23 +13396,25 @@
         "4.20.0",
         "4.21.0-202603241154",
         "4.21.0-202603300623",
-        "4.21.0-202604060715"
+        "4.21.0-202604060715",
+        "4.21.0-202604140347"
       ]
     },
     "channelVersionRanges": {
       "tech-preview": {
         "minVersion": "4.20.0",
-        "maxVersion": "4.21.0-202604060715"
+        "maxVersion": "4.21.0-202604140347"
       }
     },
     "availableVersions": [
       "4.20.0",
       "4.21.0-202603241154",
       "4.21.0-202603300623",
-      "4.21.0-202604060715"
+      "4.21.0-202604060715",
+      "4.21.0-202604140347"
     ],
     "minVersion": "4.20.0",
-    "maxVersion": "4.21.0-202604060715",
+    "maxVersion": "4.21.0-202604140347",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -13331,13 +13485,14 @@
         "0.19.0-2",
         "0.19.0-3",
         "0.20.0-1",
-        "0.20.0-2"
+        "0.20.0-2",
+        "0.20.0-3"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "0.1.0-6",
-        "maxVersion": "0.20.0-2"
+        "maxVersion": "0.20.0-3"
       }
     },
     "availableVersions": [
@@ -13364,10 +13519,11 @@
       "0.19.0-2",
       "0.19.0-3",
       "0.20.0-1",
-      "0.20.0-2"
+      "0.20.0-2",
+      "0.20.0-3"
     ],
     "minVersion": "0.1.0-6",
-    "maxVersion": "0.20.0-2",
+    "maxVersion": "0.20.0-3",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"
@@ -13462,13 +13618,14 @@
         "4.21.0-202603181245",
         "4.21.0-202603242057",
         "4.21.0-202603300221",
-        "4.21.0-202604060715"
+        "4.21.0-202604060715",
+        "4.21.0-202604140043"
       ]
     },
     "channelVersionRanges": {
       "stable": {
         "minVersion": "4.21.0-202601121715",
-        "maxVersion": "4.21.0-202604060715"
+        "maxVersion": "4.21.0-202604140043"
       }
     },
     "availableVersions": [
@@ -13481,10 +13638,11 @@
       "4.21.0-202603181245",
       "4.21.0-202603242057",
       "4.21.0-202603300221",
-      "4.21.0-202604060715"
+      "4.21.0-202604060715",
+      "4.21.0-202604140043"
     ],
     "minVersion": "4.21.0-202601121715",
-    "maxVersion": "4.21.0-202604060715",
+    "maxVersion": "4.21.0-202604140043",
     "catalog": "redhat-operator-index",
     "ocpVersion": "v4.21",
     "catalogUrl": "registry.redhat.io/redhat/redhat-operator-index:v4.21"


### PR DESCRIPTION
## Summary

- **Dockerfile fix**: Add `ENV NODE_ENV=production` to the production stage.
  Without this, the container defaults to Vite dev mode and fails with
  `ENOENT: /app/index.html` since the production image only ships the
  pre-built `dist/` directory. The local run scripts (`container-run.sh`,
  `start-app.sh`) were already passing `-e NODE_ENV=production`, but the
  image itself did not set it as a default.

- **Catalog refresh**: Regenerated operator metadata for all 18 catalogs
  (OCP 4.16-4.21, Red Hat + Certified + Community operator indexes) from
  `registry.redhat.io`. Updates operator versions, channels, and
  dependency information across all supported OCP versions.

## Test plan

- [x] `npm run test` passes (unit + integration)
- [x] `npx vitest run tests/scripts/catalogDataIntegrity.test.ts` passes
- [x] `npx vitest run tests/scripts/auditFetchCatalogs.test.ts` passes
- [x] Container starts without `-e NODE_ENV=production`:
      `podman run -d -p 3001:3001 mirror-gui` serves the UI at
      http://localhost:3001
- [x] Existing Prow CI jobs pass (`lint`, `unit`, `audit-catalog`,
      `catalog-integrity`, `images`)