### PR TITLE
chore(deps): Bump qs via express, fix sync progress polling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "axios": "^1.15.2",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
-        "express": "^4.21.2",
+        "express": "^4.22.2",
         "highlight.js": "^11.11.1",
         "multer": "^2.0.0-rc.3",
         "node-cron": "^4.2.1",
@@ -2578,9 +2578,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -2591,7 +2591,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -3444,14 +3444,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -3470,7 +3470,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -4962,9 +4962,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "axios": "^1.15.2",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
-    "express": "^4.21.2",
+    "express": "^4.22.2",
     "highlight.js": "^11.11.1",
     "multer": "^2.0.0-rc.3",
     "node-cron": "^4.2.1",

--- a/src/components/MirrorConfig.tsx
+++ b/src/components/MirrorConfig.tsx
@@ -144,6 +144,7 @@ interface CleanConfig {
       catalog: string;
       packages: {
         name: string;
+        defaultChannel?: string;
         channels: CleanOperatorChannel[];
       }[];
     }[];
@@ -1132,14 +1133,29 @@ const MirrorConfig: React.FC = () => {
           : catalogRef;
         return {
         catalog: resolvedCatalog,
-        packages: operator.packages.map(pkg => ({
-          name: pkg.name,
-          channels: pkg.channels.map(ch => {
-            const c: CleanOperatorChannel = { name: ch.name };
-            if (ch.minVersion?.trim()) c.minVersion = ch.minVersion;
-            return c;
-          }),
-        })),
+        packages: operator.packages.map(pkg => {
+          const operatorInfo = detailedOperators[operator.catalog]
+            ?.find(op => op.name === pkg.name);
+          const selectedChannelNames = pkg.channels.map(ch => ch.name);
+          const originalDefault = operatorInfo?.defaultChannel;
+          const needsDefaultOverride = originalDefault
+            && !selectedChannelNames.includes(originalDefault);
+
+          const cleanPkg: { name: string; defaultChannel?: string; channels: CleanOperatorChannel[] } = {
+            name: pkg.name,
+            channels: pkg.channels.map(ch => {
+              const c: CleanOperatorChannel = { name: ch.name };
+              if (ch.minVersion?.trim()) c.minVersion = ch.minVersion;
+              return c;
+            }),
+          };
+
+          if (needsDefaultOverride && selectedChannelNames.length > 0) {
+            cleanPkg.defaultChannel = selectedChannelNames[0];
+          }
+
+          return cleanPkg;
+        }),
       };
       });
     }
@@ -1149,7 +1165,7 @@ const MirrorConfig: React.FC = () => {
     }
 
     return clean;
-  }, [config, useDigestRef, catalogDigestMap]);
+  }, [config, useDigestRef, catalogDigestMap, detailedOperators]);
 
   const validateConfiguration = (currentConfig: ImageSetConfig = config): string[] => {
     const errors: string[] = [];

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -174,7 +174,23 @@ const SettingsPage: React.FC = () => {
     try {
       const response = await axios.get('/api/catalogs/sync/status');
       setCatalogSyncStatus(response.data);
-      if (response.data.status !== 'running' && syncPollRef.current) {
+      if (response.data.status === 'running' && !syncPollRef.current) {
+        syncPollRef.current = setInterval(async () => {
+          try {
+            const r = await axios.get('/api/catalogs/sync/status');
+            setCatalogSyncStatus(r.data);
+            if (r.data.status !== 'running' && syncPollRef.current) {
+              clearInterval(syncPollRef.current);
+              syncPollRef.current = null;
+            }
+          } catch (e) {
+            console.error('Error polling sync status:', e);
+          }
+        }, 3000);
+        if (!elapsedTimerRef.current) {
+          elapsedTimerRef.current = setInterval(() => setTick(t => t + 1), 1000);
+        }
+      } else if (response.data.status !== 'running' && syncPollRef.current) {
         clearInterval(syncPollRef.current);
         syncPollRef.current = null;
       }

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -10,7 +10,13 @@ async function globalSetup() {
     await fs.promises.access(path.join(catalogDataDest, 'catalog-index.json'));
   } catch {
     await fs.promises.rm(catalogDataDest, { recursive: true, force: true });
-    await fs.promises.cp(catalogDataFixture, catalogDataDest, { recursive: true });
+    await fs.promises.mkdir(catalogDataDest, { recursive: true });
+    const entries = await fs.promises.readdir(catalogDataFixture, { withFileTypes: true });
+    for (const entry of entries) {
+      const src = path.join(catalogDataFixture, entry.name);
+      const dest = path.join(catalogDataDest, entry.name);
+      await fs.promises.cp(src, dest, { recursive: true, force: true });
+    }
   }
 }
 

--- a/tests/integration/helpers/setup.ts
+++ b/tests/integration/helpers/setup.ts
@@ -18,7 +18,13 @@ async function ensureCatalogFixture(): Promise<void> {
     await fs.promises.access(path.join(catalogDataDest, 'catalog-index.json'));
   } catch {
     await fs.promises.rm(catalogDataDest, { recursive: true, force: true });
-    await fs.promises.cp(catalogDataFixture, catalogDataDest, { recursive: true });
+    await fs.promises.mkdir(catalogDataDest, { recursive: true });
+    const entries = await fs.promises.readdir(catalogDataFixture, { withFileTypes: true });
+    for (const entry of entries) {
+      const src = path.join(catalogDataFixture, entry.name);
+      const dest = path.join(catalogDataDest, entry.name);
+      await fs.promises.cp(src, dest, { recursive: true, force: true });
+    }
   }
 }
 


### PR DESCRIPTION
- **chore(deps):** Bump `qs` from 6.14.2 to 6.15.2 via `express` 4.21.2 → 4.22.2 (Dependabot security update)
- **fix(ui):** Auto-start sync progress polling on page load — when navigating to Settings while a catalog sync is already running, the progress bar and logs now update in real time instead of showing stale data from the initial fetch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Catalog sync now auto-polls every 3 seconds during active sync and displays a live elapsed-time counter.
  * Cleaned operator package output can now include a default channel when needed to preserve package defaults.

* **Chores**
  * Updated Express framework dependency to v4.22.2.

* **Tests**
  * More granular catalog fixture initialization to improve test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->