### PR TITLE
fix: move tsx from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0",
+    "tsx": "^4",
     "uuid": "^11.0.1",
     "yaml": "^2.4.1"
   },
@@ -71,7 +72,6 @@
     "globals": "^17.4.0",
     "prettier": "^3.2.5",
     "supertest": "^7.2.2",
-    "tsx": "^4",
     "typescript": "5.8.2",
     "typescript-eslint": "^8.56.1",
     "vite": "^6",


### PR DESCRIPTION
## Summary

Move `tsx` from `devDependencies` to `dependencies` in `package.json`.

The production image CMD runs `npx tsx server/index.ts`. With the
`ENV NODE_ENV=production` Dockerfile fix, `npm ci` skips devDependencies,
so tsx is no longer installed in the image. This caused npx to download
tsx on every container start, adding startup delay and requiring network
access.

## Test plan

- [x] Container starts without `npm warn exec` tsx download warning
- [x] UI serves at http://localhost:3001 (HTTP 200)
- [x] Prow CI jobs pass (`lint`, `unit`, `audit-catalog`, `catalog-integrity`, `images`)