### PR TITLE
fix: skip operation history cleanup during vitest runs

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -244,7 +244,9 @@ async function clearOperationHistory(): Promise<void> {
 }
 
 ensureDirectories().then(() => {
-  clearOperationHistory();
+  if (process.env.VITEST !== 'true') {
+    clearOperationHistory();
+  }
 });
 
 async function getSystemInfo(): Promise<SystemInfo> {


### PR DESCRIPTION
## Summary
- Skip `clearOperationHistory()` when `VITEST === 'true'` to prevent a race
  between server startup cleanup and seeded fixtures in
  `tests/integration/operationsLifecycle.test.ts`.
- Uses the same `VITEST` guard already applied to `startServer()` in
  `server/index.ts`.

## Problem
On module import, the server asynchronously clears operation/log files when
`mirrors/default` is empty. Integration tests seed operation fixtures after
import, so cleanup can delete those files and cause intermittent failures
(ENOENT / 404 / SSE timeout) in `unit-and-integration`.

## Impact
- Production and normal container startup are unchanged (`VITEST` is unset).
- Only vitest runs skip this cleanup; each test already uses an isolated
  temp `STORAGE_DIR`.

## Test plan
- [x] `npx vitest run tests/integration/operationsLifecycle.test.ts`
- [x] Branch CI green (unit-and-integration, e2e, shellcheck, container-image)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved operation history and log files during integration test runs.
  * Prevented unnecessary clearing of persisted history when running in the test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->