### PR TITLE
Fix POST /api/config/save HTTP 500 for object payloads

### DIFF
--- a/API.md
+++ b/API.md
@@ -257,7 +257,7 @@ Download a saved ImageSetConfiguration YAML file from the configs directory. The
 Save a new configuration.
 
 **Request Body:**
-- `name` (string, optional): Filename for the saved configuration (defaults to `imageset-config-<timestamp>.yaml`)
+- `name` (string, optional): Filename for the saved configuration (defaults to `imageset-config-<timestamp>.yaml`). `.yaml` is appended automatically if the name does not end with `.yaml` or `.yml`.
 - `config` (string or object, required): The ImageSetConfiguration — either as a YAML string or a JSON object
 
 **Example — JSON object:**

--- a/API.md
+++ b/API.md
@@ -257,15 +257,33 @@ Download a saved ImageSetConfiguration YAML file from the configs directory. The
 Save a new configuration.
 
 **Request Body:**
+- `name` (string, optional): Filename for the saved configuration (defaults to `imageset-config-<timestamp>.yaml`)
+- `config` (string or object, required): The ImageSetConfiguration — either as a YAML string or a JSON object
+
+**Example — JSON object:**
 ```json
 {
-  "name": "Configuration Name",
+  "name": "test-config",
   "config": {
     "kind": "ImageSetConfiguration",
     "apiVersion": "mirror.openshift.io/v2alpha1",
     "archiveSize": 4,
-    "mirror": { ... }
+    "mirror": {
+      "platform": {
+        "channels": [{"name": "stable-4.16", "minVersion": "4.16.0", "maxVersion": "4.16.3"}]
+      },
+      "operators": [],
+      "additionalImages": []
+    }
   }
+}
+```
+
+**Example — YAML string:**
+```json
+{
+  "name": "test-config.yaml",
+  "config": "kind: ImageSetConfiguration\napiVersion: mirror.openshift.io/v2alpha1\nmirror:\n  platform:\n    channels:\n      - name: stable-4.16\n        minVersion: \"4.16.0\"\n        maxVersion: \"4.16.3\"\n  operators: []\n  additionalImages: []"
 }
 ```
 
@@ -275,13 +293,14 @@ Save a new configuration.
 **Response:**
 ```json
 {
-  "success": true,
-  "data": {
-    "id": "config-id",
-    "message": "Configuration saved successfully"
-  }
+  "message": "Configuration saved successfully",
+  "filename": "test-config"
 }
 ```
+
+**Error (400):** Missing `config`, invalid YAML, or configuration fails validation (wrong `kind`, `apiVersion`, or missing `mirror` section).
+
+**Error (500):** Failed to write configuration file.
 
 #### POST /api/config/upload
 Upload a YAML configuration file.

