### PR TITLE
chore(deps): Bump qs (#26)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "axios": "^1.15.2",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
-        "express": "^4.21.2",
+        "express": "^4.22.2",
         "highlight.js": "^11.11.1",
         "multer": "^2.0.0-rc.3",
         "node-cron": "^4.2.1",
@@ -2578,9 +2578,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -2591,7 +2591,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -3444,14 +3444,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -3470,7 +3470,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -4962,9 +4962,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "axios": "^1.15.2",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
-    "express": "^4.21.2",
+    "express": "^4.22.2",
     "highlight.js": "^11.11.1",
     "multer": "^2.0.0-rc.3",
     "node-cron": "^4.2.1",

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -174,7 +174,23 @@ const SettingsPage: React.FC = () => {
     try {
       const response = await axios.get('/api/catalogs/sync/status');
       setCatalogSyncStatus(response.data);
-      if (response.data.status !== 'running' && syncPollRef.current) {
+      if (response.data.status === 'running' && !syncPollRef.current) {
+        syncPollRef.current = setInterval(async () => {
+          try {
+            const r = await axios.get('/api/catalogs/sync/status');
+            setCatalogSyncStatus(r.data);
+            if (r.data.status !== 'running' && syncPollRef.current) {
+              clearInterval(syncPollRef.current);
+              syncPollRef.current = null;
+            }
+          } catch (e) {
+            console.error('Error polling sync status:', e);
+          }
+        }, 3000);
+        if (!elapsedTimerRef.current) {
+          elapsedTimerRef.current = setInterval(() => setTick(t => t + 1), 1000);
+        }
+      } else if (response.data.status !== 'running' && syncPollRef.current) {
         clearInterval(syncPollRef.current);
         syncPollRef.current = null;
       }


### PR DESCRIPTION
Bumps the mirror-gui-security-updates group with 1 update in the / directory: [qs](https://github.com/ljharb/qs).


Updates `qs` from 6.14.2 to 6.15.2
- [Changelog](https://github.com/ljharb/qs/blob/main/CHANGELOG.md)
- [Commits](https://github.com/ljharb/qs/compare/v6.14.2...v6.15.2)

---
updated-dependencies:
- dependency-name: qs dependency-version: 6.15.2 dependency-type: indirect dependency-group: mirror-gui-security-updates ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated express dependency to the latest version for improvements and security updates.

* **Bug Fixes**
  * Improved sync status handling in Settings: polling and the elapsed-time indicator now start only when a sync is actively running and no poll is already active, and are reliably stopped when the sync ends to prevent duplicate timers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->