### PR TITLE
CLID-685: Add semantic selectors in e2e tests for dashboard and mirrorOperations

### DIFF
--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -6,11 +6,14 @@ test.describe('Dashboard', () => {
   });
 
   test('dashboard page renders environment section', async ({ page }) => {
-    await expect(page.getByText(/environment|Mirror-GUI|version/i)).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Environment' })).toBeVisible({ timeout: 10000 });
   });
 
   test('operation stats cards display', async ({ page }) => {
-    await expect(page.getByText(/total|successful|failed|running|operations/i).first()).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('heading', { name: 'Operation Statistics' })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Total Operations')).toBeVisible();
+    await expect(page.getByText('Successful', { exact: true })).toBeVisible();
+    await expect(page.getByText('Failed', { exact: true })).toBeVisible();
   });
 
   test('recent operations section renders', async ({ page }) => {

--- a/tests/e2e/mirrorOperations.spec.ts
+++ b/tests/e2e/mirrorOperations.spec.ts
@@ -10,11 +10,7 @@ test.describe('Mirror Operations', () => {
   });
 
   test('config file selector is present', async ({ page }) => {
-    await expect(page.getByText(/config|configuration|select/i)).toBeVisible();
-  });
-
-  test('start operation form is present', async ({ page }) => {
-    await expect(page.getByText(/start|run|configuration/i).first()).toBeVisible();
+    await expect(page.getByLabel('Select ImageSetConfiguration file')).toBeVisible();
   });
 
   test('operations table or content renders', async ({ page }) => {


### PR DESCRIPTION
### Summary

Replace broad regex-based selectors in dashboard.spec.ts and mirrorOperations.spec.ts E2E tests with precise semantic locators (getByRole, getByLabel) to eliminate false positives and improve test reliability.

### Implementation notes
Eliminates false positives, tests now fail correctly when the target component is absent, instead of silently passing on incidental text matches.
Improves resilience to UI refactors ,semantic selectors (getByRole, getByLabel) are tied to accessible names and ARIA attributes, not arbitrary text content, so they survive cosmetic changes like rewording descriptions or reordering sidebar items.
Aligns with Playwright best practices,semantic locators are the recommended approach for robust, maintainable tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated Playwright dashboard E2E checks to use role-based, accessible headings and exact text for Operation Statistics, including “Total Operations”, “Successful”, and “Failed”, with an added timeout for the heading to appear.
  * Improved mirror operations E2E reliability by locating the configuration file selector via its accessibility label instead of a broader text match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->