--- a/server/index.ts
+++ b/server/index.ts
@@ -1027,7 +1027,10 @@ app.post('/api/config/save', async (req: Request, res: Response) => {
       return res.status(400).json({ error: `Invalid YAML: ${(yamlError as Error).message}` });
     }
 
-    const filename = name || `imageset-config-${Date.now()}.yaml`;
+    const rawName = name || `imageset-config-${Date.now()}.yaml`;
+    const filename = rawName.endsWith('.yaml') || rawName.endsWith('.yml')
+      ? rawName
+      : `${rawName}.yaml`;
     const filepath = path.join(CONFIGS_DIR, filename);
     await fsp.writeFile(filepath, yamlString);
     res.json({ message: 'Configuration saved successfully', filename });

--- a/server/index.ts
+++ b/server/index.ts
@@ -998,12 +998,41 @@ app.get('/api/config/download/:filename', async (req: Request, res: Response) =>
 app.post('/api/config/save', async (req: Request, res: Response) => {
   try {
     const { config, name } = req.body;
+
+    if (config === undefined || config === null || config === '') {
+      return res.status(400).json({ error: 'config is required' });
+    }
+
+    let yamlString: string;
+    if (typeof config === 'string') {
+      yamlString = config;
+    } else if (typeof config === 'object' && !Array.isArray(config)) {
+      yamlString = YAML.stringify(config);
+    } else {
+      return res.status(400).json({ error: 'config must be a YAML string or JSON object' });
+    }
+
+    try {
+      const parsed = YAML.parse(yamlString);
+      if (!parsed?.kind || parsed.kind !== 'ImageSetConfiguration') {
+        return res.status(400).json({ error: 'Invalid configuration: Must be an ImageSetConfiguration' });
+      }
+      if (!parsed.apiVersion || !parsed.apiVersion.includes('mirror.openshift.io')) {
+        return res.status(400).json({ error: 'Invalid configuration: Must have mirror.openshift.io API version' });
+      }
+      if (!parsed.mirror) {
+        return res.status(400).json({ error: 'Invalid configuration: Missing mirror section' });
+      }
+    } catch (yamlError: unknown) {
+      return res.status(400).json({ error: `Invalid YAML: ${(yamlError as Error).message}` });
+    }
+
     const filename = name || `imageset-config-${Date.now()}.yaml`;
     const filepath = path.join(CONFIGS_DIR, filename);
-
-    await fsp.writeFile(filepath, config);
+    await fsp.writeFile(filepath, yamlString);
     res.json({ message: 'Configuration saved successfully', filename });
-  } catch {
+  } catch (err) {
+    console.error('Failed to save configuration:', err);
     res.status(500).json({ error: 'Failed to save configuration' });
   }
 });

--- a/server/index.ts
+++ b/server/index.ts
@@ -999,6 +999,15 @@ app.post('/api/config/save', async (req: Request, res: Response) => {
   try {
     const { config, name } = req.body;
 
+    if (name !== undefined && name !== null && name !== '') {
+      if (typeof name !== 'string') {
+        return res.status(400).json({ error: 'name must be a string' });
+      }
+      if (name !== path.basename(name)) {
+        return res.status(400).json({ error: 'Invalid filename' });
+      }
+    }
+
     if (config === undefined || config === null || config === '') {
       return res.status(400).json({ error: 'config is required' });
     }

--- a/tests/integration/config.test.ts
+++ b/tests/integration/config.test.ts
@@ -106,6 +106,24 @@ describe('Config API', () => {
       expect(res.status).toBe(400);
       expect(res.body.error).toContain('YAML string or JSON object');
     });
+
+    it('returns 400 when name is not a string', async () => {
+      const res = await request.post('/api/config/save').send({
+        name: 123,
+        config: validConfigYaml,
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('name must be a string');
+    });
+
+    it('returns 400 for path traversal in name', async () => {
+      const res = await request.post('/api/config/save').send({
+        name: '../../evil',
+        config: validConfigYaml,
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('Invalid filename');
+    });
   });
 
   describe('POST /api/config/upload', () => {

--- a/tests/integration/config.test.ts
+++ b/tests/integration/config.test.ts
@@ -14,6 +14,18 @@ mirror:
   additionalImages: []
 `;
 
+const validConfigObject = {
+  kind: 'ImageSetConfiguration',
+  apiVersion: 'mirror.openshift.io/v2alpha1',
+  mirror: {
+    platform: {
+      channels: [{ name: 'stable-4.16', minVersion: '4.16.0', maxVersion: '4.16.3' }],
+    },
+    operators: [],
+    additionalImages: [],
+  },
+};
+
 describe('Config API', () => {
   let request: Awaited<ReturnType<typeof getTestApp>>;
 
@@ -37,6 +49,54 @@ describe('Config API', () => {
       expect(res.status).toBe(200);
       expect(res.body.message).toContain('successfully');
       expect(res.body.filename).toBe('test-save.yaml');
+    });
+
+    it('saves config object payload (issue #42 scenario)', async () => {
+      const res = await request
+        .post('/api/config/save')
+        .send({ config: validConfigObject, name: 'test-config' });
+      expect(res.status).toBe(200);
+      expect(res.body.message).toContain('successfully');
+      expect(res.body.filename).toBe('test-config');
+    });
+
+    it('returns 400 when config is missing', async () => {
+      const res = await request
+        .post('/api/config/save')
+        .send({ name: 'missing-config.yaml' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('config is required');
+    });
+
+    it('returns 400 for invalid kind', async () => {
+      const res = await request.post('/api/config/save').send({
+        name: 'bad-kind.yaml',
+        config: {
+          kind: 'NotImageSetConfiguration',
+          apiVersion: 'mirror.openshift.io/v2alpha1',
+          mirror: {},
+        },
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('ImageSetConfiguration');
+    });
+
+    it('returns 400 for invalid YAML string', async () => {
+      const res = await request.post('/api/config/save').send({
+        name: 'bad-yaml.yaml',
+        config: 'kind: ImageSetConfiguration\n  invalid: yaml: [',
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('Invalid YAML');
+    });
+
+    it('returns 400 when config is not a string or object', async () => {
+      const res = await request.post('/api/config/save').send({
+        name: 'bad-type.yaml',
+        config: 123,
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('YAML string or JSON object');
     });
   });
 

--- a/tests/integration/config.test.ts
+++ b/tests/integration/config.test.ts
@@ -57,7 +57,15 @@ describe('Config API', () => {
         .send({ config: validConfigObject, name: 'test-config' });
       expect(res.status).toBe(200);
       expect(res.body.message).toContain('successfully');
-      expect(res.body.filename).toBe('test-config');
+      expect(res.body.filename).toBe('test-config.yaml');
+    });
+
+    it('appends .yaml when name has no extension', async () => {
+      const res = await request
+        .post('/api/config/save')
+        .send({ config: validConfigYaml, name: 'no-ext' });
+      expect(res.status).toBe(200);
+      expect(res.body.filename).toBe('no-ext.yaml');
     });
 
     it('returns 400 when config is missing', async () => {


### PR DESCRIPTION
## Summary
- Fix `POST /api/config/save` returning HTTP 500 when `config` is a JSON object (as documented in `API.md`)
- Accept `config` as YAML string or JSON object; validate structure; return 400 for bad input
- Append `.yaml` automatically when `name` has no extension
- Update `API.md` to match actual request/response contract

Fixes https://github.com/openshift/mirror-gui/issues/42

## Test plan
- [x] `npx vitest run tests/integration/config.test.ts` — 17 passed
- [x] Curl Attempt 1 from #42 (object payload) → HTTP 200
- [x] UI Save Configuration regression check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The configuration save endpoint now accepts either YAML text or structured JSON configuration objects.
  * Saved filenames automatically get a `.yaml` extension (and use a timestamp-based default when omitted).
  * Successful requests now return the saved filename.

* **Bug Fixes**
  * Added stricter validation for required configuration details, supported configuration type, and correct request payload shapes.
  * Invalid inputs (including unsafe filename path components) now return clear `400` errors instead of saving.

* **Documentation / Tests**
  * Updated API documentation and expanded integration coverage for the new payload formats and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->