### PR TITLE
chore(deps-security): bump axios from 1.15.2 to 1.16.0; fix test fixture race

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@patternfly/react-icons": "^6",
         "@patternfly/react-table": "^6",
         "@patternfly/react-templates": "^6.4.3",
-        "axios": "^1.15.2",
+        "axios": "^1.16.0",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
         "express": "^4.22.2",
@@ -2547,12 +2547,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@patternfly/react-icons": "^6",
     "@patternfly/react-table": "^6",
     "@patternfly/react-templates": "^6.4.3",
-    "axios": "^1.15.2",
+    "axios": "^1.16.0",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "express": "^4.22.2",

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,23 +1,7 @@
-import fs from 'fs';
-import path from 'path';
-
-const projectRoot = path.resolve(import.meta.dirname, '../..');
-const catalogDataDest = path.join(projectRoot, 'catalog-data');
-const catalogDataFixture = path.join(projectRoot, 'tests/fixtures/catalog-data');
+import { ensureCatalogFixture } from '../helpers/catalogDataFixture.js';
 
 async function globalSetup() {
-  try {
-    await fs.promises.access(path.join(catalogDataDest, 'catalog-index.json'));
-  } catch {
-    await fs.promises.rm(catalogDataDest, { recursive: true, force: true });
-    await fs.promises.mkdir(catalogDataDest, { recursive: true });
-    const entries = await fs.promises.readdir(catalogDataFixture, { withFileTypes: true });
-    for (const entry of entries) {
-      const src = path.join(catalogDataFixture, entry.name);
-      const dest = path.join(catalogDataDest, entry.name);
-      await fs.promises.cp(src, dest, { recursive: true, force: true });
-    }
-  }
+  await ensureCatalogFixture();
 }
 
 export default globalSetup;

--- a/tests/helpers/catalogDataFixture.ts
+++ b/tests/helpers/catalogDataFixture.ts
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+
+const projectRoot = path.resolve(import.meta.dirname, '../..');
+const catalogDataDest = path.join(projectRoot, 'catalog-data');
+const catalogDataFixture = path.join(projectRoot, 'tests/fixtures/catalog-data');
+
+export async function ensureCatalogFixture(): Promise<void> {
+  try {
+    await fs.promises.access(path.join(catalogDataDest, 'catalog-index.json'));
+  } catch {
+    await fs.promises.rm(catalogDataDest, { recursive: true, force: true });
+    await fs.promises.mkdir(catalogDataDest, { recursive: true });
+    const entries = await fs.promises.readdir(catalogDataFixture, { withFileTypes: true });
+    for (const entry of entries) {
+      const src = path.join(catalogDataFixture, entry.name);
+      const dest = path.join(catalogDataDest, entry.name);
+      await fs.promises.cp(src, dest, { recursive: true, force: true });
+    }
+  }
+}

--- a/tests/integration/helpers/globalSetup.ts
+++ b/tests/integration/helpers/globalSetup.ts
@@ -1,0 +1,5 @@
+import { ensureCatalogFixture } from '../../helpers/catalogDataFixture.js';
+
+export default async function globalSetup() {
+  await ensureCatalogFixture();
+}

--- a/tests/integration/helpers/setup.ts
+++ b/tests/integration/helpers/setup.ts
@@ -9,25 +9,6 @@ process.env.VITEST = 'true';
 process.env.STORAGE_DIR = storageDir;
 process.env.OC_MIRROR_AUTHFILE = path.join(storageDir, 'pull-secret.json');
 
