### PR TITLE
CLID-661: Improve catalog digest display for CI-built images

### DIFF
--- a/src/components/MirrorConfig.tsx
+++ b/src/components/MirrorConfig.tsx
@@ -487,7 +487,7 @@ const MirrorConfig: React.FC = () => {
   const catalogDigestMap = useMemo(() => {
     const map: Record<string, string> = {};
     for (const cat of availableCatalogs) {
-      if (cat.digest && cat.digest !== 'unknown') {
+      if (cat.digest && cat.digest.startsWith('sha256:')) {
         map[cat.url] = cat.digest;
       }
     }

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import axios from 'axios';
 import {
@@ -141,34 +141,16 @@ const SettingsPage: React.FC = () => {
   const [catalogDigests, setCatalogDigests] = useState<{ name: string; url: string; digest: string | null; syncedAt: string | null }[]>([]);
   const [digestsExpanded, setDigestsExpanded] = useState(false);
   /** Snapshot of digest by `catalogName:ocpVersion` taken when sync starts; used to label Updated vs Unchanged after sync. */
-  const [preSyncDigests, setPreSyncDigests] = useState<Record<string, string>>({});
 
   const fetchCatalogDigests = useCallback(async () => {
     try {
       const response = await axios.get('/api/catalogs');
-      const withDigest = response.data.filter((c: any) => c.digest && c.digest !== 'unknown');
-      setCatalogDigests(withDigest);
+      setCatalogDigests(response.data);
     } catch {
       setCatalogDigests([]);
     }
   }, []);
 
-  const digestChangeStats = useMemo(() => {
-    let updated = 0;
-    let tracked = 0;
-    for (const cat of catalogDigests) {
-      const ocp = cat.url.split(':').pop() || '';
-      const key = `${cat.name}:${ocp}`;
-      if (!Object.prototype.hasOwnProperty.call(preSyncDigests, key)) {
-        continue;
-      }
-      tracked += 1;
-      if ((preSyncDigests[key] || '') !== (cat.digest || '')) {
-        updated += 1;
-      }
-    }
-    return { updated, tracked };
-  }, [catalogDigests, preSyncDigests]);
 
   const fetchSyncStatus = useCallback(async () => {
     try {
@@ -202,13 +184,6 @@ const SettingsPage: React.FC = () => {
   const startCatalogSync = async () => {
     try {
       await axios.post('/api/catalogs/sync');
-
-      const snapshot: Record<string, string> = {};
-      for (const cat of catalogDigests) {
-        const ocp = cat.url.split(':').pop() || '';
-        snapshot[`${cat.name}:${ocp}`] = cat.digest || '';
-      }
-      setPreSyncDigests(snapshot);
 
       setCatalogSyncStatus(prev => ({ ...prev, status: 'running', syncStartTime: new Date().toISOString(), logs: [], error: null, diff: [] }));
       syncPollRef.current = setInterval(fetchSyncStatus, 3000);
@@ -256,7 +231,6 @@ const SettingsPage: React.FC = () => {
     try {
       const response = await axios.delete('/api/catalogs/sync/data');
       addSuccessAlert(response.data.message);
-      setPreSyncDigests({});
       await fetchSyncStatus();
       await fetchCatalogDigests();
     } catch (error: any) {
@@ -810,11 +784,7 @@ const SettingsPage: React.FC = () => {
 
                 {catalogDigests.length > 0 && (
                   <ExpandableSection
-                    toggleText={
-                      digestChangeStats.updated > 0
-                        ? `Catalog Digests (${catalogDigests.length}) — ${digestChangeStats.updated} updated`
-                        : `Catalog Digests (${catalogDigests.length})`
-                    }
+                    toggleText={`Catalog Digests (${catalogDigests.length})`}
                     isExpanded={digestsExpanded}
                     onToggle={(_e, expanded) => setDigestsExpanded(expanded)}
                     className="pf-v6-u-mt-lg"
@@ -826,46 +796,48 @@ const SettingsPage: React.FC = () => {
                           <Th>OCP</Th>
                           <Th>Digest</Th>
                           <Th>Synced</Th>
-                          <Th>Status</Th>
                         </Tr>
                       </Thead>
                       <Tbody>
                         {catalogDigests.map((cat, i) => {
                           const ocp = cat.url.split(':').pop() || '';
-                          const shortDigest = cat.digest ? `${cat.digest.slice(0, 19)}...` : '';
+                          const isRealDigest = cat.digest?.startsWith('sha256:');
+                          const shortDigest = isRealDigest ? `${cat.digest!.slice(0, 19)}...` : '';
                           const digestKey = `${cat.name}:${ocp}`;
-                          const hasPreSync = Object.prototype.hasOwnProperty.call(preSyncDigests, digestKey);
-                          const digestChanged = hasPreSync && (preSyncDigests[digestKey] || '') !== (cat.digest || '');
                           return (
                             <Tr key={`${digestKey}-${i}`}>
                               <Td>{cat.name}</Td>
                               <Td>{ocp}</Td>
                               <Td>
-                                <Tooltip content={cat.digest || ''}>
-                                  <span style={{ fontFamily: 'var(--pf-t--global--font--family--mono)', fontSize: '0.85rem', cursor: 'default' }}>
-                                    {shortDigest}
-                                  </span>
-                                </Tooltip>
-                                {' '}
-                                <Button
-                                  variant="plain"
-                                  isInline
-                                  icon={<CopyIcon />}
-                                  onClick={() => {
-                                    navigator.clipboard.writeText(cat.digest || '');
-                                    addSuccessAlert('Digest copied');
-                                  }}
-                                  aria-label="Copy digest"
-                                  style={{ padding: 0 }}
-                                />
+                                <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }} flexWrap={{ default: 'nowrap' }}>
+                                  {isRealDigest ? (
+                                    <>
+                                      <Tooltip content={cat.digest || ''}>
+                                        <Label color="blue" isCompact><span style={{ fontFamily: 'var(--pf-t--global--font--family--mono)' }}>{shortDigest}</span></Label>
+                                      </Tooltip>
+                                      <Button
+                                        variant="plain"
+                                        isInline
+                                        icon={<CopyIcon />}
+                                        onClick={() => {
+                                          navigator.clipboard.writeText(cat.digest || '');
+                                          addSuccessAlert('Digest copied');
+                                        }}
+                                        aria-label="Copy digest"
+                                        style={{ padding: 0 }}
+                                      />
+                                    </>
+                                  ) : (
+                                    <Tooltip content="Run Sync Catalogs to fetch real digests">
+                                      <Label color="orange" isCompact icon={<InfoCircleIcon />}>N/A</Label>
+                                    </Tooltip>
+                                  )}
+                                </Flex>
                               </Td>
                               <Td>
-                                {cat.syncedAt && <Timestamp date={new Date(cat.syncedAt)} tooltip={{ variant: 'default' }} />}
-                              </Td>
-                              <Td>
-                                {digestChanged
-                                  ? <Label color="green" isCompact>Updated</Label>
-                                  : <Label color="grey" isCompact>Current</Label>}
+                                {cat.syncedAt
+                                  ? <Timestamp date={new Date(cat.syncedAt)} tooltip={{ variant: 'default' }} />
+                                  : <span className="pf-v6-u-color-200">Not synced</span>}
                               </Td>
                             </Tr>
                           );

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -795,7 +795,7 @@ const SettingsPage: React.FC = () => {
                           <Th>Catalog</Th>
                           <Th>OCP</Th>
                           <Th>Digest</Th>
-                          <Th>Synced</Th>
+                          <Th>Updated</Th>
                         </Tr>
                       </Thead>
                       <Tbody>
@@ -828,7 +828,7 @@ const SettingsPage: React.FC = () => {
                                       />
                                     </>
                                   ) : (
-                                    <Tooltip content="Run Sync Catalogs to fetch real digests">
+                                    <Tooltip content="Built-in catalog data does not include digests. Run Sync Catalogs to fetch them.">
                                       <Label color="orange" isCompact icon={<InfoCircleIcon />}>N/A</Label>
                                     </Tooltip>
                                   )}


### PR DESCRIPTION
CI-built images use multi-stage `FROM` instructions to pull catalog index
images, so real SHA256 digests are not available at build time. This PR
improves the UI to handle that gracefully.

**Changes:**

- `Settings.tsx`: Show `N/A` with an informative tooltip ("Built-in catalog
  data does not include digests. Run Sync Catalogs to fetch them.") instead
  of displaying placeholder values like `from-build`
- `Settings.tsx`: Remove the redundant Status column from the Catalog Digests
  table
- `Settings.tsx`: Rename the `Synced` column to `Updated` so the timestamp
  label is accurate for both baked-in image data and runtime sync results
- `Settings.tsx`: Use monospace font and PatternFly `Flex` for consistent
  digest label alignment; clean up unused state and imports
- `MirrorConfig.tsx`: Filter `catalogDigestMap` to only accept `sha256:`
  prefixed digests, correctly disabling "Use digest references" until a
  runtime sync provides real digests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Features**
  * Updated digest validation to recognize only properly formatted digests in catalog configuration.
  * Simplified the Catalog Digests table UI with streamlined column display.

* **Bug Fixes**
  * Fixed digest filtering logic to correctly identify valid catalog digest references.
  * Improved display of invalid digests with clearer "N/A" indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->