### PR TITLE
CLID-696: Add optional oc-mirror flags to Mirror Operations

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -41,6 +41,117 @@ interface OperationRecord {
   logs: string[];
 }
 
+interface OptionalFlagsBody {
+  removeSignatures?: boolean;
+  imageTimeout?: string;
+  retryDelay?: string;
+  retryTimes?: number;
+}
+
+const OPTIONAL_FLAG_KEYS = new Set([
+  'removeSignatures',
+  'imageTimeout',
+  'retryDelay',
+  'retryTimes',
+]);
+
+/** Accept Go-style durations used by oc-mirror: "30s", "10m", "10m30s". */
+function parseDurationToSeconds(value: string): number | null {
+  const minutesAndSeconds = /^(?:(\d+)m)?(\d+)s$/.exec(value);
+  if (minutesAndSeconds) {
+    return Number(minutesAndSeconds[1] || 0) * 60 + Number(minutesAndSeconds[2]);
+  }
+  const minutesOnly = /^(\d+)m$/.exec(value);
+  if (minutesOnly) {
+    return Number(minutesOnly[1]) * 60;
+  }
+  return null;
+}
+
+function buildOptionalFlagArgs(
+  raw: unknown,
+): { ok: true; args: string[] } | { ok: false; error: string } {
+  if (raw == null) {
+    return { ok: true, args: [] };
+  }
+
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ok: false, error: 'optionalFlags must be an object' };
+  }
+
+  const flags = raw as Record<string, unknown>;
+  for (const key of Object.keys(flags)) {
+    if (!OPTIONAL_FLAG_KEYS.has(key)) {
+      return { ok: false, error: `Unknown optional flag: ${key}` };
+    }
+  }
+
+  const typed = flags as OptionalFlagsBody;
+  const additionalArgs: string[] = [];
+
+  if (typed.removeSignatures != null) {
+    if (typeof typed.removeSignatures !== 'boolean') {
+      return { ok: false, error: 'optionalFlags.removeSignatures must be a boolean' };
+    }
+    if (typed.removeSignatures) {
+      additionalArgs.push('--remove-signatures');
+    }
+  }
+
+  if (typed.imageTimeout != null) {
+    if (typeof typed.imageTimeout !== 'string') {
+      return {
+        ok: false,
+        error: 'optionalFlags.imageTimeout must be a duration string (e.g. "10m", "600s", "10m30s")',
+      };
+    }
+    const totalSeconds = parseDurationToSeconds(typed.imageTimeout);
+    if (totalSeconds === null) {
+      return {
+        ok: false,
+        error: 'optionalFlags.imageTimeout must match format like "10m", "600s", or "10m30s"',
+      };
+    }
+    if (totalSeconds <= 0) {
+      return { ok: false, error: 'optionalFlags.imageTimeout must be greater than 0' };
+    }
+    additionalArgs.push('--image-timeout', typed.imageTimeout);
+  }
+
+  if (typed.retryDelay != null) {
+    if (typeof typed.retryDelay !== 'string') {
+      return {
+        ok: false,
+        error: 'optionalFlags.retryDelay must be a duration string (e.g. "30s", "1m", "1m30s")',
+      };
+    }
+    const totalSeconds = parseDurationToSeconds(typed.retryDelay);
+    if (totalSeconds === null) {
+      return {
+        ok: false,
+        error: 'optionalFlags.retryDelay must match format like "30s", "1m", or "1m30s"',
+      };
+    }
+    additionalArgs.push('--retry-delay', typed.retryDelay);
+  }
+
+  if (typed.retryTimes != null) {
+    if (
+      typeof typed.retryTimes !== 'number' ||
+      !Number.isInteger(typed.retryTimes) ||
+      typed.retryTimes < 0
+    ) {
+      return {
+        ok: false,
+        error: 'optionalFlags.retryTimes must be a non-negative integer',
+      };
+    }
+    additionalArgs.push('--retry-times', String(typed.retryTimes));
+  }
+
+  return { ok: true, args: additionalArgs };
+}
+
 interface SystemInfo {
   ocMirrorVersion: string;
   systemArchitecture: string;
@@ -1455,9 +1566,15 @@ app.get('/api/operations/history', async (req: Request, res: Response) => {
 
 app.post('/api/operations/start', async (req: Request, res: Response) => {
   try {
-    const { configFile, mirrorDestinationSubdir } = req.body;
+    const { configFile, mirrorDestinationSubdir, optionalFlags } = req.body;
     const operationId = uuidv4();
     const configPath = path.join(CONFIGS_DIR, configFile);
+
+    const optionalFlagsResult = buildOptionalFlagArgs(optionalFlags);
+    if (!optionalFlagsResult.ok) {
+      return res.status(400).json({ error: optionalFlagsResult.error });
+    }
+    const additionalArgs = optionalFlagsResult.args;
 
     try {
       await fsp.access(configPath);
@@ -1592,6 +1709,7 @@ app.post('/api/operations/start', async (req: Request, res: Response) => {
       '--src-tls-verify=false',
       '--cache-dir', cacheDir,
       '--authfile', AUTHFILE_PATH,
+      ...additionalArgs,
       mirrorUrl,
     ], {
       stdio: ['ignore', 'pipe', 'pipe'],

--- a/src/components/MirrorOperations.tsx
+++ b/src/components/MirrorOperations.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, type CSSProperties, type ReactNode } from 'react';
 import axios from 'axios';
 import {
   Card,
@@ -40,6 +40,10 @@ import {
   ToolbarContent,
   ToolbarItem,
   ToolbarGroup,
+  ExpandableSection,
+  ExpandableSectionToggle,
+  Switch,
+  NumberInput,
 } from '@patternfly/react-core';
 import {
   SyncAltIcon,
@@ -78,6 +82,223 @@ interface Operation {
   errorMessage?: string;
 }
 
+interface OptionalFlags {
+  removeSignatures: boolean;
+  imageTimeoutEnabled: boolean;
+  imageTimeoutMinutes: string;
+  imageTimeoutSeconds: string;
+  retryDelayEnabled: boolean;
+  retryDelaySeconds: string;
+  retryTimesEnabled: boolean;
+  retryTimesValue: string;
+}
+
+interface OptionalFlagsPayload {
+  removeSignatures?: boolean;
+  imageTimeout?: string;
+  retryDelay?: string;
+  retryTimes?: number;
+}
+
+const DEFAULT_OPTIONAL_FLAGS: OptionalFlags = {
+  removeSignatures: false,
+  imageTimeoutEnabled: false,
+  imageTimeoutMinutes: '10',
+  imageTimeoutSeconds: '0',
+  retryDelayEnabled: false,
+  retryDelaySeconds: '0',
+  retryTimesEnabled: false,
+  retryTimesValue: '5',
+};
+
+const infoButtonStyle: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minWidth: 'auto',
+  height: '1.25rem',
+  lineHeight: 1,
+  position: 'relative',
+  top: '1px',
+  color: 'var(--pf-t--global--text--color--regular, #151515)',
+};
+
+const FormGroupInfoLabel = ({
+  text,
+  ariaLabel,
+  bodyContent,
+}: {
+  text: string;
+  ariaLabel: string;
+  bodyContent: ReactNode;
+}) => (
+  <span
+    style={{
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: 'var(--pf-t--global--spacer--xs)',
+    }}
+  >
+    <span>{text}</span>
+    <Popover
+      bodyContent={bodyContent}
+      // Keep the popover inside the card: triggers sit on the left edge,
+      // so prefer opening to the right / bottom-start instead of centered top.
+      position="right"
+      flipBehavior={['right', 'right-start', 'bottom-start', 'top-start', 'bottom', 'top']}
+    >
+      <Button
+        variant="plain"
+        aria-label={ariaLabel}
+        hasNoPadding
+        type="button"
+        style={infoButtonStyle}
+      >
+        <InfoCircleIcon style={{ fontSize: '0.875rem' }} />
+      </Button>
+    </Popover>
+  </span>
+);
+
+const sanitizeDigitsInput = (value: string): string => value.replace(/\D+/g, '');
+
+const parseNonNegativeInt = (value: string): number | null => {
+  const trimmedValue = value.trim();
+  if (!trimmedValue) {
+    return 0;
+  }
+  if (!/^\d+$/.test(trimmedValue)) {
+    return null;
+  }
+  return Number.parseInt(trimmedValue, 10);
+};
+
+const formatGoDuration = (minutes: string, seconds: string): string | null => {
+  const mins = parseNonNegativeInt(minutes);
+  const secs = parseNonNegativeInt(seconds);
+  if (mins === null || secs === null) {
+    return null;
+  }
+  if (mins > 0 && secs > 0) {
+    return `${mins}m${secs}s`;
+  }
+  if (mins > 0) {
+    return `${mins}m`;
+  }
+  return `${secs}s`;
+};
+
+const getDurationTotalSeconds = (minutes: string, seconds: string): number | null => {
+  const mins = parseNonNegativeInt(minutes);
+  const secs = parseNonNegativeInt(seconds);
+  if (mins === null || secs === null) {
+    return null;
+  }
+  return mins * 60 + secs;
+};
+
+const getDurationValidationMessage = (
+  minutes: string,
+  seconds: string,
+  label: string,
+  requirePositive: boolean,
+): string => {
+  const totalSeconds = getDurationTotalSeconds(minutes, seconds);
+  if (totalSeconds === null) {
+    return `${label} must contain digits only`;
+  }
+  if (requirePositive && totalSeconds <= 0) {
+    return `${label} must be greater than 0`;
+  }
+  return '';
+};
+
+const getNonNegativeIntegerValidationMessage = (value: string, label: string): string => {
+  const trimmedValue = value.trim();
+  if (!trimmedValue) {
+    return `${label} is required when enabled`;
+  }
+  if (!/^\d+$/.test(trimmedValue)) {
+    return `${label} must contain digits only`;
+  }
+  return '';
+};
+
+const buildOptionalFlagsPayload = (flags: OptionalFlags): OptionalFlagsPayload | null => {
+  const payload: OptionalFlagsPayload = {};
+
+  if (flags.removeSignatures) {
+    payload.removeSignatures = true;
+  }
+
+  if (flags.imageTimeoutEnabled) {
+    const message = getDurationValidationMessage(
+      flags.imageTimeoutMinutes,
+      flags.imageTimeoutSeconds,
+      'Image timeout',
+      true,
+    );
+    if (message) {
+      return null;
+    }
+    const duration = formatGoDuration(flags.imageTimeoutMinutes, flags.imageTimeoutSeconds);
+    if (!duration) {
+      return null;
+    }
+    payload.imageTimeout = duration;
+  }
+
+  if (flags.retryDelayEnabled) {
+    const message = getNonNegativeIntegerValidationMessage(flags.retryDelaySeconds, 'Retry delay');
+    if (message) {
+      return null;
+    }
+    payload.retryDelay = `${Number.parseInt(flags.retryDelaySeconds, 10)}s`;
+  }
+
+  if (flags.retryTimesEnabled) {
+    const message = getNonNegativeIntegerValidationMessage(flags.retryTimesValue, 'Retry times');
+    if (message) {
+      return null;
+    }
+    payload.retryTimes = Number.parseInt(flags.retryTimesValue, 10);
+  }
+
+  return payload;
+};
+
+const getOptionalFlagsValidationError = (flags: OptionalFlags): string => {
+  if (flags.imageTimeoutEnabled) {
+    const message = getDurationValidationMessage(
+      flags.imageTimeoutMinutes,
+      flags.imageTimeoutSeconds,
+      'Image timeout',
+      true,
+    );
+    if (message) {
+      return message;
+    }
+  }
+  if (flags.retryDelayEnabled) {
+    const message = getNonNegativeIntegerValidationMessage(flags.retryDelaySeconds, 'Retry delay');
+    if (message) {
+      return message;
+    }
+  }
+  if (flags.retryTimesEnabled) {
+    const message = getNonNegativeIntegerValidationMessage(flags.retryTimesValue, 'Retry times');
+    if (message) {
+      return message;
+    }
+  }
+  return '';
+};
+
+const adjustDigitField = (value: string, delta: number, min: number): string => {
+  const current = parseNonNegativeInt(value) ?? 0;
+  return String(Math.max(min, current + delta));
+};
+
 const MirrorOperations: React.FC = () => {
   const { addSuccessAlert, addDangerAlert, addWarningAlert } = useAlerts();
 
@@ -109,6 +330,8 @@ const MirrorOperations: React.FC = () => {
   const [checkedOpIds, setCheckedOpIds] = useState<Set<string>>(new Set());
   const [bulkDeleteTarget, setBulkDeleteTarget] = useState<'selected' | 'all' | null>(null);
   const [bulkDeleting, setBulkDeleting] = useState(false);
+  const [advancedOptionsExpanded, setAdvancedOptionsExpanded] = useState(false);
+  const [optionalFlags, setOptionalFlags] = useState<OptionalFlags>(DEFAULT_OPTIONAL_FLAGS);
 
   const operationsRef = useRef<Operation[]>([]);
   const notifiedOperationsRef = useRef(new Set<string>());
@@ -328,11 +551,26 @@ const MirrorOperations: React.FC = () => {
       return;
     }
 
+    const flagsValidationError = getOptionalFlagsValidationError(optionalFlags);
+    if (flagsValidationError) {
+      addDangerAlert(flagsValidationError);
+      return;
+    }
+
+    const optionalFlagsPayload = buildOptionalFlagsPayload(optionalFlags);
+    if (optionalFlagsPayload === null) {
+      addDangerAlert('Invalid optional flags');
+      return;
+    }
+
     try {
       setLoading(true);
       const response = await axios.post('/api/operations/start', {
         configFile: selectedConfig,
         mirrorDestinationSubdir: mirrorDestinationSubdir.trim() || undefined,
+        ...(Object.keys(optionalFlagsPayload).length > 0
+          ? { optionalFlags: optionalFlagsPayload }
+          : {}),
       });
 
       addSuccessAlert('Operation started successfully!');
@@ -354,9 +592,11 @@ const MirrorOperations: React.FC = () => {
         setTimeout(() => clearInterval(logInterval), 300000);
       }
     } catch (error: unknown) {
-      const err = error as { response?: { data?: { message?: string } }; message?: string };
+      const err = error as { response?: { data?: { message?: string; error?: string } }; message?: string };
       console.error('Error starting operation:', error);
-      addDangerAlert(`Failed to start operation: ${err.response?.data?.message || err.message}`);
+      addDangerAlert(
+        `Failed to start operation: ${err.response?.data?.error || err.response?.data?.message || err.message}`,
+      );
     } finally {
       setLoading(false);
     }
@@ -634,38 +874,11 @@ const MirrorOperations: React.FC = () => {
             <FlexItem>
               <FormGroup
                 label={
-                  <span
-                    style={{
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      gap: 'var(--pf-t--global--spacer--xs)',
-                    }}
-                  >
-                    <span>Mirror Destination Folder</span>
-                    <Popover
-                      bodyContent="Mirror output is saved to data/mirrors/<folder>. Defaults to &quot;default&quot; if unchanged. Select an existing folder or create a new one from the dropdown."
-                    >
-                      <Button
-                        variant="plain"
-                        aria-label="More info"
-                        hasNoPadding
-                        type="button"
-                        style={{
-                          display: 'inline-flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          minWidth: 'auto',
-                          height: '1.25rem',
-                          lineHeight: 1,
-                          position: 'relative',
-                          top: '1px',
-                          color: 'var(--pf-t--global--text--color--regular, #151515)',
-                        }}
-                      >
-                        <InfoCircleIcon style={{ fontSize: '0.875rem' }} />
-                      </Button>
-                    </Popover>
-                  </span>
+                  <FormGroupInfoLabel
+                    text="Mirror Destination Folder"
+                    ariaLabel="More info about mirror destination folder"
+                    bodyContent="Mirror output is saved to data/mirrors/<folder>. Defaults to &quot;default&quot; if unchanged. Select an existing folder or create a new one from the dropdown."
+                  />
                 }
                 fieldId="mirror-subdir"
               >
@@ -751,6 +964,17 @@ const MirrorOperations: React.FC = () => {
               </FormGroup>
             </FlexItem>
             <FlexItem>
+              <ExpandableSectionToggle
+                isExpanded={advancedOptionsExpanded}
+                onToggle={(expanded) => setAdvancedOptionsExpanded(expanded)}
+                toggleId="advanced-options-toggle"
+                contentId="advanced-options-content"
+                isDetached
+              >
+                Advanced Options
+              </ExpandableSectionToggle>
+            </FlexItem>
+            <FlexItem>
               <Button
                 variant="primary"
                 icon={loading ? <Spinner size="md" /> : <PlayIcon />}
@@ -761,6 +985,259 @@ const MirrorOperations: React.FC = () => {
               </Button>
             </FlexItem>
           </Flex>
+
+          <ExpandableSection
+            className="pf-v6-u-mt-md"
+            isExpanded={advancedOptionsExpanded}
+            isDetached
+            direction="down"
+            toggleId="advanced-options-toggle"
+            contentId="advanced-options-content"
+          >
+            <FormGroup
+              label={
+                <FormGroupInfoLabel
+                  text="Remove signatures"
+                  ariaLabel="More info about remove signatures"
+                  bodyContent="When enabled, image signatures are not copied to the mirror destination."
+                />
+              }
+              fieldId="flag-remove-signatures"
+              className="pf-v6-u-mb-md"
+            >
+              <Switch
+                id="flag-remove-signatures"
+                isChecked={optionalFlags.removeSignatures}
+                onChange={(_e, checked) =>
+                  setOptionalFlags((prev) => ({ ...prev, removeSignatures: checked }))
+                }
+                aria-label="Enable remove signatures"
+              />
+            </FormGroup>
+
+            <FormGroup
+              label={
+                <FormGroupInfoLabel
+                  text="Image timeout"
+                  ariaLabel="More info about image timeout"
+                  bodyContent="Maximum time to wait when pulling each image before oc-mirror gives up on that attempt. Default is 10 minutes."
+                />
+              }
+              fieldId="flag-image-timeout"
+              className="pf-v6-u-mb-md"
+            >
+              <Switch
+                id="flag-image-timeout"
+                isChecked={optionalFlags.imageTimeoutEnabled}
+                onChange={(_e, checked) =>
+                  setOptionalFlags((prev) => ({ ...prev, imageTimeoutEnabled: checked }))
+                }
+                aria-label="Enable image timeout"
+              />
+              {optionalFlags.imageTimeoutEnabled && (
+                <div className="pf-v6-u-mt-sm">
+                  <Flex spaceItems={{ default: 'spaceItemsMd' }}>
+                    <FlexItem>
+                      <NumberInput
+                        id="flag-image-timeout-minutes"
+                        value={
+                          optionalFlags.imageTimeoutMinutes
+                            ? Number(optionalFlags.imageTimeoutMinutes)
+                            : 0
+                        }
+                        min={0}
+                        onMinus={() =>
+                          setOptionalFlags((prev) => ({
+                            ...prev,
+                            imageTimeoutMinutes: adjustDigitField(prev.imageTimeoutMinutes, -1, 0),
+                          }))
+                        }
+                        onPlus={() =>
+                          setOptionalFlags((prev) => ({
+                            ...prev,
+                            imageTimeoutMinutes: adjustDigitField(prev.imageTimeoutMinutes, 1, 0),
+                          }))
+                        }
+                        onChange={(e: React.FormEvent<HTMLInputElement>) => {
+                          const val = (e.target as HTMLInputElement).value;
+                          setOptionalFlags((prev) => ({
+                            ...prev,
+                            imageTimeoutMinutes: sanitizeDigitsInput(val),
+                          }));
+                        }}
+                        widthChars={4}
+                        unit="m"
+                        minusBtnAriaLabel="Decrease image timeout minutes"
+                        plusBtnAriaLabel="Increase image timeout minutes"
+                      />
+                    </FlexItem>
+                    <FlexItem>
+                      <NumberInput
+                        id="flag-image-timeout-seconds"
+                        value={
+                          optionalFlags.imageTimeoutSeconds
+                            ? Number(optionalFlags.imageTimeoutSeconds)
+                            : 0
+                        }
+                        min={0}
+                        onMinus={() =>
+                          setOptionalFlags((prev) => ({
+                            ...prev,
+                            imageTimeoutSeconds: adjustDigitField(prev.imageTimeoutSeconds, -1, 0),
+                          }))
+                        }
+                        onPlus={() =>
+                          setOptionalFlags((prev) => ({
+                            ...prev,
+                            imageTimeoutSeconds: adjustDigitField(prev.imageTimeoutSeconds, 1, 0),
+                          }))
+                        }
+                        onChange={(e: React.FormEvent<HTMLInputElement>) => {
+                          const val = (e.target as HTMLInputElement).value;
+                          setOptionalFlags((prev) => ({
+                            ...prev,
+                            imageTimeoutSeconds: sanitizeDigitsInput(val),
+                          }));
+                        }}
+                        widthChars={4}
+                        unit="s"
+                        minusBtnAriaLabel="Decrease image timeout seconds"
+                        plusBtnAriaLabel="Increase image timeout seconds"
+                      />
+                    </FlexItem>
+                  </Flex>
+                </div>
+              )}
+            </FormGroup>
+
+            <FormGroup
+              label={
+                <FormGroupInfoLabel
+                  text="Retry delay"
+                  ariaLabel="More info about retry delay"
+                  bodyContent={
+                    <div>
+                      Fixed wait, in seconds, before each retry after a failure.
+                      <br />
+                      <br />
+                      Set to <strong>0</strong> for oc-mirror&apos;s default behavior: the wait
+                      starts short and roughly doubles after each failed attempt
+                      (for example 1s → 2s → 4s), instead of waiting the same amount every time.
+                    </div>
+                  }
+                />
+              }
+              fieldId="flag-retry-delay"
+              className="pf-v6-u-mb-md"
+            >
+              <Switch
+                id="flag-retry-delay"
+                isChecked={optionalFlags.retryDelayEnabled}
+                onChange={(_e, checked) =>
+                  setOptionalFlags((prev) => ({ ...prev, retryDelayEnabled: checked }))
+                }
+                aria-label="Enable retry delay"
+              />
+              {optionalFlags.retryDelayEnabled && (
+                <div className="pf-v6-u-mt-sm">
+                  <NumberInput
+                    id="flag-retry-delay-seconds"
+                    value={
+                      optionalFlags.retryDelaySeconds
+                        ? Number(optionalFlags.retryDelaySeconds)
+                        : 0
+                    }
+                    min={0}
+                    onMinus={() =>
+                      setOptionalFlags((prev) => ({
+                        ...prev,
+                        retryDelaySeconds: adjustDigitField(prev.retryDelaySeconds, -1, 0),
+                      }))
+                    }
+                    onPlus={() =>
+                      setOptionalFlags((prev) => ({
+                        ...prev,
+                        retryDelaySeconds: adjustDigitField(prev.retryDelaySeconds, 1, 0),
+                      }))
+                    }
+                    onChange={(e: React.FormEvent<HTMLInputElement>) => {
+                      const val = (e.target as HTMLInputElement).value;
+                      setOptionalFlags((prev) => ({
+                        ...prev,
+                        retryDelaySeconds: sanitizeDigitsInput(val),
+                      }));
+                    }}
+                    widthChars={4}
+                    unit="s"
+                    minusBtnAriaLabel="Decrease retry delay"
+                    plusBtnAriaLabel="Increase retry delay"
+                  />
+                </div>
+              )}
+            </FormGroup>
+
+            <FormGroup
+              label={
+                <FormGroupInfoLabel
+                  text="Retry times"
+                  ariaLabel="More info about retry times"
+                  bodyContent="How many times oc-mirror retries a failed image pull. Default is 5."
+                />
+              }
+              fieldId="flag-retry-times"
+            >
+              <Switch
+                id="flag-retry-times"
+                isChecked={optionalFlags.retryTimesEnabled}
+                onChange={(_e, checked) =>
+                  setOptionalFlags((prev) => ({ ...prev, retryTimesEnabled: checked }))
+                }
+                aria-label="Enable retry times"
+              />
+              {optionalFlags.retryTimesEnabled && (
+                <div className="pf-v6-u-mt-sm">
+                  <NumberInput
+                    id="flag-retry-times-value"
+                    value={
+                      optionalFlags.retryTimesValue
+                        ? Number(optionalFlags.retryTimesValue)
+                        : 0
+                    }
+                    min={0}
+                    onMinus={() =>
+                      setOptionalFlags((prev) => {
+                        const current = prev.retryTimesValue
+                          ? Number(prev.retryTimesValue)
+                          : 0;
+                        return {
+                          ...prev,
+                          retryTimesValue: String(Math.max(0, current - 1)),
+                        };
+                      })
+                    }
+                    onPlus={() =>
+                      setOptionalFlags((prev) => {
+                        const current = prev.retryTimesValue
+                          ? Number(prev.retryTimesValue)
+                          : 0;
+                        return { ...prev, retryTimesValue: String(current + 1) };
+                      })
+                    }
+                    onChange={(e: React.FormEvent<HTMLInputElement>) => {
+                      const val = (e.target as HTMLInputElement).value;
+                      setOptionalFlags((prev) => ({
+                        ...prev,
+                        retryTimesValue: sanitizeDigitsInput(val),
+                      }));
+                    }}
+                    widthChars={4}
+                    minusBtnAriaLabel="Decrease retry times"
+                    plusBtnAriaLabel="Increase retry times"
+                  />
+                </div>
+              )}
+            </FormGroup>
+          </ExpandableSection>
         </CardBody>
       </Card>
 

--- a/src/components/MirrorOperations.tsx
+++ b/src/components/MirrorOperations.tsx
@@ -1067,6 +1067,7 @@ const MirrorOperations: React.FC = () => {
                         }}
                         widthChars={4}
                         unit="m"
+                        inputAriaLabel="Image timeout minutes"
                         minusBtnAriaLabel="Decrease image timeout minutes"
                         plusBtnAriaLabel="Increase image timeout minutes"
                       />
@@ -1101,6 +1102,7 @@ const MirrorOperations: React.FC = () => {
                         }}
                         widthChars={4}
                         unit="s"
+                        inputAriaLabel="Image timeout seconds"
                         minusBtnAriaLabel="Decrease image timeout seconds"
                         plusBtnAriaLabel="Increase image timeout seconds"
                       />
@@ -1169,6 +1171,7 @@ const MirrorOperations: React.FC = () => {
                     }}
                     widthChars={4}
                     unit="s"
+                    inputAriaLabel="Retry delay seconds"
                     minusBtnAriaLabel="Decrease retry delay"
                     plusBtnAriaLabel="Increase retry delay"
                   />
@@ -1231,6 +1234,7 @@ const MirrorOperations: React.FC = () => {
                       }));
                     }}
                     widthChars={4}
+                    inputAriaLabel="Retry times"
                     minusBtnAriaLabel="Decrease retry times"
                     plusBtnAriaLabel="Increase retry times"
                   />

--- a/tests/e2e/mirrorOperations.spec.ts
+++ b/tests/e2e/mirrorOperations.spec.ts
@@ -25,6 +25,27 @@ test.describe('Mirror Operations', () => {
     await expect(page.getByText('Mirror Destination Folder')).toBeVisible({ timeout: 10000 });
   });
 
+  test('Advanced Options section is present and expandable', async ({ page }) => {
+    const toggle = page.getByRole('button', { name: /Advanced Options/i });
+    await expect(toggle).toBeVisible({ timeout: 10000 });
+    await toggle.click();
+    await expect(page.getByLabel('Enable remove signatures')).toBeVisible();
+    await expect(page.getByLabel('Enable image timeout')).toBeVisible();
+    await expect(page.getByLabel('Enable retry delay')).toBeVisible();
+    await expect(page.getByLabel('Enable retry times')).toBeVisible();
+
+    await page.locator('#flag-image-timeout').click({ force: true });
+    await expect(page.locator('#flag-image-timeout-minutes')).toBeVisible();
+    await expect(page.locator('#flag-image-timeout-seconds')).toBeVisible();
+
+    await page.locator('#flag-retry-delay').click({ force: true });
+    await expect(page.locator('#flag-retry-delay-seconds')).toBeVisible();
+    await expect(page.locator('#flag-retry-delay-minutes')).toHaveCount(0);
+
+    await page.getByLabel('More info about retry delay').click();
+    await expect(page.getByText(/roughly doubles after each failed attempt/i)).toBeVisible();
+  });
+
   test('Mirror Destination Folder shows default toggle text', async ({ page }) => {
     await expect(page.getByText('default', { exact: true })).toBeVisible({ timeout: 10000 });
   });

--- a/tests/integration/operations.test.ts
+++ b/tests/integration/operations.test.ts
@@ -67,6 +67,42 @@ describe('Operations API', () => {
       expect(res.status).toBe(400);
       expect(res.body.error).toBeDefined();
     });
+
+    it('rejects unknown optionalFlags keys', async () => {
+      const res = await request.post('/api/operations/start').send({
+        configFile: 'ops-test-config.yaml',
+        optionalFlags: { unknownFlag: true },
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('Unknown optional flag');
+    });
+
+    it('rejects invalid imageTimeout format', async () => {
+      const res = await request.post('/api/operations/start').send({
+        configFile: 'ops-test-config.yaml',
+        optionalFlags: { imageTimeout: '10minutes' },
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('imageTimeout');
+    });
+
+    it('rejects zero imageTimeout duration', async () => {
+      const res = await request.post('/api/operations/start').send({
+        configFile: 'ops-test-config.yaml',
+        optionalFlags: { imageTimeout: '0s' },
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('greater than 0');
+    });
+
+    it('rejects non-integer retryTimes', async () => {
+      const res = await request.post('/api/operations/start').send({
+        configFile: 'ops-test-config.yaml',
+        optionalFlags: { retryTimes: 1.5 },
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('retryTimes');
+    });
   });
 
   describe('DELETE /api/operations/:id', () => {

--- a/tests/integration/operationsLifecycle.test.ts
+++ b/tests/integration/operationsLifecycle.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
@@ -8,6 +8,8 @@ import { ensureTestDirs } from './helpers/setup.js';
 describe('Operations lifecycle API', () => {
   let request: Awaited<ReturnType<typeof getTestApp>>;
   const seededOpId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+  let fakeOcMirrorDir: string;
+  let origPath: string;
 
   beforeAll(async () => {
     await ensureTestDirs();
@@ -38,7 +40,7 @@ describe('Operations lifecycle API', () => {
       operationRecord.logs.join('\n')
     );
 
-    const fakeOcMirrorDir = path.join(os.tmpdir(), `oc-mirror-fake-${Date.now()}`);
+    fakeOcMirrorDir = path.join(os.tmpdir(), `oc-mirror-fake-${Date.now()}`);
     await fs.promises.mkdir(fakeOcMirrorDir, { recursive: true });
     const fakeScript = path.join(fakeOcMirrorDir, 'oc-mirror');
     // Capture argv so tests can assert optional flags reach the spawned command.
@@ -53,8 +55,13 @@ describe('Operations lifecycle API', () => {
       ].join('\n'),
     );
     await fs.promises.chmod(fakeScript, 0o755);
-    const origPath = process.env.PATH || '';
+    origPath = process.env.PATH || '';
     process.env.PATH = `${fakeOcMirrorDir}:${origPath}`;
+  });
+
+  afterAll(async () => {
+    process.env.PATH = origPath;
+    await fs.promises.rm(fakeOcMirrorDir, { recursive: true, force: true });
   });
 
   describe('POST /api/operations/start success path', () => {
@@ -107,7 +114,7 @@ describe('Operations lifecycle API', () => {
         for (let attempt = 0; attempt < 20; attempt += 1) {
           try {
             argsContent = await fs.promises.readFile(argsFile, 'utf8');
-            if (argsContent.includes('--remove-signatures')) {
+            if (argsContent.includes('file:')) {
               break;
             }
           } catch {

--- a/tests/integration/operationsLifecycle.test.ts
+++ b/tests/integration/operationsLifecycle.test.ts
@@ -41,7 +41,17 @@ describe('Operations lifecycle API', () => {
     const fakeOcMirrorDir = path.join(os.tmpdir(), `oc-mirror-fake-${Date.now()}`);
     await fs.promises.mkdir(fakeOcMirrorDir, { recursive: true });
     const fakeScript = path.join(fakeOcMirrorDir, 'oc-mirror');
-    await fs.promises.writeFile(fakeScript, '#!/bin/sh\nexit 0\n');
+    // Capture argv so tests can assert optional flags reach the spawned command.
+    await fs.promises.writeFile(
+      fakeScript,
+      [
+        '#!/bin/sh',
+        'args_file="${OC_MIRROR_ARGS_FILE:-/tmp/oc-mirror-last-args.txt}"',
+        'printf "%s\\n" "$@" > "$args_file"',
+        'exit 0',
+        '',
+      ].join('\n'),
+    );
     await fs.promises.chmod(fakeScript, 0o755);
     const origPath = process.env.PATH || '';
     process.env.PATH = `${fakeOcMirrorDir}:${origPath}`;
@@ -64,6 +74,72 @@ describe('Operations lifecycle API', () => {
       expect(res.body.message).toContain('success');
       expect(res.body.operationId).toBeDefined();
       expect(typeof res.body.operationId).toBe('string');
+    });
+
+    it('passes optionalFlags through to the oc-mirror command argv', async () => {
+      const argsFile = path.join(os.tmpdir(), `oc-mirror-args-${Date.now()}.txt`);
+      process.env.OC_MIRROR_ARGS_FILE = argsFile;
+      try {
+        await fs.promises.rm(argsFile, { force: true });
+
+        const configRes = await request.post('/api/config/save').send({
+          config:
+            'kind: ImageSetConfiguration\napiVersion: mirror.openshift.io/v2alpha1\nmirror:\n  platform: {}\n  operators: []\n  additionalImages: []',
+          name: 'lifecycle-flags-config.yaml',
+        });
+        expect(configRes.status).toBe(200);
+
+        const res = await request.post('/api/operations/start').send({
+          configFile: 'lifecycle-flags-config.yaml',
+          optionalFlags: {
+            removeSignatures: true,
+            imageTimeout: '10m',
+            retryDelay: '30s',
+            retryTimes: 3,
+          },
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body.operationId).toBeDefined();
+
+        // Wait briefly for the spawned fake oc-mirror to write argv.
+        let argsContent = '';
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+          try {
+            argsContent = await fs.promises.readFile(argsFile, 'utf8');
+            if (argsContent.includes('--remove-signatures')) {
+              break;
+            }
+          } catch {
+            // file may not exist yet
+          }
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+
+        const args = argsContent
+          .split('\n')
+          .map((line) => line.trim())
+          .filter(Boolean);
+
+        expect(args).toContain('--remove-signatures');
+        expect(args).toContain('--image-timeout');
+        expect(args).toContain('10m');
+        expect(args).toContain('--retry-delay');
+        expect(args).toContain('30s');
+        expect(args).toContain('--retry-times');
+        expect(args).toContain('3');
+
+        // Flags must appear before the final mirror URL positional arg.
+        const mirrorUrlIndex = args.findIndex((arg) => arg.startsWith('file:'));
+        expect(mirrorUrlIndex).toBeGreaterThan(-1);
+        expect(args.indexOf('--remove-signatures')).toBeLessThan(mirrorUrlIndex);
+        expect(args.indexOf('--image-timeout')).toBeLessThan(mirrorUrlIndex);
+        expect(args.indexOf('--retry-delay')).toBeLessThan(mirrorUrlIndex);
+        expect(args.indexOf('--retry-times')).toBeLessThan(mirrorUrlIndex);
+      } finally {
+        delete process.env.OC_MIRROR_ARGS_FILE;
+        await fs.promises.rm(argsFile, { force: true });
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds an **Advanced Options** section on Mirror Operations for optional oc-mirror CLI flags:
  - `--remove-signatures`
  - `--image-timeout` (minutes + seconds)
  - `--retry-delay` (seconds; `0` means oc-mirror increases the wait after each failed attempt)
  - `--retry-times`
- Selected flags are sent as `optionalFlags` in `POST /api/operations/start`, validated on the server, and appended to the spawned `oc-mirror` argv before the mirror destination URL.
- Includes integration coverage that asserts flags reach the oc-mirror command, plus e2e coverage for the Advanced Options UI and info popovers.

Jira: https://redhat.atlassian.net/browse/CLID-696

## Test plan
- [x] Expand Advanced Options; confirm info popovers stay inside the card
- [x] Enable flags and start an operation with an existing config (e.g. `gs-operator-422.yaml`)
- [x] Confirm the running `oc-mirror` process argv includes the selected flags
- [x] `npm run lint && npm run build`
- [x] `npm test -- tests/integration/operations.test.ts tests/integration/operationsLifecycle.test.ts`
- [x] `npx playwright test tests/e2e/mirrorOperations.spec.ts`
- [x] Full Playwright suite (`npx playwright test`) — 63 passed on latest rerun

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an expandable **Advanced Options** panel for starting mirror operations.
  * Users can configure: remove signatures, image timeout, retry delay, and retry times.
  * Advanced options are validated and applied to the underlying mirror command.
* **Bug Fixes**
  * Improved invalid advanced option handling, including clearer error responses for unknown keys and invalid duration/number inputs.
* **Tests**
  * Added E2E coverage for the advanced options UI and help text.
  * Extended integration tests for validation errors and verification that options are forwarded to the mirror command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->