### PR TITLE
CLID-644: Add TROUBLESHOOTING.md and docs/dev/ engineering docs

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,109 @@
+# Troubleshooting
+
+## Server logs
+
+View container logs to diagnose issues:
+
+```bash
+./mirror-gui.sh --logs    # pre-built image
+./local-build.sh --logs   # local build
+```
+
+Use `mirror-gui.sh` when running a pre-built image from the registry; use `local-build.sh` when building from source locally. Both scripts accept the same `--logs`, `--status`, `--stop`, and `--restart` flags.
+
+The server logs all incoming HTTP requests with timestamps and writes oc-mirror operation output to individual log files under the data directory.
+
+## Container startup issues
+
+If the container fails to start, check that the required port is available:
+
+```bash
+# Check if port 3000 is in use
+ss -tlnp | grep 3000
+```
+
+Both scripts automatically select the next available port if `3000` is occupied. Look for the `Web UI:` line in the script output.
+
+If the container starts but the UI is unreachable, verify the container is running:
+
+```bash
+./mirror-gui.sh --status    # pre-built image
+./local-build.sh --status   # local build
+```
+
+## Pull secret issues
+
+Mirror-GUI requires a valid pull secret to authenticate with container registries. If the dashboard shows "No pull secret detected":
+
+1. Upload a pull secret via **Settings > Pull Secret** in the UI
+2. Or place it at `pull-secret/pull-secret.json` before building the container
+
+The pull secret must be valid JSON in the standard Docker/Podman auth format with an `auths` key.
+
+To verify registry authentication, use the **Settings > Registry** tab — it shows auto-detected registries from your pull secret and can test authentication against each one.
+
+## Catalog data issues
+
+Mirror-GUI bundles pre-fetched operator catalog metadata at build time. If operators or channels appear missing or outdated:
+
+1. Use **Settings > Sync Catalogs** to fetch the latest catalog metadata from registry.redhat.io
+2. This requires a valid pull secret with access to `registry.redhat.io`
+3. The sync processes three catalog types (Red Hat, Certified, Community) across OCP 4.16–4.22
+
+If the sync fails, check that your pull secret has valid credentials for `registry.redhat.io`. See the sync logs in the Settings tab for specific errors.
+
+To reset to built-in catalog data, use the "Clear Synced Data" option in the Sync Catalogs tab.
+
+## Mirror operation failures
+
+When a mirror operation fails:
+
+1. Check the operation logs — click on the failed operation in **Mirror Operations** or **History** to view logs
+2. Common issues:
+   - **Authentication failures**: Verify pull secret credentials for the source registries
+   - **Disk space**: Check available disk space in the mirror destination and cache directories
+   - **Invalid configuration**: Verify the ImageSetConfiguration YAML is valid — the config builder validates structure on save
+   - **Network issues**: Ensure the container can reach the source registries
+
+## GPG signature errors
+
+**Invalid GPG signature for operator index images** — This is a known issue with some Red Hat operator index images. See [Red Hat KB article](https://access.redhat.com/solutions/6542281) for resolution.
+
+## Cache issues
+
+The oc-mirror cache can grow large over time. To clean it up:
+
+1. Use **Settings > Cache** to view cache size and clean up
+2. Or restart the container — the cache is ephemeral unless a persistent volume is mounted via `CACHE_DIR`
+
+## Development issues
+
+### Tests failing locally
+
+```bash
+# Ensure dependencies are installed
+npm ci
+
+# Run tests with verbose output
+npm test -- --reporter=verbose
+
+# Run a specific test file
+npx vitest run tests/unit/utils.test.ts
+```
+
+### E2E tests failing
+
+E2E tests require Playwright browsers to be installed:
+
+```bash
+npx playwright install chromium
+npm run test:e2e
+```
+
+### Port conflicts in development
+
+The development server runs on port 3001 by default. If this conflicts:
+
+```bash
+PORT=3002 npm run dev
+```

--- a/docs/dev/catalog-pipeline.md
+++ b/docs/dev/catalog-pipeline.md
@@ -1,0 +1,22 @@
+# Catalog Data Pipeline
+
+Mirror-GUI uses pre-fetched operator catalog metadata rather than querying registries at runtime. This enables offline browsing and avoids rate-limiting or authentication issues during catalog exploration.
+
+## How it works
+
+1. `sync-catalogs.sh` extracts File-Based Catalog (FBC) data from Red Hat operator index images for each supported OCP version (4.16–4.22) and catalog type (Red Hat, Certified, Community).
+
+2. The script parses FBC YAML to produce structured JSON files per catalog: `operators.json` (operator names, channels, versions, default channels), `dependencies.json` (inter-operator dependency mappings), and `catalog-info.json` (catalog metadata with digest and sync timestamp).
+
+3. A top-level `catalog-index.json` registers all processed catalogs with their URLs, types, versions, and digests.
+
+4. The server loads this data lazily on first API request and caches it in memory for the lifetime of the process. A runtime sync (triggered from the UI) writes fresh data to a separate runtime directory that takes precedence over the built-in data.
+
+## Catalog sync diffing
+
+When a catalog sync completes, the server computes a diff between the previous and new catalog data. This diff identifies:
+- New operators added to a catalog
+- Operators removed from a catalog
+- Operators with new versions available
+
+The diff is exposed via the sync status API and displayed in the UI, so users can see what changed without comparing raw JSON.

--- a/docs/dev/operations.md
+++ b/docs/dev/operations.md
@@ -1,0 +1,13 @@
+# Operation Lifecycle
+
+Mirror operations go through this lifecycle:
+
+1. **Start**: The server validates the config file exists, creates/validates the mirror destination directory (checking write permissions), saves an `OperationRecord` JSON file, and spawns `oc-mirror --v2` as a child process.
+
+2. **Running**: stdout and stderr are piped to a log file. The server tracks the child process by operation ID. The frontend can connect to an SSE endpoint to stream logs in real time.
+
+3. **Completion**: On process exit, the server determines the final status by checking the exit code and scanning logs for error markers (`[ERROR]`, `error:`). It extracts the first error line as the error message for failed operations.
+
+4. **Stop**: A stop request sends SIGTERM to the child process, with a 5-second fallback to SIGKILL. The operation is marked as "stopped" rather than "failed".
+
+Operations persist as individual JSON files. On container restart, if no mirror files exist in the default destination, stale operation history and logs are automatically cleaned up.

--- a/docs/dev/registry-auth.md
+++ b/docs/dev/registry-auth.md
@@ -1,0 +1,10 @@
+# Registry Authentication Verification
+
+The registry verification flow handles the OAuth2 token exchange that most container registries use:
+
+1. Attempt a direct `GET /v2/` request with Basic auth
+2. If the registry returns 401 with a `WWW-Authenticate: Bearer realm=...` header, extract the realm URL and service parameter
+3. Request a token from the realm with the same Basic auth credentials
+4. Report success if the token request succeeds
+
+This two-step flow is necessary because registries like `registry.redhat.io` and `quay.io` use token-based auth rather than accepting Basic auth directly on the `/v2/` endpoint.


### PR DESCRIPTION
Adds user-facing troubleshooting guide (TROUBLESHOOTING.md) and three developer reference docs under docs/dev/ covering the catalog data pipeline, mirror operation lifecycle, and registry auth verification flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a troubleshooting guide covering server, container, registry, catalog sync, mirroring, caching, and local development issues.
  * Documented the catalog data pipeline, including offline metadata, synchronization, caching, and catalog differences.
  * Added an overview of the mirror operation lifecycle, logging, status tracking, stopping, and persistence.
  * Documented registry authentication verification for Basic and token-based registries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->