### PR TITLE
Add Dependabot configuration for security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Configuration for npm dependencies (weekly security-updates)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Disable version updates, only allow security updates
+    open-pull-requests-limit: 0
+    groups:
+      mirror-gui-security-updates:
+        applies-to: security-updates
+        patterns: [ "*" ]


### PR DESCRIPTION
Configure Dependabot to monitor npm dependencies weekly for security vulnerabilities. Security updates are grouped into a single PR for easier review, while version updates are disabled.