-const projectRoot = path.resolve(import.meta.dirname, '../../..');
-const catalogDataDest = path.join(projectRoot, 'catalog-data');
-const catalogDataFixture = path.join(projectRoot, 'tests/fixtures/catalog-data');
-
-async function ensureCatalogFixture(): Promise<void> {
-  try {
-    await fs.promises.access(path.join(catalogDataDest, 'catalog-index.json'));
-  } catch {
-    await fs.promises.rm(catalogDataDest, { recursive: true, force: true });
-    await fs.promises.mkdir(catalogDataDest, { recursive: true });
-    const entries = await fs.promises.readdir(catalogDataFixture, { withFileTypes: true });
-    for (const entry of entries) {
-      const src = path.join(catalogDataFixture, entry.name);
-      const dest = path.join(catalogDataDest, entry.name);
-      await fs.promises.cp(src, dest, { recursive: true, force: true });
-    }
-  }
-}
-
 export async function ensureTestDirs(): Promise<void> {
   const dirs = [
     storageDir,
@@ -41,7 +22,6 @@ export async function ensureTestDirs(): Promise<void> {
   for (const dir of dirs) {
     await fs.promises.mkdir(dir, { recursive: true });
   }
-  await ensureCatalogFixture();
 }
 
 export async function cleanupTestDirs(): Promise<void> {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ import path from 'path';
 export default defineConfig({
   test: {
     environment: 'node',
+    globalSetup: ['tests/integration/helpers/globalSetup.ts'],
     include: ['tests/**/*.test.ts'],
     exclude: ['tests/e2e/**'],
     coverage: {


### PR DESCRIPTION
## Summary

Updates `axios` from `1.15.2` to `1.16.0` to pick up security fixes in the latest release. This also updates the transitive dependency `follow-redirects` from `^1.15.11` to `^1.16.0`.

Additionally fixes a pre-existing race condition in the vitest integration test setup that caused `ENOENT` failures in CI.

## Security fixes

- **CVE-2026-44494** (Critical, CVSS 9.4): Prototype pollution gadget in `config.proxy` enables full MitM — intercepting, reading, and modifying all HTTP traffic including credentials
- **CVE-2026-44487**: `Proxy-Authorization` credential leak to origin server during HTTP-to-HTTPS redirect flows through an authenticated proxy
- **CVE-2026-44489** (Medium, CVSS 5.4): Patch bypass of the 1.15.2 `Object.create(null)` fix — nested objects from `utils.merge()` still inherit from `Object.prototype`, re-enabling Proxy-Authorization header injection

## Notable behavioral changes

- Fetch adapter now enforces `maxBodyLength` / `maxContentLength` (previously silently ignored)
- Proxy requests preserve user-supplied `Host` headers
- Basic auth credentials embedded in URLs are now URL-decoded
- Stale `Proxy-Authorization` headers are cleared when a redirect targets a no-proxy host

## Impact assessment

Mirror GUI uses `axios` in a straightforward way: simple `get`/`post`/`delete` calls to relative `/api/*` endpoints, with no custom instances, proxy configuration, or redirect handling. The behavioral changes in 1.16.0 do not affect current usage.

## Dependency changes

- `package.json`: `axios` `^1.15.2` → `^1.16.0`
- `package-lock.json`: lock `axios` to `1.16.0` and `follow-redirects` to `1.16.0`

## Test fixture race fix

Moves the `catalog-data` fixture bootstrap out of per-test-file `ensureTestDirs()` into a vitest `globalSetup` so it runs exactly once before any test file. This eliminates the parallel `ENOENT`/`EEXIST` race that occurs when multiple vitest workers simultaneously `rm`/`mkdir`/`cp` the shared `catalog-data` directory.

- Extract bootstrap logic into shared helper (`tests/helpers/catalogDataFixture.ts`)
- Add vitest `globalSetup` (`tests/integration/helpers/globalSetup.ts`)
- Remove `ensureCatalogFixture()` from per-file `ensureTestDirs()`
- Update Playwright `global-setup.ts` to use the same shared helper

## Test plan

- [x] Rebuilt the container image with the updated dependencies
- [x] Restarted the application and verified it serves correctly
- [x] Ran the full Playwright E2E suite: **59 passed**
- [x] Cleared `catalog-data/` to CI-like empty state (only `.gitkeep`)
- [x] Ran `vitest run`: **19 test files passed, 127 tests passed**
- [x] Verified in a fresh isolated clone with empty `catalog-data/`

## References

- [axios v1.16.0 release notes](https://github.com/axios/axios/releases/tag/v1.16.0)
- [GHSA-35jp-ww65-95wh](https://github.com/axios/axios/security/advisories/GHSA-35jp-ww65-95wh) (CVE-2026-44494)
- [GHSA-p92q-9vqr-4j8v](https://github.com/axios/axios/security/advisories/GHSA-p92q-9vqr-4j8v) (CVE-2026-44487)
- [GHSA-654m-c8p4-x5fp](https://github.com/axios/axios/security/advisories/GHSA-654m-c8p4-x5fp) (CVE-2026-44489)