### PR TITLE
CLID-570: fix(tests): handle EEXIST when copying catalog fixture to existing dirs

### DIFF
--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -9,7 +9,8 @@ async function globalSetup() {
   try {
     await fs.promises.access(path.join(catalogDataDest, 'catalog-index.json'));
   } catch {
-    await fs.promises.cp(catalogDataFixture, catalogDataDest, { recursive: true, force: true });
+    await fs.promises.rm(catalogDataDest, { recursive: true, force: true });
+    await fs.promises.cp(catalogDataFixture, catalogDataDest, { recursive: true });
   }
 }
 

--- a/tests/integration/helpers/setup.ts
+++ b/tests/integration/helpers/setup.ts
@@ -17,7 +17,8 @@ async function ensureCatalogFixture(): Promise<void> {
   try {
     await fs.promises.access(path.join(catalogDataDest, 'catalog-index.json'));
   } catch {
-    await fs.promises.cp(catalogDataFixture, catalogDataDest, { recursive: true, force: true });
+    await fs.promises.rm(catalogDataDest, { recursive: true, force: true });
+    await fs.promises.cp(catalogDataFixture, catalogDataDest, { recursive: true });
   }
 }
 


### PR DESCRIPTION
`fs.promises.cp` fails with `EEXIST` when target directories already exist (e.g., from `.gitkeep` checkout in CI). Since `catalog-data/` JSON files are no longer committed to git, the directory only contains empty subdirectories after clone, causing test fixture setup to fail.

Fix: remove `catalog-data/` entirely before copying the fixture when `catalog-index.json` is missing. When real synced data is present (e.g., after running `sync-catalogs.sh` locally), it is left untouched.

Changes:
- `tests/integration/helpers/setup.ts`: rm + cp instead of cp with force
- `tests/e2e/global-setup.ts`: same pattern for Playwright E2E setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup for catalog data handling by ensuring the directory is properly cleaned and re-initialized before fixture copying, enhancing test reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->